### PR TITLE
fix(verify-pr): use gh pr comment --edit-last for idempotent report posting

### DIFF
--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -256,8 +256,10 @@ Overall result rules:
 
 ### Post to GitHub PR
 
-Post the verification report as a PR comment. Append a markdown footnote at the end
-of the report body, separated by a horizontal rule:
+Post the verification report as a PR comment using `--edit-last --create-if-none` for
+idempotent behavior — this updates an existing report comment or creates one if none
+exists, preventing duplicate reports on subsequent runs. Append a markdown footnote at
+the end of the report body, separated by a horizontal rule:
 
 ```
 ---
@@ -268,7 +270,7 @@ Read the plugin version from `plugins/sdlc-workflow/.claude-plugin/plugin.json` 
 substitute `{version}` before posting.
 
 ```
-gh pr review <pr-number> --comment --body "<report-with-footnote>" -R <owner/repo>
+gh pr comment <pr-number> --edit-last --create-if-none --body "<report-with-footnote>" -R <owner/repo>
 ```
 
 ### Revised reports


### PR DESCRIPTION
## Summary

- Replace `gh pr review --comment` with `gh pr comment --edit-last --create-if-none` in Step 12 of verify-pr skill
- Updates existing report comments in place rather than posting duplicates on subsequent runs
- Adds prose explaining the idempotent behavior

Implements [TC-3883](https://redhat.atlassian.net/browse/TC-3883)