### PR TITLE
feat(plan-feature): add Verification Commands to task template

### DIFF
--- a/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
@@ -202,6 +202,9 @@ Reference actual file paths and symbol names found during repository analysis.>
 - [ ] Test description 1
 - [ ] Test description 2
 
+## Verification Commands
+- `<command>` — <expected outcome>
+
 ## Dependencies
 - Depends on: Task N — <task title> (if any)
 ```
@@ -212,6 +215,7 @@ Reference actual file paths and symbol names found during repository analysis.>
 - File paths must be real paths discovered during repository analysis (Step 3)
 - Implementation Notes must reference existing patterns, not abstract guidance
 - Each task must be small enough for a single engineer to implement
+- Verification Commands are optional — include them when acceptance criteria can be verified by running a command against the built or running service
 
 ## Step 6 – Create Tasks in Jira
 


### PR DESCRIPTION
## Summary
- Adds an optional `## Verification Commands` section to the plan-feature task description template, placed between Test Requirements and Dependencies
- Adds a template rule clarifying that Verification Commands are optional — include them when acceptance criteria can be verified by running a command
- Enables executable acceptance criteria for tasks generated by the plan-feature skill

Implements TC-3789

## Test plan
- [x] Verify the template sections are in logical order after the addition
- [x] Verify the template rules bullet count (6) matches the number of rules present
- [x] Verify the section format matches the specification (`- \`<command>\` — <expected outcome>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)