### PR TITLE
feat(verify-pr): add test doc comment check to Step 12

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -26,6 +26,7 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 1.14 | `verify-pr` root-cause tasks MUST target the workflow phase where the gap originated, not always the implementation phase. | `verify-pr/SKILL.md` — Step 5b |
 | 1.15 | `implement-task` MUST check out the existing PR branch (instead of creating a new one) when a Target PR section is present in the task description. | `implement-task/SKILL.md` — Step 5 (Target PR flow) |
 | 1.16 | `verify-pr` MUST flag repetitive test functions that could be parameterized as a WARN finding, applying the Meszaros heuristic as the decision boundary. | `verify-pr/SKILL.md` — Step 12 |
+| 1.17 | `verify-pr` MUST flag test functions missing doc comments as a WARN finding. | `verify-pr/SKILL.md` — Step 12 |
 
 ---
 
@@ -92,6 +93,6 @@ Each constraint above references its source. The full source files are:
 
 - `plugins/sdlc-workflow/skills/plan-feature/SKILL.md` — Guardrails (§1.1–1.3), Task Description Template (§4.1–4.10), Step 5 Convention-aware task enrichment (§4.11)
 - `plugins/sdlc-workflow/skills/implement-task/SKILL.md` — Important Rules (§1.4–1.6, §5.1–5.3), Step 4/6/9 (§5.4), Step 5 (§1.15, §3.1), Step 7 (§5.9–5.13), Step 9 (§2.1–2.3, §5.6–5.8), Step 10 (§3.2)
-- `plugins/sdlc-workflow/skills/verify-pr/SKILL.md` — Step 4 (§1.10, §1.12), Important Rules (§1.11, §1.13), Step 5b (§1.14), Step 12 (§1.16)
+- `plugins/sdlc-workflow/skills/verify-pr/SKILL.md` — Step 4 (§1.10, §1.12), Important Rules (§1.11, §1.13), Step 5b (§1.14), Step 12 (§1.16, §1.17)
 - `plugins/sdlc-workflow/skills/define-feature/SKILL.md` — Guardrails (§1.7–1.8), Important Rules (§1.9)
 - `docs/methodology.md` — Core Principles (§2.1, §3.2, §5.5)

--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -687,7 +687,31 @@ Do **not** flag tests with different behavior, setup, or assertions.
    - The test function names
    - A brief explanation of why they are parameterization candidates
 
-Record PASS if no repetitive test functions are found, WARN if candidates are flagged.
+### Doc comment check
+
+5. **Inspect test function documentation**: for each test file identified in step 1, check
+   whether each test function has a documentation comment (doc comment) immediately
+   preceding it. Use the Serena instance for the task's repository with `find_symbol` and
+   `include_body=true` to inspect test functions. Fall back to Read/Grep for repos without
+   a Serena instance.
+
+   Doc comment conventions vary by language:
+   - Rust: `///` or `//!`
+   - Java/TypeScript: `/** */`
+   - Python: `"""docstring"""`
+   - Go: `//` comment immediately before the function
+
+6. **Flag missing doc comments**: for each test function lacking a doc comment, record the
+   file path and function name.
+
+7. **Record findings**: append doc comment findings to the Test Quality result. If test
+   functions are missing doc comments, record WARN with the list of undocumented functions.
+   If all test functions have doc comments, this sub-check passes silently (does not change
+   the overall Test Quality result from the repetitive test check).
+
+Record PASS if both sub-checks pass (no repetitive tests and no missing doc comments).
+Record WARN if either repetitive tests are found OR doc comments are missing.
+Record N/A if no test files exist in the PR diff.
 
 **Note:** Test Quality WARN is advisory — it does **not** elevate the overall result
 to FAIL. Treat it like Diff Size: report for visibility, but do not block the PR.


### PR DESCRIPTION
## Summary

- Extend verify-pr Step 12 (Test Quality) with a doc comment sub-check that flags test functions missing documentation comments as WARN
- Add constraint §1.17 to docs/constraints.md and update the Traceability Index

Implements [TC-4002](https://redhat.atlassian.net/browse/TC-4002)

## Test plan

- [ ] Read the modified SKILL.md and verify the new sub-step integrates naturally within Step 12
- [ ] Verify the recording logic correctly combines repetitive test and doc comment results
- [ ] Read docs/constraints.md and verify the new constraint has correct source reference and the Traceability Index is updated

## Summary by Sourcery

Extend verify-pr Test Quality checks to enforce documentation comments on test functions and document the new requirement in the constraints index.

New Features:
- Add a doc comment sub-check to verify-pr Step 12 that inspects test files for undocumented test functions and records WARN findings when documentation is missing.

Enhancements:
- Update SKILL.md Test Quality logic to combine repetitive test and doc comment findings into a single PASS/WARN/N/A outcome.

Documentation:
- Document a new constraint requiring verify-pr to flag missing test doc comments (constraint §1.17) and update the traceability index to reference it.