### PR TITLE
TC-3839: clarify PR link fallback in implement-task skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ When bumping the version, update both files together.
 
 | Repository | Role | Serena Instance | Path |
 |---|---|---|---|
+| sdlc-plugins | Claude Code plugin | — | ./ |
 
 ## Jira Configuration
 

--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -236,7 +236,7 @@ section in CLAUDE.md (the field is listed as `Git Pull Request custom field: <fi
 
 jira.update_issue(<jira-issue-id>, fields={"<field-id>": {"type": "doc", "version": 1, "content": [{"type": "paragraph", "content": [{"type": "text", "text": "<PR-URL>"}]}]}})
 
-- **If not configured**, skip the custom field update (it is optional per the project-config-contract).
+- **If not configured**, skip the custom field update — the PR link will still be included in the Jira comment below.
 
 Add a comment to the Jira task:
 


### PR DESCRIPTION
## Summary

- Updates Step 11 of the implement-task skill to explicitly document that the PR link is included in the Jira comment when the Git Pull Request custom field is not configured, instead of silently skipping
- Adds `sdlc-plugins` to the Repository Registry in CLAUDE.md

## Test plan

- [ ] Run implement-task on a project without a Git Pull Request custom field configured and verify the PR link appears in the Jira comment
- [ ] Run implement-task on a project with the custom field configured and verify it still populates the custom field

Implements TC-3839

🤖 Generated with [Claude Code](https://claude.com/claude-code)