### PR TITLE
feat(evals): add cross-skill handoff contract validation

### DIFF
--- a/evals/plan-feature/baselines/f178bde/eval-1/grading.json
+++ b/evals/plan-feature/baselines/f178bde/eval-1/grading.json
@@ -29,12 +29,32 @@
       "text": "Impact map lists concrete, specific changes (not vague or abstract descriptions)",
       "passed": true,
       "evidence": "Impact map lists 6 specific changes including: 'Add AdvisorySeveritySummary model struct to represent aggregated severity counts', 'Add severity aggregation query method to AdvisoryService that counts unique advisories per severity for a given SBOM', 'Add GET /api/v2/sbom/{id}/advisory-summary endpoint with 5-minute cache and optional threshold query param', 'Add cache invalidation hook in advisory ingestion pipeline', 'Add integration tests', 'Update REST API documentation'."
+    },
+    {
+      "text": "Every generated task description contains a Repository section with a single repository name (not multiple repos per task)",
+      "passed": true,
+      "evidence": "All 5 task files have '## Repository\\ntrustify-backend' as a standalone section with a single repo name. No task lists multiple repositories."
+    },
+    {
+      "text": "Every generated task description contains Description, Acceptance Criteria, and Test Requirements sections as required by the handoff contract in task-description-template.md",
+      "passed": true,
+      "evidence": "All 5 task files contain '## Description' (with explanatory text), '## Acceptance Criteria' (with checkbox items), and '## Test Requirements' (with checkbox items)."
+    },
+    {
+      "text": "File paths in Files to Modify and Files to Create reference paths from the repo-backend.md mock repository structure manifest, not invented paths",
+      "passed": true,
+      "evidence": "All file paths reference directories present in repo-backend.md: modules/fundamental/src/advisory/model/ (exists), modules/fundamental/src/advisory/service/advisory.rs (exists), modules/fundamental/src/sbom/endpoints/ (exists), modules/ingestor/src/graph/advisory/mod.rs (exists), tests/api/ (exists), server/src/main.rs (exists). New files are created within existing directory structures."
+    },
+    {
+      "text": "Implementation Notes in every task reference specific file paths and code patterns from the repository, not abstract or generic guidance",
+      "passed": true,
+      "evidence": "All 5 tasks reference specific file paths and patterns: Task 1 references modules/fundamental/src/advisory/model/summary.rs (AdvisorySummary pattern); Task 2 references entity/src/sbom_advisory.rs and common/src/db/query.rs; Task 3 references modules/fundamental/src/sbom/endpoints/get.rs handler pattern; Task 4 references modules/ingestor/src/graph/advisory/mod.rs; Task 5 references tests/api/sbom.rs assertion patterns."
     }
   ],
   "summary": {
-    "passed": 6,
+    "passed": 10,
     "failed": 0,
-    "total": 6,
+    "total": 10,
     "pass_rate": 1.0
   }
 }

--- a/evals/plan-feature/baselines/f178bde/eval-2/grading.json
+++ b/evals/plan-feature/baselines/f178bde/eval-2/grading.json
@@ -19,12 +19,32 @@
       "text": "Tasks document assumptions where they fill in missing details, making it clear these are assumptions pending clarification (not invented specifics presented as requirements)",
       "passed": true,
       "evidence": "Impact map has a dedicated 'Assumptions Made for Planning' section with 5 explicit assumptions (A1-A5). Each task has an 'Ambiguity note' paragraph. For example, task-1 states: 'Without profiling data or latency targets (\"should be faster\" is the only requirement), this task assumes PostgreSQL GIN indexes on text-searchable columns are the appropriate optimization.' Task-2 says: '\"More relevant\" is not defined in the feature. This task assumes relevance means better full-text match scoring using PostgreSQL's built-in ranking functions. It does NOT implement: fuzzy matching, typo tolerance, synonym support, ML-based ranking, or recency/severity weighting.' Task-3 explicitly lists what cannot be determined: 'Which fields should be filterable?'"
+    },
+    {
+      "text": "Every generated task description contains a Repository section with a single repository name (not multiple repos per task)",
+      "passed": true,
+      "evidence": "All 4 task files have '## Repository\\ntrustify-backend' as a standalone section with a single repo name."
+    },
+    {
+      "text": "Every generated task description contains Description, Acceptance Criteria, and Test Requirements sections as required by the handoff contract in task-description-template.md",
+      "passed": true,
+      "evidence": "All 4 task files contain '## Description', '## Acceptance Criteria' (with checkbox items), and '## Test Requirements' (with checkbox items) with substantive content."
+    },
+    {
+      "text": "File paths in Files to Modify and Files to Create reference paths from the repo-backend.md mock repository structure manifest, not invented paths",
+      "passed": true,
+      "evidence": "All file paths reference directories present in repo-backend.md: modules/search/src/service/mod.rs (exists), modules/search/src/endpoints/mod.rs (exists), migration/src/ (exists, following m0001_initial pattern), tests/api/search.rs (exists). New files are created within existing directory structures."
+    },
+    {
+      "text": "Implementation Notes in every task reference specific file paths and code patterns from the repository, not abstract or generic guidance",
+      "passed": true,
+      "evidence": "All 4 tasks reference specific file paths and patterns: Task 1 references migration/src/m0001_initial/mod.rs and entity/src/sbom.rs; Task 2 references modules/search/src/service/mod.rs and common/src/db/query.rs with specific functions; Task 3 references common/src/db/query.rs and modules/fundamental/src/sbom/endpoints/list.rs; Task 4 references tests/api/search.rs and tests/api/sbom.rs assertion patterns."
     }
   ],
   "summary": {
-    "passed": 4,
+    "passed": 8,
     "failed": 0,
-    "total": 4,
+    "total": 8,
     "pass_rate": 1.0
   }
 }

--- a/evals/plan-feature/baselines/f178bde/eval-3/grading.json
+++ b/evals/plan-feature/baselines/f178bde/eval-3/grading.json
@@ -24,12 +24,32 @@
       "text": "Frontend tasks reference file paths from repo-frontend.md (src/pages/, src/hooks/, src/components/); backend tasks reference paths from repo-backend.md (modules/, entity/, tests/)",
       "passed": true,
       "evidence": "Frontend tasks reference: src/api/models.ts, src/api/rest.ts, src/hooks/useSbomComparison.ts, src/pages/SbomComparePage/SbomComparePage.tsx, src/pages/SbomComparePage/components/DiffSection.tsx, src/pages/SbomComparePage/components/CompareToolbar.tsx, src/routes.tsx, src/App.tsx, src/components/SeverityBadge.tsx, src/hooks/useSboms.ts, src/pages/SbomListPage/SbomListPage.tsx. Backend tasks reference: modules/fundamental/src/sbom/service/sbom.rs, modules/fundamental/src/sbom/model/comparison.rs, modules/fundamental/src/sbom/endpoints/compare.rs, entity/src/sbom_package.rs, entity/src/sbom_advisory.rs, entity/src/package_license.rs."
+    },
+    {
+      "text": "Every generated task description contains a Repository section with a single repository name (not multiple repos per task)",
+      "passed": true,
+      "evidence": "All 5 task files have a '## Repository' section with a single repo name. Tasks 1-2 list 'trustify-backend', tasks 3-5 list 'trustify-ui'. No task lists multiple repositories."
+    },
+    {
+      "text": "Every generated task description contains Description, Acceptance Criteria, and Test Requirements sections as required by the handoff contract in task-description-template.md",
+      "passed": true,
+      "evidence": "All 5 task files contain '## Description', '## Acceptance Criteria' (with checkbox items), and '## Test Requirements' (with checkbox items) with substantive content."
+    },
+    {
+      "text": "File paths in Files to Modify and Files to Create reference paths from the corresponding mock repository structure manifests (repo-backend.md or repo-frontend.md), not invented paths",
+      "passed": true,
+      "evidence": "Backend tasks reference paths from repo-backend.md: modules/fundamental/src/sbom/model/ (exists), modules/fundamental/src/sbom/service/sbom.rs (exists), modules/fundamental/src/sbom/endpoints/ (exists). Frontend tasks reference paths from repo-frontend.md: src/api/models.ts (exists), src/api/rest.ts (exists), src/hooks/ (exists), src/pages/SbomListPage/ (exists), src/routes.tsx (exists), src/App.tsx (exists). New files are created within existing directory structures."
+    },
+    {
+      "text": "Implementation Notes in every task reference specific file paths and code patterns from the repository, not abstract or generic guidance",
+      "passed": true,
+      "evidence": "All 5 tasks reference specific file paths and patterns: Task 1 references modules/fundamental/src/sbom/model/summary.rs and entity/src/sbom_package.rs; Task 2 references modules/fundamental/src/sbom/endpoints/get.rs handler pattern; Task 3 references src/api/client.ts Axios instance and src/hooks/useSboms.ts React Query pattern; Task 4 references src/components/SeverityBadge.tsx and specific PatternFly components; Task 5 references src/pages/SbomListPage/SbomListPage.tsx existing patterns."
     }
   ],
   "summary": {
-    "passed": 5,
+    "passed": 9,
     "failed": 0,
-    "total": 5,
+    "total": 9,
     "pass_rate": 1.0
   }
 }

--- a/evals/plan-feature/evals.json
+++ b/evals/plan-feature/evals.json
@@ -12,7 +12,11 @@
         "All tasks reference repository 'trustify-backend'",
         "Task dependencies form a DAG with no circular dependencies",
         "Every task's Files to Modify and Files to Create reference paths plausible within the repo-backend.md structure",
-        "Impact map lists concrete, specific changes (not vague or abstract descriptions)"
+        "Impact map lists concrete, specific changes (not vague or abstract descriptions)",
+        "Every generated task description contains a Repository section with a single repository name (not multiple repos per task)",
+        "Every generated task description contains Description, Acceptance Criteria, and Test Requirements sections as required by the handoff contract in task-description-template.md",
+        "File paths in Files to Modify and Files to Create reference paths from the repo-backend.md mock repository structure manifest, not invented paths",
+        "Implementation Notes in every task reference specific file paths and code patterns from the repository, not abstract or generic guidance"
       ]
     },
     {
@@ -24,7 +28,11 @@
         "Impact map or task descriptions explicitly flag at least 3 ambiguities from the feature description",
         "Plan acknowledges that 'Better UI' (non-MVP) cannot be planned without design mockups or frontend repository and excludes it from scope",
         "Tasks still follow the task-description-template.md format despite ambiguous requirements",
-        "Tasks document assumptions where they fill in missing details, labeled as assumptions pending clarification"
+        "Tasks document assumptions where they fill in missing details, labeled as assumptions pending clarification",
+        "Every generated task description contains a Repository section with a single repository name (not multiple repos per task)",
+        "Every generated task description contains Description, Acceptance Criteria, and Test Requirements sections as required by the handoff contract in task-description-template.md",
+        "File paths in Files to Modify and Files to Create reference paths from the repo-backend.md mock repository structure manifest, not invented paths",
+        "Implementation Notes in every task reference specific file paths and code patterns from the repository, not abstract or generic guidance"
       ]
     },
     {
@@ -37,7 +45,11 @@
         "Backend tasks have lower task numbers than the frontend tasks that depend on them",
         "Frontend tasks reference Figma design context mentioning specific PatternFly components and visual specifications",
         "At least one frontend task explicitly depends on a backend task in its Dependencies section",
-        "Frontend tasks reference paths from repo-frontend.md; backend tasks reference paths from repo-backend.md"
+        "Frontend tasks reference paths from repo-frontend.md; backend tasks reference paths from repo-backend.md",
+        "Every generated task description contains a Repository section with a single repository name (not multiple repos per task)",
+        "Every generated task description contains Description, Acceptance Criteria, and Test Requirements sections as required by the handoff contract in task-description-template.md",
+        "File paths in Files to Modify and Files to Create reference paths from the corresponding mock repository structure manifests (repo-backend.md or repo-frontend.md), not invented paths",
+        "Implementation Notes in every task reference specific file paths and code patterns from the repository, not abstract or generic guidance"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Add 4 handoff contract assertions to plan-feature eval cases 1-3 verifying task descriptions conform to task-description-template.md contract
- Assertions validate: single-repo Repository section, required sections (Description, Acceptance Criteria, Test Requirements), file path grounding against mock repo manifests, and specific Implementation Notes
- Updated baseline grading.json files confirm 100% pass rate with no false positives

Implements [TC-4147](https://redhat.atlassian.net/browse/TC-4147)

## Test plan
- [x] Verify evals.json is valid JSON
- [x] Verify new assertions graded against existing baseline outputs produce all PASS results
- [x] Verify grading.json summary totals updated correctly (eval-1: 10/10, eval-2: 8/8, eval-3: 9/9)
- [x] Verify eval 4 (adversarial) assertions unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add new contract-validation assertions to plan-feature evals and update baseline grading to reflect the stricter checks.

New Features:
- Introduce cross-skill handoff contract validation assertions to plan-feature eval cases 1–3, enforcing task description structure and repository/file grounding.

Enhancements:
- Tighten eval configuration to ensure task descriptions conform to the task-description-template contract without affecting adversarial eval 4.

Tests:
- Refresh grading baselines for plan-feature evals 1–3 to reflect all-passing results under the new contract validation assertions.