### PR TITLE
feat(skills): add CONVENTIONS.md lookup to skills

### DIFF
--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -129,6 +129,14 @@ Goals:
 - confirm the patterns referenced in Implementation Notes exist
 - identify any conflicts with recent changes
 
+### CONVENTIONS.md lookup
+
+Check for a `CONVENTIONS.md` file at the repository root (using `list_dir`, `search_for_pattern`,
+or Glob). If present, read it and follow its conventions throughout implementation. This includes
+naming rules, directory structure for new files, code patterns, and test conventions.
+
+This step is optional — if `CONVENTIONS.md` does not exist, proceed normally.
+
 ## Step 5 – Create Branch
 
 Create a feature branch named after the Jira issue:

--- a/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
@@ -145,6 +145,15 @@ Example:
 If no Serena instance is available for a repository,
 use Explore agents with Glob, Grep, and Read tools.
 
+### CONVENTIONS.md lookup
+
+For each target repository, check for a `CONVENTIONS.md` file at the repository root
+(using `list_dir` or Glob). If present, read it and use its conventions — naming rules,
+directory structure, code patterns, test conventions — to inform the **Implementation Notes**
+in generated task descriptions. Reference specific conventions by name when they apply to a task.
+
+This step is optional — if `CONVENTIONS.md` does not exist, proceed normally.
+
 ### Goals
 
 - Identify modules related to the feature

--- a/plugins/sdlc-workflow/skills/setup/SKILL.md
+++ b/plugins/sdlc-workflow/skills/setup/SKILL.md
@@ -97,7 +97,16 @@ Check if `docs/constraints.md` already exists in the target project.
 - **If it does NOT exist**: Read `constraints.template.md` from this skill's directory and write its content to `docs/constraints.md` in the target project. Report "Created docs/constraints.md from template."
 - **If it DOES exist**: Report "Constraints document already exists — skipping" and preserve the user's customized version.
 
-## Step 7 – Validate
+## Step 7 – Scaffold CONVENTIONS.md
+
+For each repository in the **Repository Registry**, check if a `CONVENTIONS.md` file exists at the repository root (using the **Path** column from the Registry table).
+
+- **If it exists**: Report "CONVENTIONS.md already exists in <repository> — skipping" and move to the next repository.
+- **If it does NOT exist**: Ask the user whether they want to scaffold a `CONVENTIONS.md` for that repository. If yes, read `conventions.template.md` from this skill's directory and write its content to `CONVENTIONS.md` at the repository root. Report "Created CONVENTIONS.md in <repository> from template."
+
+This step is optional and does not block the rest of the setup. If the user declines for any repository, continue to the next one.
+
+## Step 8 – Validate
 
 After writing, read the CLAUDE.md back and verify:
 - `# Project Configuration` heading exists


### PR DESCRIPTION
## Summary
- Add optional `CONVENTIONS.md` lookup to **plan-feature** Repository Analysis step so conventions inform generated Implementation Notes
- Add optional `CONVENTIONS.md` lookup to **implement-task** Understand the Code step so conventions are followed during implementation
- Add **Step 7 – Scaffold CONVENTIONS.md** to `/setup` skill that offers to create `CONVENTIONS.md` from the template for repos that don't have one
- Both plan-feature and implement-task lookups are optional — skills proceed normally if `CONVENTIONS.md` doesn't exist
- Setup scaffolding is idempotent — skips repos that already have `CONVENTIONS.md`

## Jira
Implements [TC-3793](https://redhat.atlassian.net/browse/TC-3793)

## Test plan
- [x] Verify plan-feature SKILL.md includes CONVENTIONS.md lookup in Repository Analysis step
- [x] Verify implement-task SKILL.md includes CONVENTIONS.md lookup in Understand the Code step
- [x] Verify both lookups are clearly optional (no failure if file doesn't exist)
- [x] Verify setup SKILL.md has new Step 7 for scaffolding CONVENTIONS.md
- [x] Verify setup step is idempotent (skips existing CONVENTIONS.md)
- [x] Verify no conflicts with existing step content

🤖 Generated with [Claude Code](https://claude.com/claude-code)