### PR TITLE
fix(verify-pr): replace invalid --stat flag with gh api for diff size check

### DIFF
--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -151,13 +151,13 @@ Record each finding as PASS (all files match), WARN (out-of-scope files), or FAI
 
 ## Step 5 – Diff Size Check
 
-Get the diff statistics:
+Get the diff statistics using the GitHub REST API:
 
 ```
-gh pr diff <pr-number> --stat -R <owner/repo>
+gh api repos/<owner/repo>/pulls/<pr-number> --jq '.additions, .deletions, .changed_files'
 ```
 
-Compare the total lines changed against the expected scope from the task. Flag a WARN if the diff size appears disproportionately large relative to the number of files and changes described in the task.
+This returns the number of additions, deletions, and changed files. Compare the total lines changed against the expected scope from the task. Flag a WARN if the diff size appears disproportionately large relative to the number of files and changes described in the task.
 
 ## Step 6 – Commit Traceability
 


### PR DESCRIPTION
## Summary

- Replace invalid `gh pr diff --stat` command in verify-pr Step 5 with `gh api repos/<owner/repo>/pulls/<pr-number> --jq '.additions, .deletions, .changed_files'`
- The `--stat` flag is not supported by `gh pr diff`, causing "unknown flag: --stat" errors

Implements [TC-3874](https://redhat.atlassian.net/browse/TC-3874)

## Test plan

- [x] Verified `gh api repos/mrizzi/sdlc-plugins/pulls/35 --jq '.additions, .deletions, .changed_files'` returns numeric values (66, 18, 1)
- [ ] Run `/verify-pr` against an open PR and confirm the diff size check step completes without error