### PR TITLE
docs: add release process and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+All notable changes to the sdlc-workflow plugin are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.0] - 2025-03-20
+
+### Added
+
+- `/setup` skill for project configuration validation
+- Project config template and reference documentation
+
+### Changed
+
+- Bumped version to 0.3.0
+
+## [0.2.4] - 2025-03-19
+
+### Added
+
+- Self-verification step in implement-task before commit
+- Verification Commands section in plan-feature task template
+- Metrics definitions for AI-assisted SDLC workflow
+- Architectural constraints document
+
+## [0.2.3] - 2025-03-18
+
+### Fixed
+
+- Removed hardcoded Git Pull Request custom field ID from implement-task
+
+## [0.2.1] - 2025-03-17
+
+### Added
+
+- GitHub Actions workflow for plugin validation
+- CLAUDE.md with version sync instructions
+
+### Fixed
+
+- Added version and author fields to plugin manifest
+- Updated Git Pull Request custom field ID
+- Removed smoke-test job that requires authentication
+- Fixed version reference and marketplace add command in README
+- Removed invalid skills array from plugin manifest
+- Added missing description field to skill entries
+
+## [0.1.0] - 2025-03-16
+
+### Added
+
+- Initial release of the sdlc-workflow plugin
+- `plan-feature` skill — generate implementation plans and Jira tasks from a feature
+- `implement-task` skill — implement Jira tasks with structured descriptions
+- Plugin marketplace repository structure
+- Project configuration contract documentation
+- SDLC methodology documentation
+- README with installation guide

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.3] - 2025-03-18
 
+### Added
+
+- Assign-to-me on task start in implement-task
+
 ### Fixed
 
 - Removed hardcoded Git Pull Request custom field ID from implement-task
 
-## [0.2.1] - 2025-03-17
+## [0.2.2] - 2025-03-17
 
 ### Added
 
@@ -41,11 +45,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Added version and author fields to plugin manifest
-- Updated Git Pull Request custom field ID
+- Updated Git Pull Request custom field ID to customfield_10875
 - Removed smoke-test job that requires authentication
 - Fixed version reference and marketplace add command in README
 - Removed invalid skills array from plugin manifest
+
+## [0.2.1] - 2025-03-17
+
+### Fixed
+
 - Added missing description field to skill entries
+
+## [0.2.0] - 2025-03-16
+
+### Changed
+
+- Genericized skill files to use project configuration contract references
 
 ## [0.1.0] - 2025-03-16
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,33 @@
+# Releasing
+
+This document describes how to release a new version of the sdlc-workflow plugin.
+
+## Release Process
+
+1. **Develop on a branch** — make skill/plugin changes on a feature branch, open a PR, get it reviewed, and merge to the default branch.
+
+2. **Bump the version** — update the `version` field in **both** of these files (they must stay in sync):
+   - `.claude-plugin/marketplace.json` (the marketplace registry)
+   - `plugins/sdlc-workflow/.claude-plugin/plugin.json` (the plugin manifest)
+
+   Follow [Semantic Versioning](https://semver.org/):
+   - `0.X.0` → `0.(X+1).0` for new features or breaking changes
+   - `0.X.Y` → `0.X.(Y+1)` for bug fixes
+
+3. **Commit the version bump** with the message:
+   ```
+   chore(release): bump version to X.Y.Z
+   ```
+
+4. **Push to the default branch.**
+
+5. **Users update** by running:
+   ```
+   /plugin marketplace update
+   ```
+
+## Versioning Rules
+
+- The version in `marketplace.json` is what Claude Code uses to detect whether an update is available. If the version doesn't change, `/plugin marketplace update` will skip the plugin even if files have changed.
+- The version in `plugin.json` must match `marketplace.json` to avoid confusion (this is enforced by project convention — see `CLAUDE.md`).
+- This project uses relative-path plugin sources (`"source": "./plugins/sdlc-workflow"`). In the future, it can migrate to GitHub-sourced plugins for tag-based pinning and independent versioning per plugin.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -7,8 +7,8 @@ This document describes how to release a new version of the sdlc-workflow plugin
 1. **Develop on a branch** — make skill/plugin changes on a feature branch, open a PR, get it reviewed, and merge to the default branch.
 
 2. **Bump the version** — update the `version` field in **both** of these files (they must stay in sync):
-   - `.claude-plugin/marketplace.json` (the marketplace registry)
-   - `plugins/sdlc-workflow/.claude-plugin/plugin.json` (the plugin manifest)
+   - `.claude-plugin/marketplace.json` — required by Claude Code for relative-path plugins to detect available updates (see [version resolution](https://code.claude.com/docs/en/plugin-marketplaces#version-resolution-and-release-channels))
+   - `plugins/sdlc-workflow/.claude-plugin/plugin.json` — required to pass `claude plugin validate` without warnings
 
    Follow [Semantic Versioning](https://semver.org/):
    - `0.X.0` → `0.(X+1).0` for new features or breaking changes
@@ -28,6 +28,6 @@ This document describes how to release a new version of the sdlc-workflow plugin
 
 ## Versioning Rules
 
-- The version in `marketplace.json` is what Claude Code uses to detect whether an update is available. If the version doesn't change, `/plugin marketplace update` will skip the plugin even if files have changed.
-- The version in `plugin.json` must match `marketplace.json` to avoid confusion (this is enforced by project convention — see `CLAUDE.md`).
+- The version in `marketplace.json` is what Claude Code uses to detect whether an update is available for relative-path plugins. If the version doesn't change, `/plugin marketplace update` will skip the plugin even if files have changed.
+- The version in `plugin.json` is required by `claude plugin validate` — omitting it produces a warning. It must match `marketplace.json` to stay consistent.
 - This project uses relative-path plugin sources (`"source": "./plugins/sdlc-workflow"`). In the future, it can migrate to GitHub-sourced plugins for tag-based pinning and independent versioning per plugin.


### PR DESCRIPTION
## Summary
- Added `docs/releasing.md` documenting the complete release workflow (branch, bump, commit, push, update)
- Added `CHANGELOG.md` with entries for all versions from v0.1.0 through v0.3.0
- Documents versioning rules: marketplace.json as update detection source, plugin.json must stay in sync

## Test plan
- [ ] Review `docs/releasing.md` for completeness and accuracy
- [ ] Review `CHANGELOG.md` entries against git history
- [ ] Verify versioning rules match current project conventions in CLAUDE.md

Implements [TC-3808](https://redhat.atlassian.net/browse/TC-3808)

🤖 Generated with [Claude Code](https://claude.com/claude-code)