### PR TITLE
feat(skills): add loop detection guidance to implement-task

### DIFF
--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -266,3 +266,6 @@ jira.transition_issue → In Review
 - If the structured description is incomplete, ask the user rather than improvising.
 - Keep changes scoped to what the task describes — no unrelated refactoring.
 - Every commit must reference the Jira issue ID.
+- If the same test fails 3 times with the same error, stop and ask the user for guidance — do not retry the same approach.
+- If the same file is edited more than 5 times for the same change, stop and reassess your approach — present the problem and proposed alternatives to the user.
+- If a build or compile error persists after 2 fix attempts, stop and present the error and proposed alternatives to the user — do not keep trying the same fix.


### PR DESCRIPTION
## Summary

- Adds loop detection rules to the Important Rules section of the implement-task skill
- Enforces concrete thresholds: 3 test failures, 5 file edits, 2 compile error fix attempts
- Each rule requires stopping and engaging the user rather than silently retrying

Implements TC-3791

## Test plan

- [x] Verify rules appear only in the Important Rules section (no duplicates)
- [x] Verify concrete thresholds are specified (3, 5, 2)
- [x] Verify imperative language ("stop and ask", not "consider asking")