### PR TITLE
fix(verify-pr): add --jq to commit traceability and CI refresh for revised reports

### DIFF
--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -164,7 +164,7 @@ This returns the number of additions, deletions, and changed files. Compare the 
 Retrieve the commit list:
 
 ```
-gh pr view <pr-number> --json commits -R <owner/repo>
+gh pr view <pr-number> --json commits --jq '.commits[] | .messageHeadline + "\n" + .messageBody' -R <owner/repo>
 ```
 
 Verify that every commit message references the Jira issue ID (e.g. contains `<JIRA-ID>` in the message, body, or trailer).
@@ -270,6 +270,19 @@ substitute `{version}` before posting.
 ```
 gh pr review <pr-number> --comment --body "<report-with-footnote>" -R <owner/repo>
 ```
+
+### Revised reports
+
+When a verification finding has been corrected and a revised comment must be posted,
+re-run the CI status check before generating the updated report:
+
+```
+gh pr checks <pr-number> -R <owner/repo>
+```
+
+Use the fresh CI results to populate the CI Status row in the revised report. This
+ensures the report reflects the latest CI state rather than stale data from the
+initial check.
 
 ### Post to Jira
 


### PR DESCRIPTION
## Summary

- **Step 6 fix:** Add `--jq` expression to `gh pr view --json commits` command to extract both `messageHeadline` and `messageBody`, preventing false negatives when the Jira issue ID appears in the commit body or footer rather than the headline.
- **Step 12 fix:** Add "Revised reports" subsection instructing the agent to re-run `gh pr checks` before posting a revised verification comment, ensuring the CI Status row reflects the latest state.

Implements [TC-3882](https://redhat.atlassian.net/browse/TC-3882)

## Test plan

- [x] Verify SKILL.md renders correctly as valid Markdown
- [x] Confirm Step 6 `--jq` expression correctly concatenates `messageHeadline` and `messageBody`
- [x] Confirm Step 12 revised reports subsection includes CI re-check instruction
- [x] Verify line 170 prose ("message, body, or trailer") is unchanged