### PR TITLE
feat(skills): enforce DRY principle across planning and implementation

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -60,7 +60,8 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 5.1 | Changes MUST be scoped to the files listed in Files to Modify and Files to Create — no unrelated files. | `implement-task/SKILL.md` — Step 6, Important Rules |
 | 5.2 | Code MUST NOT be modified without first inspecting it (via Serena or Read/Grep/Glob). | `implement-task/SKILL.md` — Step 4, Important Rules |
 | 5.3 | Implementation MUST follow the patterns referenced in the task's Implementation Notes. | `implement-task/SKILL.md` — Important Rules |
-| 5.4 | AI MUST NOT start work autonomously — a human must trigger it. | `methodology.md` — Core Principles (Human Driven Workflow) |
+| 5.4 | Code MUST NOT duplicate existing functionality — reuse or extend existing utilities, helpers, and shared modules when equivalent logic exists. | `implement-task/SKILL.md` — Step 4, Step 6, Step 9 |
+| 5.5 | AI MUST NOT start work autonomously — a human must trigger it. | `methodology.md` — Core Principles (Human Driven Workflow) |
 
 ---
 
@@ -69,5 +70,5 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 Each constraint above references its source. The full source files are:
 
 - `plugins/sdlc-workflow/skills/plan-feature/SKILL.md` — Guardrails (§1.1–1.3), Task Description Template (§4.1–4.8)
-- `plugins/sdlc-workflow/skills/implement-task/SKILL.md` — Important Rules (§1.4–1.6, §5.1–5.3), Step 5 (§3.1), Step 9 (§2.1–2.3), Step 10 (§3.2)
-- `docs/methodology.md` — Core Principles (§2.1, §3.2, §5.4)
+- `plugins/sdlc-workflow/skills/implement-task/SKILL.md` — Important Rules (§1.4–1.6, §5.1–5.3), Step 4/6/9 (§5.4), Step 5 (§3.1), Step 9 (§2.1–2.3), Step 10 (§3.2)
+- `docs/methodology.md` — Core Principles (§2.1, §3.2, §5.5)

--- a/docs/conventions-spec.md
+++ b/docs/conventions-spec.md
@@ -90,4 +90,5 @@ The template includes the following sections (see the [template file](../plugins
 - **Error Handling** — error handling patterns and conventions
 - **Testing Conventions** — testing patterns, frameworks, and coverage requirements
 - **Commit Messages** — project-specific commit message conventions (extending the workflow conventions above)
+- **Shared Modules and Reuse** — utility directories, shared helpers, and common abstractions that should be reused instead of duplicating logic
 - **Dependencies** — policies for adding or managing dependencies

--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -162,6 +162,7 @@ Goals:
 - understand the current state of files to be modified
 - confirm the patterns referenced in Implementation Notes exist
 - identify any conflicts with recent changes
+- search for existing utilities, helpers, and shared modules that provide functionality overlapping with the planned changes — if equivalent logic already exists, plan to reuse or extend it rather than writing new code
 
 ### CONVENTIONS.md lookup
 
@@ -182,6 +183,11 @@ git checkout -b <jira-issue-id>
 The **Description** section is your primary specification — implement exactly what it describes.
 Use **Files to Modify**, **Files to Create**, and **API Changes** as your working scope.
 Follow the **Implementation Notes** for patterns and code references on how to implement the changes.
+
+**Reuse first:** Before writing new logic, check whether the Implementation Notes list reusable
+code (utilities, helpers, shared modules). If they do, use or extend the existing code. If you
+discover additional reusable code during implementation that was not listed, prefer reusing it
+over creating duplicated logic.
 
 ### Serena symbolic editing (preferred)
 
@@ -246,6 +252,13 @@ Search the staged diff for secrets, credentials, or environment files that shoul
 git diff --cached | grep -iE '(password\s*=|API_KEY|SECRET_KEY|BEGIN.*PRIVATE KEY|\.env)'
 
 If any match is found, flag it to the user and do not proceed until the issue is resolved.
+
+### Duplication check
+
+Search for functions, methods, or logic in the repository that overlap with the code you wrote.
+Use Grep or Serena's `search_for_pattern` to look for similar function names, string literals,
+or algorithmic patterns. If you find that your new code substantially duplicates existing
+utilities or helpers, refactor to reuse the existing code before proceeding.
 
 ### Compiler / linter warnings
 

--- a/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
@@ -180,6 +180,7 @@ This step is optional — if `CONVENTIONS.md` does not exist, proceed normally.
 - Detect relevant APIs and endpoints
 - Detect test locations and patterns
 - Discover existing code patterns to reference in implementation notes
+- Search for reusable utilities, helpers, and shared modules that overlap with the planned feature — flag these as reuse opportunities in Implementation Notes rather than planning new code that duplicates them
 
 ## Step 4 – Build Repository Impact Map
 
@@ -261,7 +262,7 @@ Reference actual file paths and symbol names found during repository analysis.>
 - Omit sections that don't apply (e.g. no API Changes for a pure UI task, no Files to Create if only modifying)
 - Repository must be a single repository per task
 - File paths must be real paths discovered during repository analysis (Step 3)
-- Implementation Notes must reference existing patterns, not abstract guidance
+- Implementation Notes must reference existing patterns, not abstract guidance — when reusable utilities, helpers, or shared modules were found during repository analysis, list them with file paths and symbol names so the implementer can reuse them instead of writing new code
 - Each task must be small enough for a single engineer to implement
 - Verification Commands are optional — include them when acceptance criteria can be verified by running a command against the built or running service
 

--- a/plugins/sdlc-workflow/skills/setup/SKILL.md
+++ b/plugins/sdlc-workflow/skills/setup/SKILL.md
@@ -141,6 +141,7 @@ For each section in the `CONVENTIONS.md` template, replace the `{{placeholder}}`
 - **Error Handling** — error types, patterns, and idioms
 - **Testing Conventions** — test frameworks, patterns, coverage expectations
 - **Commit Messages** — commit format and conventions
+- **Shared Modules and Reuse** — utility directories, shared helpers, common abstractions, and any reusable code that should be preferred over writing new implementations. Search for directories named `utils/`, `common/`, `shared/`, `helpers/`, or `lib/`, and for widely-imported modules. List the key modules with their paths and purpose.
 - **Dependencies** — dependency management policies
 
 #### User review

--- a/plugins/sdlc-workflow/skills/setup/conventions.template.md
+++ b/plugins/sdlc-workflow/skills/setup/conventions.template.md
@@ -76,6 +76,20 @@
 
 {{commit-messages}}
 
+## Shared Modules and Reuse
+
+<!-- Document shared utilities, helpers, and common abstractions that should be
+     reused instead of duplicating logic. This helps AI assistants find existing
+     code before writing new implementations.
+     Example:
+     - Utility directory: `src/utils/` — common helpers (string formatting, date parsing)
+     - Shared HTTP client: `src/common/http.ts` — use `apiClient` for all API calls
+     - Error types: `modules/error/` — use `AppError` and existing error variants
+     - Shared components: `client/src/components/` — reuse PatternFly wrappers
+     - Database helpers: `src/db/helpers.rs` — use `paginate()` for paginated queries -->
+
+{{shared-modules-and-reuse}}
+
 ## Dependencies
 
 <!-- Document policies for adding dependencies.


### PR DESCRIPTION
## Summary
- Add reusable-code search to plan-feature repository analysis (Step 3) and require Implementation Notes to list reusable code with file paths and symbol names
- Add duplication-check goal to implement-task code understanding (Step 4), reuse-first rule in implementation (Step 6), and duplication scan in self-verification (Step 9)
- Add constraint §5.4: code MUST NOT duplicate existing functionality
- Add "Shared Modules and Reuse" section to conventions template and spec
- Handle the new section in setup skill during CONVENTIONS.md generation

## Jira
Implements [TC-3867](https://redhat.atlassian.net/browse/TC-3867)

🤖 Generated with [Claude Code](https://claude.com/claude-code)