### PR TITLE
feat(implement-task): add data-flow trace self-verification check

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -64,6 +64,7 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 5.3 | Implementation MUST follow the patterns referenced in the task's Implementation Notes. | `implement-task/SKILL.md` — Important Rules |
 | 5.4 | Code MUST NOT duplicate existing functionality — reuse or extend existing utilities, helpers, and shared modules when equivalent logic exists. | `implement-task/SKILL.md` — Step 4, Step 6, Step 9 |
 | 5.5 | AI MUST NOT start work autonomously — a human must trigger it. | `methodology.md` — Core Principles (Human Driven Workflow) |
+| 5.6 | After implementation, each new feature MUST be traced through its complete data-flow lifecycle (input → processing → output) — incomplete paths must be fixed before committing. | `implement-task/SKILL.md` — Step 9 |
 
 ---
 
@@ -72,5 +73,5 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 Each constraint above references its source. The full source files are:
 
 - `plugins/sdlc-workflow/skills/plan-feature/SKILL.md` — Guardrails (§1.1–1.3), Task Description Template (§4.1–4.10)
-- `plugins/sdlc-workflow/skills/implement-task/SKILL.md` — Important Rules (§1.4–1.6, §5.1–5.3), Step 4/6/9 (§5.4), Step 5 (§3.1), Step 9 (§2.1–2.3), Step 10 (§3.2)
+- `plugins/sdlc-workflow/skills/implement-task/SKILL.md` — Important Rules (§1.4–1.6, §5.1–5.3), Step 4/6/9 (§5.4), Step 5 (§3.1), Step 9 (§2.1–2.3, §5.6), Step 10 (§3.2)
 - `docs/methodology.md` — Core Principles (§2.1, §3.2, §5.5)

--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -296,6 +296,32 @@ utilities or helpers, refactor to reuse the existing code before proceeding.
 
 If the project has a build or lint step, compare the current warning output against the pre-implementation baseline captured during Step 7. If new warnings were introduced, fix them before proceeding.
 
+### Data-flow trace
+
+For each new feature or capability implemented, trace the data through its complete
+lifecycle to catch partial implementations:
+
+1. **Identify data-flow stages**: for each change, determine the input (where data enters
+   the system — API request, file read, user event), processing (where it is validated,
+   transformed, or enriched), and output (where results are produced — response, persistence,
+   UI render, event emission).
+2. **Verify connections**: confirm that each stage is connected to the next. A new API
+   endpoint must not just parse a request but also invoke the processing logic and return
+   or persist the result. A new parser must propagate its output to consumers.
+3. **Flag incomplete paths**: list any data-flow path where a stage is missing or
+   disconnected. For each gap, state which stage is incomplete and what is missing.
+4. **Fix before committing**: if incomplete paths are found, implement the missing
+   connections before proceeding. If the missing stage is intentionally out of scope
+   for this task, ask the user to confirm.
+
+Output the traced data flows and their completeness status to the user before proceeding.
+
+> **Example output:**
+>
+> **Data-flow trace results:**
+> - `POST /api/v2/sbom` → parse request ✓ → validate ✓ → persist to DB ✓ → return response ✓ — **COMPLETE**
+> - `parseLicense()` → extract license ID ✓ → resolve to SPDX ✓ → attach to package ✗ — **INCOMPLETE** (output not connected)
+
 ## Step 10 – Commit and Push
 
 Commit following the Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/):


### PR DESCRIPTION
## Summary
- Adds Step 9.F (Data-Flow Trace) to the `implement-task` skill's self-verification phase
- Traces each new feature through input → processing → output stages, catching partial implementations before commit
- Produces explicit output visible to the user with completeness status
- Adds constraint §5.6 to `docs/constraints.md` with source traceability

Implements [TC-3880](https://redhat.atlassian.net/browse/TC-3880)

## Test plan
- [x] Verify SKILL.md parses correctly as valid Markdown
- [x] Verify the new sub-check follows the same pattern as existing Step 9 sub-checks
- [x] Verify `docs/constraints.md` new entry follows existing table format