### PR TITLE
feat(verify-pr): use structured template for root-cause tasks

### DIFF
--- a/plugins/sdlc-workflow/shared/task-description-template.md
+++ b/plugins/sdlc-workflow/shared/task-description-template.md
@@ -1,0 +1,79 @@
+# Task Description Template
+
+All Jira tasks created by SDLC workflow skills must follow this template.
+Skills that create tasks (plan-feature, verify-pr) produce this format;
+skills that consume tasks (implement-task) parse it.
+
+## Template
+
+```
+## Repository
+<repository-name>
+
+## Description
+<What this task achieves and why>
+
+## Files to Modify
+- `path/to/file.ext` — <brief reason>
+
+## Files to Create
+- `path/to/new_file.ext` — <purpose>
+
+## API Changes
+- `GET /v2/endpoint` — NEW: <description>
+- `PUT /v2/endpoint/{id}` — MODIFY: <what changes in request/response>
+
+## Implementation Notes
+<Specific guidance: patterns to follow, existing code to reuse,
+key functions/structs/components to interact with.
+Reference actual file paths and symbol names found during repository analysis.>
+
+## Reuse Candidates
+- `path/to/file.ext::symbol_name` — <what it does and how it relates to this task>
+
+## Acceptance Criteria
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Test Requirements
+- [ ] Test description 1
+- [ ] Test description 2
+
+## Verification Commands
+- `<command>` — <expected outcome>
+
+## Documentation Updates
+- `path/to/doc.md` — <what content to add or revise>
+
+## Dependencies
+- Depends on: Task N — <task title> (if any)
+```
+
+## Rules
+
+- Omit sections that don't apply (e.g. no API Changes for a pure UI task, no Files
+  to Create if only modifying, no Documentation Updates if no docs are impacted)
+- Repository must be a single repository per task
+- File paths must be real paths discovered during repository or code analysis
+- Implementation Notes must reference existing patterns, not abstract guidance —
+  when reusable utilities, helpers, or shared modules exist, list them with file
+  paths and symbol names so the implementer can reuse them instead of writing new code
+- Reuse Candidates is optional — include it when existing code (domain logic,
+  components, utilities, or patterns) overlaps with the planned changes, so the
+  implementer has an explicit checklist of code to consider reusing
+- Each task must be small enough for a single engineer to implement
+- Verification Commands are optional — include them when acceptance criteria can be
+  verified by running a command against the built or running service
+- Documentation Updates is optional — include it when the task changes public APIs,
+  configuration, setup steps, or architectural patterns, listing which docs need
+  updating and what content to add or revise (not the actual doc content)
+
+## Extension sections
+
+Individual skills may add context-specific sections beyond the base template.
+These extensions are documented in the skill that produces them:
+
+- **Target PR** — used by verify-pr (Step 4e) for review feedback fixes, so
+  implement-task adds commits to an existing PR branch
+- **Review Context** — used by verify-pr (Step 4e) to capture the original review
+  comment text and PR file/line reference

--- a/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
@@ -230,66 +230,11 @@ Before generating task descriptions, read `docs/constraints.md` from the project
 - For tasks that create Jira issues: include the task template rules (§4).
 - For all tasks: include the skill scope rules (§1) that apply to the skill executing the task.
 
-Create implementation tasks for each unit of work. Each task description MUST follow this template exactly:
-
-### Task Description Template
-
-```
-## Repository
-<repository-name>
-
-## Description
-<What this task achieves and why>
-
-## Files to Modify
-- `path/to/file.ext` — <brief reason>
-
-## Files to Create
-- `path/to/new_file.ext` — <purpose>
-
-## API Changes
-- `GET /v2/endpoint` — NEW: <description>
-- `PUT /v2/endpoint/{id}` — MODIFY: <what changes in request/response>
-
-## Implementation Notes
-<Specific guidance: patterns to follow, existing code to reuse,
-key functions/structs/components to interact with.
-Reference actual file paths and symbol names found during repository analysis.>
-
-## Reuse Candidates
-- `path/to/file.ext::symbol_name` — <what it does and how it relates to this task>
-
-## Acceptance Criteria
-- [ ] Criterion 1
-- [ ] Criterion 2
-
-## Test Requirements
-- [ ] Test description 1
-- [ ] Test description 2
-
-## Verification Commands
-- `<command>` — <expected outcome>
-
-## Documentation Updates
-- `path/to/doc.md` — <what content to add or revise>
-
-## Dependencies
-- Depends on: Task N — <task title> (if any)
-```
+Create implementation tasks for each unit of work. Each task description MUST follow the template defined in [`shared/task-description-template.md`](../shared/task-description-template.md) exactly — read the template and rules from that file before generating tasks.
 
 ### Documentation task guidance
 
 When a feature introduces significant new behavior (new user-facing capabilities, new APIs, or major architectural changes), consider generating a **dedicated documentation-only task** to cover cross-cutting documentation updates that span multiple implementation tasks. Use this when the documentation work is substantial enough to warrant its own task rather than being spread across individual implementation tasks.
-
-### Template rules:
-- Omit sections that don't apply (e.g. no API Changes for a pure UI task, no Files to Create if only modifying, no Documentation Updates if no docs are impacted)
-- Repository must be a single repository per task
-- File paths must be real paths discovered during repository analysis (Step 3)
-- Implementation Notes must reference existing patterns, not abstract guidance — when reusable utilities, helpers, or shared modules were found during repository analysis, list them with file paths and symbol names so the implementer can reuse them instead of writing new code
-- Reuse Candidates is optional — include it when the duplication-risk scan (Step 3) found existing code (domain logic, components, utilities, or patterns) that overlaps with the planned changes, so the implementer has an explicit checklist of code to consider reusing before writing new code
-- Each task must be small enough for a single engineer to implement
-- Verification Commands are optional — include them when acceptance criteria can be verified by running a command against the built or running service
-- Documentation Updates is optional — include it when the task changes public APIs, configuration, setup steps, or architectural patterns, listing which docs need updating and what content to add or revise (not the actual doc content)
 
 ## Step 6 – Create Tasks in Jira
 

--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -236,15 +236,11 @@ jira.create_issue with:
 - **Parent:** the current task's Jira issue ID
 - **Summary:** concise description of the required fix
 - **Labels:** `["ai-generated-jira", "review-feedback"]`
-- **Description:** structured task description following the plan-feature template:
+- **Description:** structured task description following the template defined in
+  [`shared/task-description-template.md`](../shared/task-description-template.md).
+  Include the applicable base sections plus these extension sections:
 
-  - **Repository** — same repository as the parent task
-  - **Description** — what the fix should achieve, referencing the reviewer's comment
   - **Review Context** — the original review comment text and PR file/line reference
-  - **Files to Modify** — files identified in Step 4d
-  - **Implementation Notes** — patterns to follow, referencing the parent task's code
-  - **Acceptance Criteria** — pass/fail checklist for the fix
-  - **Test Requirements** — tests to write or update for the fix
   - **Target PR** — the PR URL from Step 2 (so implement-task adds commits to the existing branch)
 
 After creating each sub-task, create a "Blocks" issue link from the sub-task to the parent task:
@@ -364,24 +360,45 @@ gap originated:
 - **convention gap** — task to update CONVENTIONS.md or project documentation to
   document the undocumented convention
 
+#### Action 1 – Create the task with a structured description
+
 jira.create_issue with:
 - **Summary:** "Root-cause: <brief description of the systemic improvement>"
 - **Labels:** `["ai-generated-jira", "root-cause"]`
-- **Description:** structured description including:
-  - What reviewer feedback exposed the gap
-  - Which workflow phase introduced the gap
-  - What preventive fix is recommended
-  - Reference: "Root-cause analysis from <PARENT-TASK-ID> verification"
+- **Description:** structured task description following the template defined in
+  [`shared/task-description-template.md`](../shared/task-description-template.md).
+  The description must be actionable — it describes the concrete change to the
+  skill, prompt, or convention that prevents the gap from recurring. Do **not**
+  include the root-cause analysis narrative in the description.
 
 Link the root-cause task to the parent task:
 
 jira.create_issue_link(type="Relates", inwardIssue=<root-cause-task-id>, outwardIssue=<parent-task-id>)
 
+#### Action 2 – Post the root-cause analysis as a comment
+
+After creating the task, post a Jira comment on the newly created root-cause task
+with the root-cause analysis narrative:
+
+jira.add_comment(<root-cause-task-id>, <analysis>)
+
+The comment must include:
+- What reviewer feedback exposed the gap
+- Which workflow phase introduced the gap (define-feature, plan-feature,
+  implement-task, or convention)
+- What preventive fix is recommended
+- Reference: "Root-cause analysis from <PARENT-TASK-ID> verification"
+
+Include the **Comment Footnote** at the end of the comment (see the Comment Footnote
+section at the top of this skill for the required ADF format).
+
 ### Step 5c – Idempotency Check
 
-Before creating a root-cause task, check the parent task's issue links for existing
-tasks whose descriptions contain "Root-cause analysis from <PARENT-TASK-ID>". If a
-root-cause task already exists for the same phase and the same defect, skip creation.
+Before creating a root-cause task (Step 5b), check for existing root-cause tasks
+linked to the parent task. For each linked task with label `root-cause`, fetch its
+comments and search for a comment containing "Root-cause analysis from
+<PARENT-TASK-ID>". If a root-cause task already exists for the same phase and the
+same defect, skip creation.
 
 Record the Root-Cause Investigation result:
 - **N/A** — no sub-tasks were created in Step 4 (nothing to investigate)


### PR DESCRIPTION
## Summary
- Extract the task description template from plan-feature into `plugins/sdlc-workflow/shared/task-description-template.md` so both plan-feature and verify-pr reference a single source of truth
- Split verify-pr Step 5b into two actions: (1) create root-cause task with structured template description, (2) post root-cause analysis as a Jira comment with Comment Footnote
- Update Step 5c idempotency check to search task comments instead of descriptions
- Update Step 4e to also reference the shared template file

Implements [TC-3903](https://redhat.atlassian.net/browse/TC-3903)

## Test plan
- [ ] Run /verify-pr on a PR with review feedback that triggers root-cause investigation and confirm the created task follows the structured template
- [ ] Confirm the root-cause analysis appears as a comment on the created task, not in its description
- [ ] Re-run /verify-pr on the same PR and confirm the idempotency check prevents duplicate root-cause tasks
- [ ] Run /plan-feature and confirm it reads the shared template correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a shared Jira task description template and update SDLC workflow skills to consume it while restructuring root-cause handling in verify-pr.

New Features:
- Add a shared task description template file used across SDLC workflow skills for Jira tasks.
- Create a dedicated Jira comment step to store root-cause analysis separately from the task description in verify-pr.

Enhancements:
- Update plan-feature and verify-pr skills to reference the shared task description template instead of inlined guidance.
- Refine verify-pr root-cause task creation to use actionable, structured descriptions and keep narrative analysis out of the task body.
- Adjust verify-pr idempotency checks to detect existing root-cause tasks via their Jira comments rather than descriptions.