### PR TITLE
feat(implement-task): add parameterized test preference guidance

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -77,6 +77,8 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 5.6 | After implementation, each new feature MUST be traced through its complete data-flow lifecycle (input → processing → output) — incomplete paths must be fixed before committing. | `implement-task/SKILL.md` — Step 9 |
 | 5.7 | Modified or created code that implements an interface, trait, or type contract MUST have all required methods, properties, and type signatures verified as complete before committing. | `implement-task/SKILL.md` — Step 9 |
 | 5.8 | Modified or created code MUST be compared against sibling implementations for parity on cross-cutting concerns (capabilities, error handling, logging, configuration) — gaps must be fixed or explicitly approved by the user before committing. | `implement-task/SKILL.md` — Step 9 |
+| 5.9 | implement-task SHOULD prefer parameterized tests when multiple test cases exercise the same behavior with different inputs, applying the Meszaros heuristic as the decision boundary. | `implement-task/SKILL.md` — Step 7 |
+| 5.10 | implement-task MUST NOT introduce parameterized test patterns if sibling test analysis shows the project does not use them. | `implement-task/SKILL.md` — Step 7 |
 
 ---
 
@@ -85,7 +87,7 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 Each constraint above references its source. The full source files are:
 
 - `plugins/sdlc-workflow/skills/plan-feature/SKILL.md` — Guardrails (§1.1–1.3), Task Description Template (§4.1–4.10), Step 5 Convention-aware task enrichment (§4.11)
-- `plugins/sdlc-workflow/skills/implement-task/SKILL.md` — Important Rules (§1.4–1.6, §5.1–5.3), Step 4/6/9 (§5.4), Step 5 (§1.15, §3.1), Step 9 (§2.1–2.3, §5.6–5.8), Step 10 (§3.2)
+- `plugins/sdlc-workflow/skills/implement-task/SKILL.md` — Important Rules (§1.4–1.6, §5.1–5.3), Step 4/6/9 (§5.4), Step 5 (§1.15, §3.1), Step 7 (§5.9–5.10), Step 9 (§2.1–2.3, §5.6–5.8), Step 10 (§3.2)
 - `plugins/sdlc-workflow/skills/verify-pr/SKILL.md` — Step 4 (§1.10, §1.12), Important Rules (§1.11, §1.13), Step 5b (§1.14)
 - `plugins/sdlc-workflow/skills/define-feature/SKILL.md` — Guardrails (§1.7–1.8), Important Rules (§1.9)
 - `docs/methodology.md` — Core Principles (§2.1, §3.2, §5.5)

--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -256,6 +256,9 @@ For each test file being created or modified:
    - Test setup and teardown (e.g., fixture creation, mock patterns, database seeding)
    - Test naming conventions (e.g., `test_<action>_<scenario>`, `it('should ...')`)
    - Test organization (e.g., grouping by feature, by HTTP method, by success/failure)
+   - Parameterized/data-driven test usage (e.g., `@ParameterizedTest` in JUnit 5,
+     `forEach`/data arrays in Mocha/Jest, `@pytest.mark.parametrize` in pytest,
+     table-driven patterns in Go, `#[rstest]`/`#[case]` in Rust)
 3. **Record test conventions**: output the discovered test conventions to the user in a
    structured list alongside the production code conventions. This list serves as a
    binding reference during test implementation in Step 7.
@@ -267,6 +270,7 @@ For each test file being created or modified:
 > - **Response validation:** List endpoint tests validate `total_count`, `items.len()`, and at least one item's key fields
 > - **Error cases:** All endpoint tests include a 404 test with `assert_eq!(resp.status(), StatusCode::NOT_FOUND)`
 > - **Test naming:** Tests follow `test_<endpoint>_<scenario>` pattern (e.g., `test_list_advisories_filtered`)
+> - **Parameterized tests:** Sibling tests use `#[rstest]` with `#[case]` for multi-ecosystem parsing tests (e.g., `test_parse_sbom` in `tests/parser/`)
 
 ## Step 5 – Create Branch
 
@@ -441,6 +445,18 @@ response data, assert on the actual values — not just the count. Assert on spe
 or key fields so that test failures reveal *what* changed, not just *how many*. Length
 checks alone hide regressions behind a passing count and prevent subsequent assertions
 from running.
+
+**Prefer parameterized tests for repetitive cases:** When multiple test cases exercise
+the same behavior with different inputs and expected outputs, use the project's
+parameterized test mechanism instead of writing individual test functions for each case.
+Apply the Meszaros heuristic as the decision boundary: parameterize when tests share the
+same algorithm (setup, action, assertion structure) with different data; use individual
+tests when behavior, setup, or assertions differ between cases. If the test body would
+need conditionals to handle parameter variations, use separate tests instead. Common
+mechanisms include JUnit 5 `@ParameterizedTest`, Mocha/Jest `forEach`/data arrays,
+pytest `@pytest.mark.parametrize`, Go table-driven tests, and Rust `rstest`. However,
+if the sibling test analysis in Step 4 shows the project does not use parameterized
+tests, do not introduce them — follow the project's existing test patterns instead.
 
 Run tests to verify:
 


### PR DESCRIPTION
## Summary

- Add parameterized/data-driven test pattern detection to Step 4's test convention analysis
- Add parameterized test preference guidance to Step 7 (Write Tests) using the Meszaros heuristic
- Add constraints §5.9 and §5.10 to docs/constraints.md

Implements [TC-3997](https://redhat.atlassian.net/browse/TC-3997)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add guidance and constraints for preferring parameterized tests based on existing project patterns and the Meszaros heuristic in the implement-task workflow.

Enhancements:
- Extend Step 4 test convention analysis to detect parameterized/data-driven test usage across common testing frameworks.
- Update Step 7 test-writing guidance to recommend parameterized tests for repetitive cases while respecting existing project test patterns and the Meszaros heuristic.

Documentation:
- Document new constraints §5.9–§5.10 governing when implement-task should prefer or avoid introducing parameterized tests, and reference them from the implement-task skill documentation.