### PR TITLE
fix(plugin): add missing description field to skill entries

### DIFF
--- a/plugins/sdlc-workflow/.claude-plugin/plugin.json
+++ b/plugins/sdlc-workflow/.claude-plugin/plugin.json
@@ -4,10 +4,12 @@
   "skills": [
     {
       "name": "plan-feature",
+      "description": "Generate an implementation plan and Jira tasks from a Jira feature and Figma mockups.",
       "path": "./skills/plan-feature/SKILL.md"
     },
     {
       "name": "implement-task",
+      "description": "Implement a Jira task by reading its structured description, modifying code, running tests, and updating Jira.",
       "path": "./skills/implement-task/SKILL.md"
     }
   ]


### PR DESCRIPTION
## Summary
- Adds the required `description` field to each skill entry in `plugin.json`
- Fixes plugin installation failure: `skills: Invalid input`

## Test plan
- [ ] Install the plugin in another project and verify it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)