### PR TITLE
fix(skills): use inlineCard ADF node for Git Pull Request custom field

### DIFF
--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -262,7 +262,7 @@ section in CLAUDE.md (the field is listed as `Git Pull Request custom field: <fi
 - **If configured**, update that custom field on the Jira issue with the PR URL.
   The field requires ADF (Atlassian Document Format), not a plain string:
 
-jira.update_issue(<jira-issue-id>, fields={"<field-id>": {"type": "doc", "version": 1, "content": [{"type": "paragraph", "content": [{"type": "text", "text": "<PR-URL>"}]}]}})
+jira.update_issue(<jira-issue-id>, fields={"<field-id>": {"type": "doc", "version": 1, "content": [{"type": "paragraph", "content": [{"type": "inlineCard", "attrs": {"url": "<PR-URL>"}}]}]}})
 
 - **If not configured**, skip the custom field update — the PR link will still be included in the Jira comment below.
 


### PR DESCRIPTION
## Summary
- Changes the ADF snippet in `implement-task/SKILL.md` Step 11 from a plain `text` node to an `inlineCard` node with `attrs.url`
- PR URLs written to the Git Pull Request custom field (`customfield_10875`) will now render as clickable Smart Links in Jira

## Test plan
- [x] Verify the ADF snippet in Step 11 uses `inlineCard` with `attrs.url` instead of `text`
- [x] Run implement-task on a test issue and confirm the PR link in Jira renders as a clickable Smart Link

Implements TC-3847

🤖 Generated with [Claude Code](https://claude.com/claude-code)