### PR TITLE
fix(implement-task): remove hardcoded Git Pull Request custom field ID

### DIFF
--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -188,10 +188,15 @@ Push the branch and open a pull request.
 
 ## Step 10 – Update Jira
 
-Update the **Git Pull Request** custom field on the Jira issue with the PR URL.
-This field requires ADF (Atlassian Document Format), not a plain string:
+Look up the **Git Pull Request custom field** ID from the project's **Jira Configuration**
+section in CLAUDE.md (the field is listed as `Git Pull Request custom field: <field-id>`).
 
-jira.update_issue(<jira-issue-id>, fields={"customfield_10875": {"type": "doc", "version": 1, "content": [{"type": "paragraph", "content": [{"type": "text", "text": "<PR-URL>"}]}]}})
+- **If configured**, update that custom field on the Jira issue with the PR URL.
+  The field requires ADF (Atlassian Document Format), not a plain string:
+
+jira.update_issue(<jira-issue-id>, fields={"<field-id>": {"type": "doc", "version": 1, "content": [{"type": "paragraph", "content": [{"type": "text", "text": "<PR-URL>"}]}]}})
+
+- **If not configured**, skip the custom field update (it is optional per the project-config-contract).
 
 Add a comment to the Jira task:
 


### PR DESCRIPTION
## Summary

- Removes the hardcoded `customfield_10875` from implement-task SKILL.md Step 10
- Instructs the agent to read the Git Pull Request custom field ID from the project's Jira Configuration section in CLAUDE.md
- Makes the custom field update conditional — skipped if the field is not configured (optional per the project-config-contract)
- Preserves the ADF format requirement for the field value

## Test plan

- [ ] `grep customfield_ plugins/sdlc-workflow/skills/implement-task/SKILL.md` returns zero matches
- [x] Step 10 references "Jira Configuration" and "Git Pull Request custom field" from the project's CLAUDE.md

Implements TC-3821

🤖 Generated with [Claude Code](https://claude.com/claude-code)