### PR TITLE
feat(skills): add duplication-risk scan and Reuse Candidates section

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -51,6 +51,7 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 4.7 | Implementation Notes MUST reference existing patterns found in the code, not abstract guidance. | `plan-feature/SKILL.md` — Template rules |
 | 4.8 | Every task created in Jira MUST include the `ai-generated-jira` label. | `plan-feature/SKILL.md` — Step 6a |
 | 4.9 | Tasks that change public APIs, configuration, setup steps, or architectural patterns SHOULD include an optional **Documentation Updates** section listing which docs need updating and what content to add or revise. | `plan-feature/SKILL.md` — Template rules |
+| 4.10 | Tasks SHOULD include a **Reuse Candidates** section when overlapping code (domain logic, components, utilities, or patterns) was found during repository analysis, listing file paths, symbol names, and relevance descriptions. | `plan-feature/SKILL.md` — Task Description Template |
 
 ---
 
@@ -70,6 +71,6 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 
 Each constraint above references its source. The full source files are:
 
-- `plugins/sdlc-workflow/skills/plan-feature/SKILL.md` — Guardrails (§1.1–1.3), Task Description Template (§4.1–4.9)
+- `plugins/sdlc-workflow/skills/plan-feature/SKILL.md` — Guardrails (§1.1–1.3), Task Description Template (§4.1–4.10)
 - `plugins/sdlc-workflow/skills/implement-task/SKILL.md` — Important Rules (§1.4–1.6, §5.1–5.3), Step 4/6/9 (§5.4), Step 5 (§3.1), Step 9 (§2.1–2.3), Step 10 (§3.2)
 - `docs/methodology.md` — Core Principles (§2.1, §3.2, §5.5)

--- a/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
@@ -192,6 +192,7 @@ Use Glob, `list_dir`, or `search_for_pattern` to locate these files. Record them
 - Detect test locations and patterns
 - Discover existing code patterns to reference in implementation notes
 - Search for reusable utilities, helpers, and shared modules that overlap with the planned feature — flag these as reuse opportunities in Implementation Notes rather than planning new code that duplicates them
+- Perform a systematic duplication-risk scan: for each planned change in the impact map, search for existing domain logic, similar components, and algorithmic patterns — not just utilities — that overlap with the planned work. Use `find_symbol`, `search_for_pattern`, or Grep to locate candidates. Record matches as reuse candidates for inclusion in the task description's **Reuse Candidates** section
 - Identify documentation files that may need updating when the feature changes public APIs, configuration, setup steps, or architectural patterns
 
 ## Step 4 – Build Repository Impact Map
@@ -255,6 +256,9 @@ Create implementation tasks for each unit of work. Each task description MUST fo
 key functions/structs/components to interact with.
 Reference actual file paths and symbol names found during repository analysis.>
 
+## Reuse Candidates
+- `path/to/file.ext::symbol_name` — <what it does and how it relates to this task>
+
 ## Acceptance Criteria
 - [ ] Criterion 1
 - [ ] Criterion 2
@@ -282,6 +286,7 @@ When a feature introduces significant new behavior (new user-facing capabilities
 - Repository must be a single repository per task
 - File paths must be real paths discovered during repository analysis (Step 3)
 - Implementation Notes must reference existing patterns, not abstract guidance — when reusable utilities, helpers, or shared modules were found during repository analysis, list them with file paths and symbol names so the implementer can reuse them instead of writing new code
+- Reuse Candidates is optional — include it when the duplication-risk scan (Step 3) found existing code (domain logic, components, utilities, or patterns) that overlaps with the planned changes, so the implementer has an explicit checklist of code to consider reusing before writing new code
 - Each task must be small enough for a single engineer to implement
 - Verification Commands are optional — include them when acceptance criteria can be verified by running a command against the built or running service
 - Documentation Updates is optional — include it when the task changes public APIs, configuration, setup steps, or architectural patterns, listing which docs need updating and what content to add or revise (not the actual doc content)


### PR DESCRIPTION
## Summary
- Extends plan-feature Step 3 repository analysis with a systematic duplication-risk scan that searches for domain logic, components, and algorithmic patterns — not just utilities
- Adds an optional **Reuse Candidates** section to the Task Description Template between Implementation Notes and Acceptance Criteria
- Adds template rule documenting when to include/omit the section
- Adds constraint §4.10 to `docs/constraints.md` and updates the traceability index

Implements [TC-3870](https://redhat.atlassian.net/browse/TC-3870)