### PR TITLE
feat(implement-task): add cross-module shared entity analysis

### DIFF
--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -529,6 +529,44 @@ parity with sibling implementations.
    intentional (the new code deliberately omits a capability), ask the user to confirm
    before proceeding.
 
+#### Cross-module shared entity analysis
+
+Sibling parity (above) compares files in the same directory or module. When the
+implementation inserts into, updates, or deletes from a shared database entity
+(table, collection, or document store) that is used by multiple modules, extend
+the analysis across module boundaries to detect pattern inconsistencies.
+
+1. **Identify shared entities**: for each database operation in the new or modified
+   code (e.g., `insert()`, `update()`, `delete()`, ORM save/create calls, raw SQL),
+   determine the target entity (table name, model class, or schema object).
+2. **Search cross-module**: use Serena's `search_for_pattern` (or Grep as fallback)
+   to find all other modules that interact with the same entity. Look for:
+   - Insert/upsert operations on the same table or model
+   - Update or delete operations that reference the same entity
+   - Schema definitions or migrations for the entity
+3. **Compare patterns**: for each cross-module usage found, compare:
+   - Transaction handling (e.g., nested/savepoint transactions vs. bare operations)
+   - Constraint handling (e.g., duplicate-key/conflict handling, ON CONFLICT clauses,
+     try/catch around unique violations)
+   - Error handling (e.g., how constraint violations are caught and reported)
+   - Data validation (e.g., pre-insert checks, foreign key verification)
+   - Locking strategies (e.g., SELECT FOR UPDATE, advisory locks)
+4. **Flag cross-module anomalies**: if the new code uses a pattern that differs from
+   how other modules interact with the same entity, flag it as a potential anomaly.
+   State what the new code does, what the other module(s) do instead, and which
+   files contain the differing pattern.
+5. **Fix or confirm**: if anomalies are found, align the new code with the
+   established cross-module pattern before proceeding. If the deviation is
+   intentional, ask the user to confirm before proceeding.
+
+> **Example output:**
+>
+> **Cross-module shared entity analysis results:**
+> - Entity `source_document` — 2 modules interact:
+>   - `ingestor/graph/mod.rs`: uses nested transaction with `ON CONFLICT DO UPDATE` for duplicate-key handling
+>   - `risk_assessment/service/mod.rs` (new code): uses plain `insert()` with no conflict handling — **ANOMALY**
+>   - Recommendation: adopt the ingestor's `ON CONFLICT` pattern to handle duplicate inserts gracefully
+
 #### Caller-site parity
 
 When the implementation creates or modifies code that **calls** a shared abstraction
@@ -565,7 +603,7 @@ other caller in the codebase uses that pattern.
    caller pattern before proceeding. If the deviation is intentional, ask the user to
    confirm before proceeding.
 
-Output the contract verification, sibling parity, and caller-site parity results to the user before proceeding.
+Output the contract verification, sibling parity, cross-module shared entity, and caller-site parity results to the user before proceeding.
 
 > **Example output:**
 >


### PR DESCRIPTION
## Summary

- Add cross-module shared entity analysis to implement-task's sibling parity check (Step 9)
- When code inserts into a shared database table used by multiple modules, the analysis now searches cross-module for other interactions with the same entity and compares their patterns (transaction handling, constraint handling, error handling, data validation, locking strategies)
- Includes example output demonstrating detection of the `source_document` anomaly between `ingestor` and `risk_assessment` modules

Implements [TC-3988](https://redhat.atlassian.net/browse/TC-3988)

## Test plan

- [ ] Verify the new `#### Cross-module shared entity analysis` subsection appears in SKILL.md within `### Contract & sibling parity`
- [ ] Verify the subsection follows the same structure as sibling subsections (numbered steps, bold lead-ins, example output)
- [ ] Verify the example output demonstrates detection of the `source_document` anomaly scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document cross-module shared entity analysis as part of the implement-task sibling parity workflow and ensure its results are included in the final parity output.

Documentation:
- Add a new "Cross-module shared entity analysis" subsection to the implement-task SKILL describing how to detect and handle inconsistent database interaction patterns for shared entities across modules, with example output.
- Update the contract verification section to state that cross-module shared entity results are included alongside sibling and caller-site parity in the reported output.