### PR TITLE
feat(verify-pr): add test quality check for repetitive test functions

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -25,6 +25,7 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 1.13 | `verify-pr` MUST NOT auto-merge. Merging is always a human decision. | `verify-pr/SKILL.md` — Important Rules |
 | 1.14 | `verify-pr` root-cause tasks MUST target the workflow phase where the gap originated, not always the implementation phase. | `verify-pr/SKILL.md` — Step 5b |
 | 1.15 | `implement-task` MUST check out the existing PR branch (instead of creating a new one) when a Target PR section is present in the task description. | `implement-task/SKILL.md` — Step 5 (Target PR flow) |
+| 1.16 | `verify-pr` MUST flag repetitive test functions that could be parameterized as a WARN finding, applying the Meszaros heuristic as the decision boundary. | `verify-pr/SKILL.md` — Step 12 |
 
 ---
 
@@ -88,6 +89,6 @@ Each constraint above references its source. The full source files are:
 
 - `plugins/sdlc-workflow/skills/plan-feature/SKILL.md` — Guardrails (§1.1–1.3), Task Description Template (§4.1–4.10), Step 5 Convention-aware task enrichment (§4.11)
 - `plugins/sdlc-workflow/skills/implement-task/SKILL.md` — Important Rules (§1.4–1.6, §5.1–5.3), Step 4/6/9 (§5.4), Step 5 (§1.15, §3.1), Step 7 (§5.9–5.10), Step 9 (§2.1–2.3, §5.6–5.8), Step 10 (§3.2)
-- `plugins/sdlc-workflow/skills/verify-pr/SKILL.md` — Step 4 (§1.10, §1.12), Important Rules (§1.11, §1.13), Step 5b (§1.14)
+- `plugins/sdlc-workflow/skills/verify-pr/SKILL.md` — Step 4 (§1.10, §1.12), Important Rules (§1.11, §1.13), Step 5b (§1.14), Step 12 (§1.16)
 - `plugins/sdlc-workflow/skills/define-feature/SKILL.md` — Guardrails (§1.7–1.8), Important Rules (§1.9)
 - `docs/methodology.md` — Core Principles (§2.1, §3.2, §5.5)

--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -657,7 +657,42 @@ Repository Registry.
 
 Record PASS/FAIL for each individual criterion.
 
-## Step 12 – Verification Commands
+## Step 12 – Test Quality
+
+Scan test files in the PR for repetitive test functions that could be parameterized.
+This check applies the Meszaros heuristic: flag only when multiple test functions share
+the same algorithm (setup, action, assertion structure) with different data values.
+Do **not** flag tests with different behavior, setup, or assertions.
+
+1. **Identify test files in the PR**: filter the PR diff to test files:
+   ```
+   gh pr diff <pr-number> --name-only -R <owner/repo>
+   ```
+   Filter for files matching test patterns (e.g., `test_`, `_test.`, `.test.`, `tests/`,
+   `spec/`, `*_spec.`).
+
+2. **Inspect test function bodies**: for each test file with multiple test functions, use
+   the Serena instance for the task's repository (from the **Repository Registry** in
+   CLAUDE.md) with `find_symbol` and `include_body=true` to read the test function bodies.
+   Fall back to Read/Grep for repos without a Serena instance.
+
+3. **Detect repetitive patterns**: check whether any group of 2+ test functions shares
+   the same structure — identical assertions, same setup pattern, same control flow —
+   with only data values (inputs, expected outputs, fixture names) differing. If the
+   test body would need conditionals to handle parameter variations, the tests are
+   **not** candidates.
+
+4. **Record findings**: for each group of repetitive test functions, record:
+   - The file path
+   - The test function names
+   - A brief explanation of why they are parameterization candidates
+
+Record PASS if no repetitive test functions are found, WARN if candidates are flagged.
+
+**Note:** Test Quality WARN is advisory — it does **not** elevate the overall result
+to FAIL. Treat it like Diff Size: report for visibility, but do not block the PR.
+
+## Step 13 – Verification Commands
 
 If the task description includes a **Verification Commands** section, run each command and check the result against the expected outcome.
 
@@ -668,9 +703,9 @@ For each command:
 
 If no Verification Commands section exists in the task, skip this step and record N/A.
 
-## Step 13 – Generate Report
+## Step 14 – Generate Report
 
-Compile all findings from Steps 4–12 (including Step 10's CI failure sub-tasks) into a structured verification report:
+Compile all findings from Steps 4–13 (including Step 10's CI failure sub-tasks) into a structured verification report:
 
 ```
 ## Verification Report for <JIRA-ID> (commit <short-sha>)
@@ -685,6 +720,7 @@ Compile all findings from Steps 4–12 (including Step 10's CI failure sub-tasks
 | Sensitive Patterns | PASS/FAIL | <summary> |
 | CI Status | PASS/WARN/FAIL | <summary> |
 | Acceptance Criteria | PASS/FAIL | <N of M criteria met> |
+| Test Quality | PASS/WARN | <summary> |
 | Verification Commands | PASS/FAIL/N/A | <summary> |
 
 ### Overall: PASS / WARN / FAIL
@@ -697,11 +733,11 @@ Overall result rules:
 - **WARN** — at least one WARN but no FAIL
 - **FAIL** — at least one FAIL
 
-**Note:** The Root-Cause Investigation row is informational and does **NOT** affect the
-Overall result. Its value (DONE/SKIPPED/N/A) is reported for visibility but excluded
+**Note:** The Root-Cause Investigation and Test Quality rows are informational and do
+**NOT** affect the Overall result. Their values are reported for visibility but excluded
 from the PASS/WARN/FAIL determination.
 
-## Step 14 – Post Report
+## Step 15 – Post Report
 
 ### Retrieve HEAD Commit SHA
 
@@ -720,7 +756,7 @@ Each verification run creates a **new** PR comment (never overwrites previous re
 This provides a verification history over time, with each report clearly referencing
 the commit SHA it verified.
 
-Update the report header from Step 13 to include the commit SHA:
+Update the report header from Step 14 to include the commit SHA:
 
 ```
 ## Verification Report for <JIRA-ID> (commit <short-sha>)


### PR DESCRIPTION
## Summary

- Add new Step 12 (Test Quality) to verify-pr that flags repetitive test functions using Meszaros heuristic
- Update verification report table with Test Quality row (advisory WARN-only, does not block PR)
- Renumber Steps 12→13 (Verification Commands), 13→14 (Generate Report), 14→15 (Post Report)
- Add constraint §1.16 to docs/constraints.md with traceability index update

Implements [TC-3998](https://redhat.atlassian.net/browse/TC-3998)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a non-blocking test quality check in the verify-pr workflow and document it as a formal constraint.

New Features:
- Add a Test Quality step to verify-pr that scans PR test files for repetitive test functions suitable for parameterization using the Meszaros heuristic.
- Extend the verification report with a Test Quality row that surfaces advisory WARN findings without affecting the overall PASS/WARN/FAIL outcome.

Enhancements:
- Renumber subsequent verify-pr steps and adjust related references to accommodate the new Test Quality step.
- Update the constraints documentation and traceability index to capture the new test quality requirement for verify-pr.