### PR TITLE
feat(skills): add GitHub issue Closes reference to PR description

### DIFF
--- a/docs/project-config-contract.md
+++ b/docs/project-config-contract.md
@@ -82,6 +82,7 @@ that skills need to create issues, query tasks, and update fields.
 | Field | Description | Example |
 |---|---|---|
 | Git Pull Request custom field | Custom field ID for storing PR URLs (requires ADF format) | `customfield_10875` |
+| GitHub Issue custom field | Custom field ID containing a GitHub issue URL (plain string or ADF) | `customfield_10747` |
 | Default labels | Labels to apply to AI-generated issues | `ai-generated-jira` |
 
 #### Structure
@@ -93,6 +94,7 @@ that skills need to create issues, query tasks, and update fields.
 - Cloud ID: https://issues.redhat.com
 - Feature issue type ID: 10142
 - Git Pull Request custom field: customfield_10875
+- GitHub Issue custom field: customfield_10747
 ```
 
 #### How skills use it
@@ -101,6 +103,7 @@ that skills need to create issues, query tasks, and update fields.
 - "Use the Cloud ID as the `cloudId` parameter in all Jira MCP tool calls."
 - "Use the Feature issue type ID when creating feature-level issues."
 - "If a Git Pull Request custom field is configured, update it with the PR URL."
+- "If a GitHub Issue custom field is configured, read it from the Jira issue and add a `Closes` reference to the PR description."
 
 ---
 

--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -94,6 +94,18 @@ Parse the structured description expecting these sections:
 
 If any required section is missing or the description doesn't follow the template, stop and ask the user for clarification.
 
+### GitHub Issue extraction
+
+Look up the **GitHub Issue custom field** ID from the project's **Jira Configuration**
+section in CLAUDE.md (the field is listed as `GitHub Issue custom field: <field-id>`).
+
+- **If configured**, read the custom field value from the fetched issue's fields.
+  The value may be a plain URL string or an ADF document containing a URL — extract
+  the URL in either case. Parse the GitHub issue URL to extract `owner`, `repo`, and
+  `number` from the pattern `https://github.com/<owner>/<repo>/issues/<number>`.
+  Store the parsed reference as `<owner>/<repo>#<number>` for use in Step 10.
+- **If not configured or the field is empty**, skip silently — this is optional.
+
 ## Step 2 – Verify Dependencies
 
 If the task has Dependencies, check each one:
@@ -253,6 +265,11 @@ The footer MUST reference the Jira issue ID.
 Always include `--trailer="Assisted-by: Claude Code"` to attribute AI assistance.
 
 Push the branch and open a pull request.
+
+If a GitHub issue reference was extracted in Step 1, append a `Closes <owner>/<repo>#<number>`
+line to the PR description body. GitHub recognizes this keyword and will auto-close the
+linked issue when the PR is merged. Do **not** add this to the commit message — only the
+PR description.
 
 ## Step 11 – Update Jira
 

--- a/plugins/sdlc-workflow/skills/setup/SKILL.md
+++ b/plugins/sdlc-workflow/skills/setup/SKILL.md
@@ -57,11 +57,13 @@ Otherwise, determine which fields are missing and gather them:
    b. Use `getAccessibleAtlassianResources` to discover the Cloud ID.
    c. Use `getJiraProjectIssueTypesMetadata` with the chosen project key to list issue types and ask the user which one is the Feature type (this provides the Feature issue type ID).
    d. Ask the user if they have a Git Pull Request custom field ID (optional).
+   e. Ask the user if they have a GitHub Issue custom field ID (optional).
 3. If no Atlassian MCP is available, ask the user to provide the missing fields directly:
    - Project key
    - Cloud ID (Jira instance URL or cloud UUID)
    - Feature issue type ID
    - Git Pull Request custom field (optional)
+   - GitHub Issue custom field (optional)
 
 Only ask for fields that are not already configured.
 

--- a/plugins/sdlc-workflow/skills/setup/project-config.template.md
+++ b/plugins/sdlc-workflow/skills/setup/project-config.template.md
@@ -12,6 +12,7 @@
 - Cloud ID: {{cloud-id}}
 - Feature issue type ID: {{feature-issue-type-id}}
 - Git Pull Request custom field: {{custom-field-id}}
+- GitHub Issue custom field: {{custom-field-id}}
 
 ## Code Intelligence
 


### PR DESCRIPTION
## Summary
- Add optional `GitHub Issue custom field` support to the implement-task skill
- When configured in CLAUDE.md and populated on a Jira task, the skill appends `Closes owner/repo#number` to the PR description
- Document the new optional field in `docs/project-config-contract.md`

Implements [TC-3866](https://redhat.atlassian.net/browse/TC-3866)

Closes mrizzi/sdlc-plugins#28