### PR TITLE
docs(verify-pr): convention gap task structuring guidance

### DIFF
--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -510,6 +510,27 @@ jira.create_issue with:
   skill, prompt, or convention that prevents the gap from recurring. Do **not**
   include the root-cause analysis narrative in the description.
 
+#### Convention gap task structuring
+
+When a convention gap task involves documenting **annotation or labeling requirements**
+(e.g., file annotations, comment markers, metadata tags), apply these structuring
+guidelines in the task description:
+
+1. **Consolidate related requirements into a unified convention.** If multiple annotation
+   types serve a common purpose (e.g., marking test fixtures, flagging generated files,
+   tagging migration phases), describe them as sub-examples under a single convention
+   rather than as independent items. This prevents implementers from rendering each
+   requirement as a separate bullet in CONVENTIONS.md when they belong together
+   conceptually.
+
+2. **Prescribe canonical searchable markers.** When the convention involves annotating
+   files with comments, headers, or labels, the task description must instruct the
+   implementer to define canonical prefixes or phrases that tooling and reviewers can
+   use to reliably identify annotated files. For example: specify exact comment prefixes
+   (e.g., `Fixture:`, `Generated-by:`), required phrasing patterns, or structured
+   header formats — so that `grep` or CI scripts can locate annotated files without
+   false positives.
+
 Link the root-cause task to the parent task:
 
 jira.create_issue_link(type="Relates", inwardIssue=<root-cause-task-id>, outwardIssue=<parent-task-id>)


### PR DESCRIPTION
## Summary

- Add convention gap task structuring guidance to verify-pr Step 5b
- Tasks that document annotation/labeling requirements must consolidate related items into unified conventions
- Tasks must prescribe canonical searchable markers (comment prefixes, phrasing patterns) for tooling recognition

Implements [TC-4157](https://redhat.atlassian.net/browse/TC-4157)

## Test plan

- [ ] Verify Step 5b in SKILL.md contains consolidation guidance
- [ ] Verify Step 5b in SKILL.md contains canonical marker guidance
- [ ] Confirm no other files were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document additional guidance for structuring convention gap tasks in the verify-pr workflow, focusing on how to describe annotation and labeling requirements.

Documentation:
- Add guidance on consolidating related annotation or labeling requirements into unified conventions in verify-pr Step 5b documentation.
- Document the requirement to define canonical searchable markers (e.g., prefixes or phrasing) for annotated resources so tooling and reviewers can reliably identify them.