### PR TITLE
chore(release): bump version to 0.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "sdlc-workflow",
       "source": "./plugins/sdlc-workflow",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "description": "AI-assisted SDLC workflow skills for planning features and implementing tasks with full Jira traceability."
     }
   ]


### PR DESCRIPTION
## Summary

- Bump marketplace.json version to 0.3.0 to match plugin.json (already updated in PR #13)
- Syncs both version files as required by the project's version management policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)