### PR TITLE
fix(docs): update Git Pull Request custom field ID to customfield_10875

### DIFF
--- a/docs/project-config-contract.md
+++ b/docs/project-config-contract.md
@@ -81,7 +81,7 @@ that skills need to create issues, query tasks, and update fields.
 
 | Field | Description | Example |
 |---|---|---|
-| Git Pull Request custom field | Custom field ID for storing PR URLs | `customfield_12310220` |
+| Git Pull Request custom field | Custom field ID for storing PR URLs (requires ADF format) | `customfield_10875` |
 | Default labels | Labels to apply to AI-generated issues | `ai-generated-jira` |
 
 #### Structure
@@ -92,7 +92,7 @@ that skills need to create issues, query tasks, and update fields.
 - Project key: TC
 - Cloud ID: https://issues.redhat.com
 - Feature issue type ID: 10142
-- Git Pull Request custom field: customfield_12310220
+- Git Pull Request custom field: customfield_10875
 ```
 
 #### How skills use it
@@ -189,7 +189,7 @@ replacing the values with their own.
 - Project key: TC
 - Cloud ID: https://issues.redhat.com
 - Feature issue type ID: 10142
-- Git Pull Request custom field: customfield_12310220
+- Git Pull Request custom field: customfield_10875
 
 ## Code Intelligence
 

--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -178,9 +178,10 @@ Push the branch and open a pull request.
 
 ## Step 10 – Update Jira
 
-Update the **Git Pull Request** custom field on the Jira issue with the PR URL:
+Update the **Git Pull Request** custom field on the Jira issue with the PR URL.
+This field requires ADF (Atlassian Document Format), not a plain string:
 
-jira.update_issue(<jira-issue-id>, fields={"customfield_12310220": "<PR-URL>"})
+jira.update_issue(<jira-issue-id>, fields={"customfield_10875": {"type": "doc", "version": 1, "content": [{"type": "paragraph", "content": [{"type": "text", "text": "<PR-URL>"}]}]}})
 
 Add a comment to the Jira task:
 


### PR DESCRIPTION
## Summary
- Replace all references to `customfield_12310220` with `customfield_10875` across docs and skill files
- Document that the Git Pull Request field requires ADF format, not a plain string
- Update TC-3806 Jira task description to use the correct field ID

## Changes
- `docs/project-config-contract.md`: Updated 3 occurrences of the custom field ID and added ADF format note
- `plugins/sdlc-workflow/skills/implement-task/SKILL.md`: Updated Step 10 with correct field ID and ADF format example

Implements TC-3810

## Test plan
- [x] `grep -r customfield_12310220` returns zero matches
- [x] Verify setting `customfield_10875` with ADF format succeeds on a test issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)