### PR TITLE
fix(plugin): add version and author fields to manifest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# sdlc-plugins
+
+## Version Management
+
+The plugin version must be kept in sync in two files:
+
+- `plugins/sdlc-workflow/.claude-plugin/plugin.json` — the plugin manifest (required by CI validation)
+- `.claude-plugin/marketplace.json` — the marketplace registry (required for relative-path plugins per Claude Code docs)
+
+When bumping the version, update both files together.

--- a/plugins/sdlc-workflow/.claude-plugin/plugin.json
+++ b/plugins/sdlc-workflow/.claude-plugin/plugin.json
@@ -1,4 +1,8 @@
 {
   "name": "sdlc-workflow",
-  "description": "AI-assisted SDLC workflow skills for planning features and implementing tasks with full Jira traceability."
+  "description": "AI-assisted SDLC workflow skills for planning features and implementing tasks with full Jira traceability.",
+  "version": "0.2.2",
+  "author": {
+    "name": "Marco Rizzi"
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `version` (`0.2.2`) and `author` (`Marco Rizzi`) fields to the sdlc-workflow plugin manifest
- Eliminates CI validation warnings about missing version and author information

## Test plan
- [x] `claude plugin validate` passes locally with zero warnings
- [x] Validate Plugins CI workflow passes with zero warnings

Implements TC-3816