### PR TITLE
refactor(skills): genericize skill files to use contract references

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "sdlc-workflow",
       "source": "./plugins/sdlc-workflow",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "description": "AI-assisted SDLC workflow skills for planning features and implementing tasks with full Jira traceability."
     }
   ]

--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -79,12 +79,11 @@ This ensures the issue status reflects that implementation is underway.
 ## Step 4 – Understand the Code
 
 Inspect the files listed in Files to Modify and Files to Create locations using
-the dedicated Serena instance for the task's repository:
+the dedicated Serena instance for the task's repository. Look up the correct
+Serena Instance name in the **Repository Registry** section of the project's CLAUDE.md.
 
-- `mcp__serena-trustify__*` for trustify
-- `mcp__serena-trustify-ui__*` for trustify-ui
-- `mcp__serena-trustify-helm-charts__*` for trustify-helm-charts
-- `mcp__serena-scale-testing__*` for scale-testing
+Tools are called as `mcp__<serena-instance>__<tool>`, where `<serena-instance>` is
+the instance name from the Repository Registry.
 
 1. **Overview without full reads**: use `get_symbols_overview` on files to modify to see
    their structure (classes, functions, types) without reading the entire file.
@@ -95,9 +94,9 @@ the dedicated Serena instance for the task's repository:
 4. **Non-symbolic search**: use `search_for_pattern` for configuration, string literals,
    or patterns not captured as symbols.
 
-> **Note:** The YAML language server used by `serena-trustify-helm-charts` does not support
-> `textDocument/references`, so `find_referencing_symbols` will fail with error `-32601`.
-> Use `search_for_pattern` instead for impact analysis on Helm chart files.
+> **Note:** Check the **Code Intelligence** section of the project's CLAUDE.md for
+> per-instance limitations (e.g., some language servers may not support certain operations).
+> Adapt your tool usage accordingly.
 
 **Fallback**: if no Serena instance is available for the repository, use Read, Grep, and Glob tools directly.
 
@@ -120,7 +119,8 @@ Follow the **Implementation Notes** for patterns and code references on how to i
 
 ### Serena symbolic editing (preferred)
 
-Use the dedicated Serena instance for the task's repository (e.g. `mcp__serena-trustify__*`, `mcp__serena-trustify-helm-charts__*`, `mcp__serena-scale-testing__*`):
+Use the dedicated Serena instance for the task's repository (look up the instance name
+in the project's **Repository Registry**):
 
 - `replace_symbol_body` — rewrite an entire function, method, struct, or component
 - `insert_after_symbol` / `insert_before_symbol` — add new code relative to existing symbols
@@ -197,7 +197,7 @@ jira.transition_issue → In Review
 
 ## Important Rules
 
-- Do not guess — use the dedicated Serena instance for the target repo (`mcp__serena-trustify__*`, `mcp__serena-trustify-ui__*`, `mcp__serena-trustify-helm-charts__*`, or `mcp__serena-scale-testing__*`) with tools like `get_symbols_overview`, `find_symbol`, `find_referencing_symbols` to inspect code before modifying it. Fall back to Read/Grep/Glob for repos without a Serena instance.
+- Do not guess — use the Serena instance specified in the project's **Repository Registry** (CLAUDE.md) for the target repo, with tools like `get_symbols_overview`, `find_symbol`, `find_referencing_symbols` to inspect code before modifying it. Check the **Code Intelligence** section for per-instance limitations. Fall back to Read/Grep/Glob for repos without a Serena instance.
 - Follow the Implementation Notes closely — they reference real code patterns.
 - If the structured description is incomplete, ask the user rather than improvising.
 - Keep changes scoped to what the task describes — no unrelated refactoring.

--- a/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
@@ -95,15 +95,13 @@ Analyze relevant repositories to identify impacted modules, APIs, and tests.
 
 ### Serena-first workflow
 
-Each target repository has a dedicated Serena MCP server instance:
+Each target repository has a dedicated Serena MCP server instance, as specified in
+the **Repository Registry** section of the project's CLAUDE.md. Look up the Serena
+Instance column to determine the correct instance name for each repository.
 
-- `serena-trustify` — for the trustify Rust backend
-- `serena-trustify-ui` — for the trustify-ui TypeScript frontend
-- `serena-trustify-helm-charts` — for the trustify-helm-charts Helm charts
-- `serena-scale-testing` — for the scale-testing Rust performance tests
-
-Use the instance matching the repository you are analyzing. Tools are called directly
-(not via `query_project`), prefixed by the instance name.
+Use the instance matching the repository you are analyzing. Tools are called as
+`mcp__<serena-instance>__<tool>`, where `<serena-instance>` is the instance name
+from the Repository Registry.
 
 For each target repository with a Serena instance:
 
@@ -116,13 +114,13 @@ For each target repository with a Serena instance:
 4. **Non-symbolic search**: use `search_for_pattern` for string literals, configuration keys,
    route definitions, or anything not captured as a symbol.
 
-> **Note:** The YAML language server used by `serena-trustify-helm-charts` does not support
-> `textDocument/references`, so `find_referencing_symbols` will fail with error `-32601`.
-> Use `search_for_pattern` instead for impact analysis on Helm chart files.
+> **Note:** Check the **Code Intelligence** section of the project's CLAUDE.md for
+> per-instance limitations (e.g., some language servers may not support certain operations).
+> Adapt your tool usage accordingly.
 
 Example:
 
-    mcp__serena-trustify__find_symbol(
+    mcp__<serena-instance>__find_symbol(
       name_path_pattern="SbomService",
       substring_matching=true,
       include_body=false
@@ -278,7 +276,7 @@ Include:
 
 ## Important Rules
 
-- Do not guess repository structure — use the dedicated Serena instance for the target repo (`mcp__serena-trustify__*`, `mcp__serena-trustify-ui__*`, `mcp__serena-trustify-helm-charts__*`, or `mcp__serena-scale-testing__*`) with tools like `get_symbols_overview`, `find_symbol`, `find_referencing_symbols`, `search_for_pattern`. Fall back to Glob/Grep/Read for repos without a Serena instance.
+- Do not guess repository structure — use the Serena instance specified in the project's **Repository Registry** (CLAUDE.md) for the target repo, with tools like `get_symbols_overview`, `find_symbol`, `find_referencing_symbols`, `search_for_pattern`. Check the **Code Intelligence** section for per-instance limitations. Fall back to Glob/Grep/Read for repos without a Serena instance.
 - Prefer inspecting real code before planning.
 - Ensure every task has clear implementation notes.
 - Ensure tasks remain small enough for a single engineer.


### PR DESCRIPTION
## Summary
- Replace all hardcoded Trustify-specific Serena instance names (`serena-trustify`, `serena-trustify-ui`, etc.) with generic references to the Project Configuration Contract
- Skills now reference the Repository Registry and Code Intelligence sections of the project's CLAUDE.md
- Bump plugin version from 0.1.0 to 0.2.0

## Test plan
- [x] `grep -r 'serena-trustify' plugins/` returns no results
- [x] `claude plugin validate .` passes
- [x] Skills remain functionally complete — no behavioral changes, only reference changes
- [x] marketplace.json version is 0.2.0

Implements TC-3804

🤖 Generated with [Claude Code](https://claude.com/claude-code)