### PR TITLE
feat(implement-task): add contract and sibling parity self-verification check

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -68,6 +68,8 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 5.4 | Code MUST NOT duplicate existing functionality — reuse or extend existing utilities, helpers, and shared modules when equivalent logic exists. | `implement-task/SKILL.md` — Step 4, Step 6, Step 9 |
 | 5.5 | AI MUST NOT start work autonomously — a human must trigger it. | `methodology.md` — Core Principles (Human Driven Workflow) |
 | 5.6 | After implementation, each new feature MUST be traced through its complete data-flow lifecycle (input → processing → output) — incomplete paths must be fixed before committing. | `implement-task/SKILL.md` — Step 9 |
+| 5.7 | Modified or created code that implements an interface, trait, or type contract MUST have all required methods, properties, and type signatures verified as complete before committing. | `implement-task/SKILL.md` — Step 9 |
+| 5.8 | Modified or created code MUST be compared against sibling implementations for parity on cross-cutting concerns (capabilities, error handling, logging, configuration) — gaps must be fixed or explicitly approved by the user before committing. | `implement-task/SKILL.md` — Step 9 |
 
 ---
 
@@ -76,6 +78,6 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 Each constraint above references its source. The full source files are:
 
 - `plugins/sdlc-workflow/skills/plan-feature/SKILL.md` — Guardrails (§1.1–1.3), Task Description Template (§4.1–4.10)
-- `plugins/sdlc-workflow/skills/implement-task/SKILL.md` — Important Rules (§1.4–1.6, §5.1–5.3), Step 4/6/9 (§5.4), Step 5 (§3.1), Step 9 (§2.1–2.3, §5.6), Step 10 (§3.2)
+- `plugins/sdlc-workflow/skills/implement-task/SKILL.md` — Important Rules (§1.4–1.6, §5.1–5.3), Step 4/6/9 (§5.4), Step 5 (§3.1), Step 9 (§2.1–2.3, §5.6–5.8), Step 10 (§3.2)
 - `plugins/sdlc-workflow/skills/define-feature/SKILL.md` — Guardrails (§1.7–1.8), Important Rules (§1.9)
 - `docs/methodology.md` — Core Principles (§2.1, §3.2, §5.5)

--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -366,6 +366,53 @@ Output the traced data flows and their completeness status to the user before pr
 > - `POST /api/v2/sbom` → parse request ✓ → validate ✓ → persist to DB ✓ → return response ✓ — **COMPLETE**
 > - `parseLicense()` → extract license ID ✓ → resolve to SPDX ✓ → attach to package ✗ — **INCOMPLETE** (output not connected)
 
+### Contract & sibling parity
+
+Verify that modified or created code fully honors its type contracts and maintains
+parity with sibling implementations.
+
+#### Contract verification
+
+1. **Identify contracts**: for each file modified or created, determine whether the code
+   implements or extends any interface, trait, abstract class, protocol, or type contract.
+   Use Serena's `find_symbol` or Grep to locate the contract definition.
+2. **Check completeness**: verify that all required methods, properties, and type signatures
+   defined by the contract are implemented. Check that return types cover all variants
+   (e.g., both sync and async, both success and error paths, all union/enum members).
+3. **Check semantics**: verify that method signatures match the contract — parameter types,
+   return types, and nullability/optionality must align.
+4. **Flag gaps**: list any missing or incomplete contract implementations. For each gap,
+   state which contract member is missing and what is required.
+
+#### Sibling parity analysis
+
+1. **Identify siblings**: reuse the sibling files identified during the convention
+   conformance analysis in Step 4. If no siblings were identified (e.g., the file is
+   unique), skip this analysis.
+2. **Compare capabilities**: for each sibling, compare cross-cutting concerns against the
+   new or modified code:
+   - Shared capabilities (e.g., all providers support CRUD, all handlers validate input)
+   - Error handling (e.g., all siblings wrap errors the same way)
+   - Logging and observability (e.g., all siblings log at the same points)
+   - Configuration options (e.g., all siblings accept the same option types)
+3. **Flag parity gaps**: list any capabilities present in siblings but missing from the
+   new implementation. For each gap, state which sibling provides the capability and
+   what is missing.
+4. **Fix or confirm**: if gaps are found, fix them before proceeding. If a gap is
+   intentional (the new code deliberately omits a capability), ask the user to confirm
+   before proceeding.
+
+Output the contract verification and sibling parity results to the user before proceeding.
+
+> **Example output:**
+>
+> **Contract & sibling parity results:**
+> - `StorageProvider` implements `Provider` trait — `get()` ✓, `list()` ✓, `delete()` ✓, `update()` ✗ — **GAP** (missing `update` method)
+> - Sibling parity with `S3Provider`, `GcsProvider`:
+>   - Retry logic ✓ (all siblings use exponential backoff)
+>   - Logging ✗ — `StorageProvider` missing `info!()` on successful operations — **GAP**
+>   - Config options ✓ (all accept `ProviderConfig`)
+
 ## Step 10 – Commit and Push
 
 Commit following the Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/):


### PR DESCRIPTION
## Summary

- Adds Step 9.G (Contract & Sibling Parity Check) to the `implement-task` skill — verifies interface/type contracts are fully implemented and compares against sibling implementations for cross-cutting concern parity
- Adds constraints §5.7 (contract verification) and §5.8 (sibling parity) to `docs/constraints.md`
- Updates the Traceability Index to reference the new constraints

Implements [TC-3881](https://redhat.atlassian.net/browse/TC-3881)