### PR TITLE
feat(plan-feature): add convention-aware task enrichment

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -61,6 +61,7 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 4.8 | Every task created in Jira MUST include the `ai-generated-jira` label. | `plan-feature/SKILL.md` — Step 6a |
 | 4.9 | Tasks that change public APIs, configuration, setup steps, or architectural patterns SHOULD include an optional **Documentation Updates** section listing which docs need updating and what content to add or revise. | `plan-feature/SKILL.md` — Template rules |
 | 4.10 | Tasks SHOULD include a **Reuse Candidates** section when overlapping code (domain logic, components, utilities, or patterns) was found during repository analysis, listing file paths, symbol names, and relevance descriptions. | `plan-feature/SKILL.md` — Task Description Template |
+| 4.11 | When a task's scope matches a convention from CONVENTIONS.md (e.g., migrations with FK columns requiring indexes), the Implementation Notes MUST include explicit guidance referencing the convention by section name with a concrete example file. | `plan-feature/SKILL.md` — Step 5 (Convention-aware task enrichment) |
 
 ---
 
@@ -83,7 +84,7 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 
 Each constraint above references its source. The full source files are:
 
-- `plugins/sdlc-workflow/skills/plan-feature/SKILL.md` — Guardrails (§1.1–1.3), Task Description Template (§4.1–4.10)
+- `plugins/sdlc-workflow/skills/plan-feature/SKILL.md` — Guardrails (§1.1–1.3), Task Description Template (§4.1–4.10), Step 5 Convention-aware task enrichment (§4.11)
 - `plugins/sdlc-workflow/skills/implement-task/SKILL.md` — Important Rules (§1.4–1.6, §5.1–5.3), Step 4/6/9 (§5.4), Step 5 (§1.15, §3.1), Step 9 (§2.1–2.3, §5.6–5.8), Step 10 (§3.2)
 - `plugins/sdlc-workflow/skills/verify-pr/SKILL.md` — Step 4 (§1.10, §1.12), Important Rules (§1.11, §1.13), Step 5b (§1.14)
 - `plugins/sdlc-workflow/skills/define-feature/SKILL.md` — Guardrails (§1.7–1.8), Important Rules (§1.9)

--- a/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
@@ -236,6 +236,39 @@ Create implementation tasks for each unit of work. Each task description MUST fo
 
 When a feature introduces significant new behavior (new user-facing capabilities, new APIs, or major architectural changes), consider generating a **dedicated documentation-only task** to cover cross-cutting documentation updates that span multiple implementation tasks. Use this when the documentation work is substantial enough to warrant its own task rather than being spread across individual implementation tasks.
 
+### Convention-aware task enrichment
+
+After drafting each task's Implementation Notes, cross-reference the conventions discovered
+during the CONVENTIONS.md lookup (Step 3) with the task's scope. If the task touches an area
+covered by a documented convention, include explicit guidance in the Implementation Notes
+referencing the convention by section name and describing the required action.
+
+This ensures that conventions are not merely discovered but actively propagated into every
+task where they apply — preventing gaps where implement-task follows the task faithfully but
+misses a convention that was never mentioned.
+
+**How to apply:**
+
+1. For each task, review its Files to Modify, Files to Create, and Description against the
+   conventions collected in Step 3.
+2. When a match is found, add a line to Implementation Notes of the form:
+   `"Per CONVENTIONS.md §<Section Name>: <specific action required>"`
+3. Include a reference to an existing file that demonstrates the convention in practice,
+   so the implementer has a concrete example to follow.
+
+**Example — database migrations with foreign keys:**
+
+When a task creates or modifies a database migration that defines foreign key columns,
+include guidance such as:
+
+> Per CONVENTIONS.md §Migration Patterns: add `Index::create()` for all FK columns.
+> See `migration/m0001200_source_document_fk_indexes.rs` for the established pattern.
+
+This applies equally to any convention pattern — error handling strategies, naming rules,
+test structure, API design patterns, logging conventions, etc. The goal is to make every
+relevant convention explicit in the task description rather than relying on the implementer
+to independently discover and apply it.
+
 ## Step 6 – Create Tasks in Jira
 
 ### 6a – Create the tasks


### PR DESCRIPTION
## Summary
- Adds a "Convention-aware task enrichment" subsection to plan-feature Step 5 that cross-references CONVENTIONS.md conventions with each task's scope and propagates matching conventions into Implementation Notes
- Includes a concrete example for database migrations with FK columns requiring indexes
- Adds constraint §4.11 to `docs/constraints.md` with traceable source reference

Implements [TC-3904](https://redhat.atlassian.net/browse/TC-3904)

## Test plan
- [x] Verify SKILL.md renders correctly and the new subsection integrates into the Step 5 flow
- [x] Verify constraint §4.11 in constraints.md follows existing table format
- [x] Run plan-feature on a feature with migration tasks to confirm convention propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce convention-aware enrichment of implementation tasks and formalize it as a documented planning constraint.

New Features:
- Add a convention-aware task enrichment step to the plan-feature workflow so tasks explicitly embed relevant conventions from CONVENTIONS.md into their Implementation Notes.

Enhancements:
- Document concrete guidance and an example for propagating database migration conventions, such as index requirements for foreign key columns, into task descriptions.
- Extend the constraints catalog with a new constraint linking convention-aware task enrichment in plan-feature to a traceable source section.