### PR TITLE
feat(implement-task): run CONVENTIONS.md CI checks before committing

### DIFF
--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -202,6 +202,20 @@ naming rules, directory structure for new files, code patterns, and test convent
 
 This step is optional — if `CONVENTIONS.md` does not exist, proceed normally.
 
+#### Verification commands extraction
+
+When reading `CONVENTIONS.md`, search for a section that lists CI check commands — look for
+headings or labels such as "CI checks", "All CI checks", "Linting", "Pre-commit checks",
+"Verification", or similar. Extract every command listed in that section and record them
+for use in Step 9's CI verification sub-step.
+
+Also look for any commands that generate code artifacts (e.g., OpenAPI spec generation,
+code generation, schema generation). Record these separately — they may produce file
+changes that need to be committed alongside the implementation.
+
+If no CI check section is found in `CONVENTIONS.md`, proceed normally — Step 9 will
+fall back to standard build/lint checks.
+
 ### Convention conformance analysis
 
 After inspecting the files to modify, analyze established conventions in the surrounding
@@ -543,9 +557,28 @@ Use Grep or Serena's `search_for_pattern` to look for similar function names, st
 or algorithmic patterns. If you find that your new code substantially duplicates existing
 utilities or helpers, refactor to reuse the existing code before proceeding.
 
-### Compiler / linter warnings
+### CI checks from CONVENTIONS.md
 
-If the project has a build or lint step, compare the current warning output against the pre-implementation baseline captured during Step 7. If new warnings were introduced, fix them before proceeding.
+If `CONVENTIONS.md` was loaded in Step 4 and verification commands were extracted,
+run every CI check command recorded during the verification commands extraction.
+Execute each command in sequence. If any command fails, fix the issue before
+proceeding to the next command.
+
+1. **Run all CI check commands**: execute each command extracted from the
+   `CONVENTIONS.md` CI checks section (e.g., formatting, linting, type checking,
+   compilation). These commands are project-specific — do not hardcode or assume
+   which tools the project uses.
+2. **Run code generation commands**: if any code generation commands were extracted
+   (e.g., OpenAPI spec generation, schema generation, code scaffolding), run them
+   now. If they produce file changes, stage those changes for commit alongside the
+   implementation — they are part of the deliverable.
+3. **Fix failures**: if any CI check command fails, fix the underlying issue and
+   re-run the failing command until it passes. Do not skip failing checks.
+
+If `CONVENTIONS.md` was not found or contained no CI check section, fall back to
+running the project's standard build or lint step (if one exists) and compare the
+warning output against the pre-implementation baseline captured during Step 7. If
+new warnings were introduced, fix them before proceeding.
 
 ### Data-flow trace
 


### PR DESCRIPTION
## Summary

- Step 4's CONVENTIONS.md lookup now extracts verification commands (CI checks and code generation commands) for reuse in Step 9
- Step 9's vague "Compiler / linter warnings" sub-step is replaced with "CI checks from CONVENTIONS.md" — runs all CI commands found in the project's CONVENTIONS.md before committing
- Code generation commands are run and their outputs staged for commit alongside the implementation
- The instruction is method-based (reads commands from CONVENTIONS.md) — no hardcoded tool commands

Implements [TC-4008](https://redhat.atlassian.net/browse/TC-4008)

## Test plan

- [ ] Verify Step 4 CONVENTIONS.md lookup includes new "Verification commands extraction" sub-section
- [ ] Verify Step 9 "CI checks from CONVENTIONS.md" replaces the old "Compiler / linter warnings"
- [ ] Confirm no hardcoded tool commands (cargo, npm, etc.) appear in the new instructions
- [ ] Run implement-task on a project with CONVENTIONS.md CI checks section and verify commands are extracted and run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Integrate project-specific CI and code generation commands from CONVENTIONS.md into the implement-task workflow and ensure they are run before committing changes.

New Features:
- Add a verification commands extraction sub-step that reads CI and code generation commands from a project's CONVENTIONS.md for later reuse.
- Introduce a CI checks step that executes all extracted CI and code generation commands before committing, staging generated artifacts as part of the deliverable.

Enhancements:
- Replace the generic compiler/linter warnings step with a CONVENTIONS.md-driven CI verification step that falls back to standard build or lint checks when no CI section is defined.