### PR TITLE
docs: add version bump decision guide

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -10,9 +10,9 @@ This document describes how to release a new version of the sdlc-workflow plugin
    - `.claude-plugin/marketplace.json` — required by Claude Code for relative-path plugins to detect available updates (see [version resolution](https://code.claude.com/docs/en/plugin-marketplaces#version-resolution-and-release-channels))
    - `plugins/sdlc-workflow/.claude-plugin/plugin.json` — required to pass `claude plugin validate` without warnings
 
-   Follow [Semantic Versioning](https://semver.org/):
-   - `0.X.0` → `0.(X+1).0` for new features or breaking changes
-   - `0.X.Y` → `0.X.(Y+1)` for bug fixes
+   Follow [Semantic Versioning](https://semver.org/) using the decision criteria in the [Version Bump Decision Guide](#version-bump-decision-guide) below:
+   - `0.X.0` → `0.(X+1).0` (y-stream) for new features or breaking changes
+   - `0.X.Y` → `0.X.(Y+1)` (z-stream) for enhancements, bug fixes, and polish
 
 3. **Commit the version bump** with the message:
    ```
@@ -33,6 +33,40 @@ This document describes how to release a new version of the sdlc-workflow plugin
    ```
    /plugin marketplace update
    ```
+
+## Version Bump Decision Guide
+
+The version bump decision is a **human judgment call**, not a mechanical scan of commit prefixes. A commit tagged `feat` does not automatically mean a y-stream bump — many `feat` commits are enhancements to existing functionality and belong in a z-stream release.
+
+### Decision checklist
+
+Ask these questions about the changes since the last release:
+
+| Question | If yes |
+|---|---|
+| Does this release introduce a **new skill** (e.g. `verify-pr`, `plan-feature`)? | y-stream |
+| Does it add a **new workflow phase** or fundamentally change the SDLC methodology? | y-stream |
+| Does it introduce a **breaking change** to the task template contract, plugin manifest, or project configuration? | y-stream |
+| Does it improve an **existing skill's output**, formatting, or prompts? | z-stream |
+| Does it add guidance, guardrails, or documentation to an existing skill? | z-stream |
+| Is it a bug fix, typo correction, or documentation update? | z-stream |
+
+If none of the y-stream criteria apply, use a z-stream bump — even if every commit uses the `feat` prefix.
+
+### Examples
+
+These examples use real commit messages from this project to illustrate the distinction:
+
+**z-stream (`feat` commits that are enhancements, not new features):**
+
+- `feat(skills): enhance comment footer with plugin link, skill name, and version` — improves existing comment output formatting; no new capability is introduced
+- `feat(skills): add CONVENTIONS.md fill-in prompt to setup skill` — adds a prompt to an existing skill; the skill itself already exists
+- `feat(skills): add loop detection guidance to implement-task` — adds guardrails to an existing skill's instructions
+
+**y-stream (genuinely new features or breaking changes):**
+
+- `feat(skills): add verify-pr skill for PR verification against Jira tasks` — introduces an entirely new skill that didn't exist before
+- `feat(plan-feature): add constraint-aware task generation` — adds a new capability (constraint awareness) that changes how tasks are generated, altering the task template output
 
 ## Versioning Rules
 


### PR DESCRIPTION
## Summary

- Adds a **Version Bump Decision Guide** section to `docs/releasing.md` with a decision checklist table for y-stream vs z-stream bump criteria
- Provides concrete examples using real commit messages from this project showing when `feat` commits are z-stream (enhancements) vs y-stream (new features)
- Makes explicit that version bump decisions require human judgment, not mechanical commit prefix scanning

## Test plan

- [x] Documentation is internally consistent with existing semver rules
- [x] Examples reference realistic commit messages from project history
- [x] All three acceptance criteria from TC-3846 are satisfied

Implements TC-3846

🤖 Generated with [Claude Code](https://claude.com/claude-code)