### PR TITLE
feat(implement-task): add test documentation guidance with given-when-then structure

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -80,6 +80,9 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 5.8 | Modified or created code MUST be compared against sibling implementations for parity on cross-cutting concerns (capabilities, error handling, logging, configuration) — gaps must be fixed or explicitly approved by the user before committing. | `implement-task/SKILL.md` — Step 9 |
 | 5.9 | implement-task SHOULD prefer parameterized tests when multiple test cases exercise the same behavior with different inputs, applying the Meszaros heuristic as the decision boundary. | `implement-task/SKILL.md` — Step 7 |
 | 5.10 | implement-task MUST NOT introduce parameterized test patterns if sibling test analysis shows the project does not use them. | `implement-task/SKILL.md` — Step 7 |
+| 5.11 | `implement-task` MUST add a doc comment to every test function it creates, regardless of sibling test documentation patterns. | `implement-task/SKILL.md` — Step 7 |
+| 5.12 | `implement-task` MUST add given-when-then inline comments to non-trivial test functions (tests with distinct setup, action, and assertion phases). | `implement-task/SKILL.md` — Step 7 |
+| 5.13 | `implement-task` MUST NOT add given-when-then comments to trivial tests (single assertion, no distinct setup phase). | `implement-task/SKILL.md` — Step 7 |
 
 ---
 
@@ -88,7 +91,7 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 Each constraint above references its source. The full source files are:
 
 - `plugins/sdlc-workflow/skills/plan-feature/SKILL.md` — Guardrails (§1.1–1.3), Task Description Template (§4.1–4.10), Step 5 Convention-aware task enrichment (§4.11)
-- `plugins/sdlc-workflow/skills/implement-task/SKILL.md` — Important Rules (§1.4–1.6, §5.1–5.3), Step 4/6/9 (§5.4), Step 5 (§1.15, §3.1), Step 7 (§5.9–5.10), Step 9 (§2.1–2.3, §5.6–5.8), Step 10 (§3.2)
+- `plugins/sdlc-workflow/skills/implement-task/SKILL.md` — Important Rules (§1.4–1.6, §5.1–5.3), Step 4/6/9 (§5.4), Step 5 (§1.15, §3.1), Step 7 (§5.9–5.13), Step 9 (§2.1–2.3, §5.6–5.8), Step 10 (§3.2)
 - `plugins/sdlc-workflow/skills/verify-pr/SKILL.md` — Step 4 (§1.10, §1.12), Important Rules (§1.11, §1.13), Step 5b (§1.14), Step 12 (§1.16)
 - `plugins/sdlc-workflow/skills/define-feature/SKILL.md` — Guardrails (§1.7–1.8), Important Rules (§1.9)
 - `docs/methodology.md` — Core Principles (§2.1, §3.2, §5.5)

--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -458,6 +458,38 @@ pytest `@pytest.mark.parametrize`, Go table-driven tests, and Rust `rstest`. How
 if the sibling test analysis in Step 4 shows the project does not use parameterized
 tests, do not introduce them — follow the project's existing test patterns instead.
 
+**Document every test function:** Add a documentation comment before every test function
+explaining what it verifies — a single line using the language's doc comment convention
+(e.g., `///` in Rust, `/** */` in Java/TypeScript, `"""` docstring in Python). This applies
+regardless of whether sibling tests have documentation; AI-generated tests introduce this
+as a new standard that overrides the "Follow test conventions" guidance above for
+documentation specifically.
+
+For non-trivial tests — those with distinct setup, action, and assertion phases — also add
+given-when-then section comments (`// Given`, `// When`, `// Then`) inside the test body to
+make the structure navigable at a glance. A test is trivial (skip given-when-then) when it
+has a single assertion with no distinct setup phase.
+
+> **Example (Rust):**
+>
+> ```rust
+> /// Verifies that an SBOM with no dependencies produces an empty risk score.
+> #[test]
+> fn test_empty_sbom_risk_score() {
+>     // Given an SBOM with no dependencies
+>     let sbom = create_test_sbom(vec![]);
+>
+>     // When calculating the risk score
+>     let score = calculate_risk(&sbom);
+>
+>     // Then the score should be zero
+>     assert_eq!(score, RiskScore::default());
+> }
+> ```
+>
+> The doc comment convention varies by language — use `///` for Rust, `/** */` for
+> Java/TypeScript, `"""docstring"""` for Python, `//` doc comments for Go, etc.
+
 Run tests to verify:
 
 cargo test (for Rust)


### PR DESCRIPTION
## Summary
- Add doc comment requirement for every AI-generated test function in implement-task Step 7
- Add given-when-then inline comments for non-trivial tests (distinct setup/action/assertion phases)
- Override sibling convention adherence specifically for test documentation
- Add constraints §5.9–5.11 to docs/constraints.md with traceability index update

Implements [TC-4001](https://redhat.atlassian.net/browse/TC-4001)

## Test plan
- [ ] Read modified SKILL.md and verify new guidance integrates after existing Step 7 blocks
- [ ] Verify override relationship with "Follow test conventions" is clearly documented
- [ ] Verify example includes language convention note
- [ ] Verify constraints.md has correct source references and traceability index

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify implement-task guidance for documenting AI-generated tests, including mandatory doc comments and structured given-when-then sections, and align constraints documentation with these rules.

New Features:
- Introduce a requirement that every AI-generated test function include a language-appropriate documentation comment describing what it verifies.
- Define guidance for using given-when-then inline comments in non-trivial tests with distinct setup, action, and assertion phases.

Enhancements:
- Clarify that the new test documentation standard overrides existing sibling test convention guidance specifically for documentation behavior.
- Document language-specific examples of test doc comments and given-when-then usage to make expectations concrete.

Documentation:
- Add new constraints §5.9–5.11 to constraints.md to codify test documentation and given-when-then requirements, and update the traceability index for implement-task SKILL steps.