### PR TITLE
feat(implement-task): add assign-to-me on task start

### DIFF
--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -68,13 +68,23 @@ jira.get_issue(<dependency-id>)
 
 Verify status is Done or equivalent. If not, stop and inform the user.
 
-## Step 3 – Transition to In Progress
+## Step 3 – Transition to In Progress and Assign
 
-Transition the Jira issue to indicate work has started:
+Transition the Jira issue to indicate work has started, and assign it to the current user:
+
+1. Retrieve the current user's Jira account ID:
+
+jira.user_info()
+
+2. Assign the task to the current user:
+
+jira.edit_issue(<jira-issue-id>, assignee=<current-user-account-id>)
+
+3. Transition the issue to In Progress:
 
 jira.transition_issue → In Progress
 
-This ensures the issue status reflects that implementation is underway.
+This ensures both ownership and status are reflected in Jira as soon as implementation begins.
 
 ## Step 4 – Understand the Code
 


### PR DESCRIPTION
## Summary
- Updates Step 3 of the `implement-task` skill to automatically assign the Jira task to the current user when implementation begins
- The skill now retrieves the user's account ID via `jira.user_info()` and sets the assignee via `jira.edit_issue()` before transitioning to In Progress
- Ensures ownership is reflected in Jira as soon as work starts

Implements [TC-3819](https://redhat.atlassian.net/browse/TC-3819)

## Test plan
- [ ] Run `/implement-task` on a test Jira task and verify the task is assigned to the current user
- [ ] Verify the "In Progress" transition still works correctly alongside the new assignment step

🤖 Generated with [Claude Code](https://claude.com/claude-code)