### PR TITLE
docs: policy mapping for autonomous skill execution

### DIFF
--- a/docs/specs/2026-04-21-policy-mapping.md
+++ b/docs/specs/2026-04-21-policy-mapping.md
@@ -89,6 +89,8 @@ These policies apply identically in every skill where the touchpoint appears.
 
 **Autonomous policy:** Attempt REST API automatically if credentials are pre-configured in CLAUDE.md (`## Jira Configuration` → `### REST API Credentials`). If credentials are not configured, escalate (`requires-manual-review`). Never retry MCP — if MCP failed once, it will fail again in the same session.
 
+**Enforcement:** Pre-script. The pre-script sets `JIRA_SERVER_URL`, `JIRA_EMAIL`, and `JIRA_API_TOKEN` environment variables from the policy store before the agent starts. The agent definition uses REST API directly — no MCP, no fallback prompt. If credentials are missing, the pre-script fails and the pipeline escalates without launching the agent.
+
 ### XC-2: REST API Credential Collection
 
 **Appears in:** setup (S-D), define-feature (D-B)
@@ -96,6 +98,8 @@ These policies apply identically in every skill where the touchpoint appears.
 **Current behavior:** Interactively collect Server URL, Email, API Token and ask storage preference.
 
 **Autonomous policy:** Credentials must be pre-configured. If missing, escalate (`requires-manual-review`). Autonomous agents must not collect or store secrets interactively.
+
+**Enforcement:** Pre-script. Same mechanism as XC-1 — credentials are supplied by the pre-script, never collected by the agent.
 
 ### XC-3: Project Configuration Validation
 
@@ -105,29 +109,31 @@ These policies apply identically in every skill where the touchpoint appears.
 
 **Autonomous policy:** Same — hard stop. Project Configuration is a mandatory prerequisite. This is already autonomous-compatible.
 
+**Enforcement:** Pre-script. The pre-script validates that CLAUDE.md contains the required `# Project Configuration` sections before launching the agent. If missing, the pipeline fails immediately.
+
 ---
 
 ## Setup (15 touchpoints)
 
 Setup is a one-time configuration skill. In autonomous mode, setup must have already been run — downstream skills require Project Configuration to exist. The autonomous policies below apply if setup is invoked programmatically (e.g., during automated project onboarding).
 
-| # | Step | Current interaction | Category | Autonomous policy |
-|---|---|---|---|---|
-| 1 | Step 2 | "What is the repository short name?" | Human-driven | **Human-driven.** Repository identity is a naming decision. |
-| 2 | Step 2 | "What is the repository role?" | Human-driven | **Human-driven.** Role is a classification decision. |
-| 3 | Step 3 | "Which Jira project do you want to use?" | Human-driven | **Human-driven.** Project selection is an organizational decision. |
-| 4 | Step 3 | "Which issue type is the Feature type?" | Human-driven | **Human-driven.** Issue type mapping is project-specific. |
-| 5 | Step 3.3 | "Do you have a Git Pull Request custom field ID?" | Procedural | **Default:** skip. If the field exists in Project Configuration from a prior run, preserve it. Otherwise, leave unconfigured — it is optional. |
-| 6 | Step 3.3 | "Do you have a GitHub Issue custom field ID?" | Procedural | **Default:** same as #5. |
-| 7 | Step 4 | "Are there any known limitations for Serena instances?" | Procedural | **Default:** assume no limitations. Write "No limitations known" in the Limitations section. If Serena tools fail during downstream skill execution, those failures will surface naturally. |
-| 8 | Step 7 | "Would you like to scaffold CONVENTIONS.md for this repo?" | Procedural | **Default:** always scaffold. CONVENTIONS.md is needed for convention checking in plan-feature and implement-task. Scaffolding is non-destructive (only creates if absent). |
-| 9 | Step 7 | "Would you like me to fill in CONVENTIONS.md now?" | Procedural | **Default:** always auto-populate using codebase analysis. The analysis is deterministic and best-effort. Content is refinable later via convention gap tasks. |
-| 10 | Step 5 | "Ready to write changes?" | Approval gate | **Auto-proceed.** Validate generated config: all required fields present (Project key, Cloud ID, Feature issue type ID), Repository Registry has ≥1 entry, Code Intelligence section exists. If valid, write. If validation fails, escalate. |
-| S-A | Step 2 | "Repo local path?" (when `get_diagnostics` fails) | Exception handling | **Reject/Escalate.** If `get_diagnostics` is unavailable, escalate (`requires-manual-review`). The local path cannot be safely guessed. |
-| S-B | Step 2 | "Continue without code intelligence or set up Serena first?" | Procedural | **Default:** continue without code intelligence. Downstream skills handle the absence of Serena gracefully (fallback to Glob/Grep/Read). |
-| S-C | Step 3.2 | MCP failure → "Use REST API fallback?" | Exception handling | **XC-1** (see cross-cutting). |
-| S-D | Step 3.3 | REST API credential collection + storage preference | Procedural | **XC-2** (see cross-cutting). |
-| S-E | Step 7 | "Review auto-populated CONVENTIONS.md before writing" | Approval gate | **Auto-proceed.** Auto-populated content is best-effort codebase analysis. Proceed without review. Content is validated and refined through convention gap tasks created by verify-pr's root-cause flywheel. |
+| # | Step | Current interaction | Category | Autonomous policy | Enforcement |
+|---|---|---|---|---|---|
+| 1 | Step 2 | "What is the repository short name?" | Human-driven | **Human-driven.** Repository identity is a naming decision. | — |
+| 2 | Step 2 | "What is the repository role?" | Human-driven | **Human-driven.** Role is a classification decision. | — |
+| 3 | Step 3 | "Which Jira project do you want to use?" | Human-driven | **Human-driven.** Project selection is an organizational decision. | — |
+| 4 | Step 3 | "Which issue type is the Feature type?" | Human-driven | **Human-driven.** Issue type mapping is project-specific. | — |
+| 5 | Step 3.3 | "Do you have a Git Pull Request custom field ID?" | Procedural | **Default:** skip. If the field exists in Project Configuration from a prior run, preserve it. Otherwise, leave unconfigured — it is optional. | Agent definition |
+| 6 | Step 3.3 | "Do you have a GitHub Issue custom field ID?" | Procedural | **Default:** same as #5. | Agent definition |
+| 7 | Step 4 | "Are there any known limitations for Serena instances?" | Procedural | **Default:** assume no limitations. Write "No limitations known" in the Limitations section. If Serena tools fail during downstream skill execution, those failures will surface naturally. | Agent definition |
+| 8 | Step 7 | "Would you like to scaffold CONVENTIONS.md for this repo?" | Procedural | **Default:** always scaffold. CONVENTIONS.md is needed for convention checking in plan-feature and implement-task. Scaffolding is non-destructive (only creates if absent). | Agent definition |
+| 9 | Step 7 | "Would you like me to fill in CONVENTIONS.md now?" | Procedural | **Default:** always auto-populate using codebase analysis. The analysis is deterministic and best-effort. Content is refinable later via convention gap tasks. | Agent definition |
+| 10 | Step 5 | "Ready to write changes?" | Approval gate | **Auto-proceed.** Validate generated config: all required fields present (Project key, Cloud ID, Feature issue type ID), Repository Registry has ≥1 entry, Code Intelligence section exists. If valid, write. If validation fails, escalate. | Post-script — validate config structure before allowing the write |
+| S-A | Step 2 | "Repo local path?" (when `get_diagnostics` fails) | Exception handling | **Reject/Escalate.** If `get_diagnostics` is unavailable, escalate (`requires-manual-review`). The local path cannot be safely guessed. | Pre-script — verify Serena diagnostics are reachable before launching agent |
+| S-B | Step 2 | "Continue without code intelligence or set up Serena first?" | Procedural | **Default:** continue without code intelligence. Downstream skills handle the absence of Serena gracefully (fallback to Glob/Grep/Read). | Agent definition |
+| S-C | Step 3.2 | MCP failure → "Use REST API fallback?" | Exception handling | **XC-1** (see cross-cutting). | Pre-script |
+| S-D | Step 3.3 | REST API credential collection + storage preference | Procedural | **XC-2** (see cross-cutting). | Pre-script |
+| S-E | Step 7 | "Review auto-populated CONVENTIONS.md before writing" | Approval gate | **Auto-proceed.** Auto-populated content is best-effort codebase analysis. Proceed without review. Content is validated and refined through convention gap tasks created by verify-pr's root-cause flywheel. | Agent definition |
 
 ---
 
@@ -135,80 +141,80 @@ Setup is a one-time configuration skill. In autonomous mode, setup must have alr
 
 Define-feature collects strategic intent. All content-collection touchpoints remain human-driven — this is by design. An autonomous agent cannot invent product requirements.
 
-| # | Step | Current interaction | Category | Autonomous policy |
-|---|---|---|---|---|
-| 11 | Step 1 | "Are you ready to begin?" | Procedural | **Default:** skip. Proceed directly to content collection. |
-| 12 | Step 2 | Confirm or provide Feature title | Human-driven | **Human-driven.** Feature naming is a product decision. |
-| 13 | Step 3a | "Provide high-level description — the What & Why" | Human-driven | **Human-driven.** |
-| 14 | Step 3b | "How does this fit into product strategy?" | Human-driven | **Human-driven.** |
-| 15 | Step 3c | "Who benefits? Current vs. target state?" | Human-driven | **Human-driven.** |
-| 16 | Step 3d | "Which input mode: row-by-row or batch paste?" | Human-driven | **Human-driven.** |
-| 17 | Step 3d | "Add another requirement, or done?" | Human-driven | **Human-driven.** |
-| 18 | Step 3e | "Architecture characteristics and NFRs?" | Human-driven | **Human-driven.** |
-| 19 | Step 3f | "Success scenarios with personas, outcomes?" | Human-driven | **Human-driven.** |
-| 20 | Step 3g | "Prerequisites, dependencies, assumptions?" | Human-driven | **Human-driven.** |
-| 21 | Step 3h | "SRE metrics, observability, feedback?" | Human-driven | **Human-driven.** |
-| 22 | Step 3i | "Documentation impact categories?" | Human-driven | **Human-driven.** |
-| 23 | Step 4 | "Assign to yourself or leave unassigned?" | Procedural | **Default:** leave unassigned. Assignment happens when implement-task picks up the work (Step 3 of implement-task already auto-assigns). |
-| 24 | Step 5 | "Ready to create this Feature in Jira?" | Approval gate | **Human-driven.** This is the final approval for strategic content. Unlike technical approval gates, this guards product intent. Stays human-driven even in autonomous mode. |
-| 25 | Step 5 | "Which section(s) to revise?" | Human-driven | **Human-driven.** |
-| 26 | Step 5 | Re-display preview, re-ask "Ready to create?" | Approval gate | **Human-driven.** Same reasoning as #24. |
-| 27 | Step 5 | Re-collect content for revised section | Human-driven | **Human-driven.** |
-| D-A | Step 0.5 | MCP failure → "Use REST API fallback?" | Exception handling | **XC-1** (see cross-cutting). |
-| D-B | Step 0.5 | REST API credential collection | Procedural | **XC-2** (see cross-cutting). |
+| # | Step | Current interaction | Category | Autonomous policy | Enforcement |
+|---|---|---|---|---|---|
+| 11 | Step 1 | "Are you ready to begin?" | Procedural | **Default:** skip. Proceed directly to content collection. | Agent definition |
+| 12 | Step 2 | Confirm or provide Feature title | Human-driven | **Human-driven.** Feature naming is a product decision. | — |
+| 13 | Step 3a | "Provide high-level description — the What & Why" | Human-driven | **Human-driven.** | — |
+| 14 | Step 3b | "How does this fit into product strategy?" | Human-driven | **Human-driven.** | — |
+| 15 | Step 3c | "Who benefits? Current vs. target state?" | Human-driven | **Human-driven.** | — |
+| 16 | Step 3d | "Which input mode: row-by-row or batch paste?" | Human-driven | **Human-driven.** | — |
+| 17 | Step 3d | "Add another requirement, or done?" | Human-driven | **Human-driven.** | — |
+| 18 | Step 3e | "Architecture characteristics and NFRs?" | Human-driven | **Human-driven.** | — |
+| 19 | Step 3f | "Success scenarios with personas, outcomes?" | Human-driven | **Human-driven.** | — |
+| 20 | Step 3g | "Prerequisites, dependencies, assumptions?" | Human-driven | **Human-driven.** | — |
+| 21 | Step 3h | "SRE metrics, observability, feedback?" | Human-driven | **Human-driven.** | — |
+| 22 | Step 3i | "Documentation impact categories?" | Human-driven | **Human-driven.** | — |
+| 23 | Step 4 | "Assign to yourself or leave unassigned?" | Procedural | **Default:** leave unassigned. Assignment happens when implement-task picks up the work (Step 3 of implement-task already auto-assigns). | Agent definition |
+| 24 | Step 5 | "Ready to create this Feature in Jira?" | Approval gate | **Human-driven.** This is the final approval for strategic content. Unlike technical approval gates, this guards product intent. Stays human-driven even in autonomous mode. | — |
+| 25 | Step 5 | "Which section(s) to revise?" | Human-driven | **Human-driven.** | — |
+| 26 | Step 5 | Re-display preview, re-ask "Ready to create?" | Approval gate | **Human-driven.** Same reasoning as #24. | — |
+| 27 | Step 5 | Re-collect content for revised section | Human-driven | **Human-driven.** | — |
+| D-A | Step 0.5 | MCP failure → "Use REST API fallback?" | Exception handling | **XC-1** (see cross-cutting). | Pre-script |
+| D-B | Step 0.5 | REST API credential collection | Procedural | **XC-2** (see cross-cutting). | Pre-script |
 
 ---
 
 ## Plan-feature (3 touchpoints)
 
-| # | Step | Current interaction | Category | Autonomous policy |
-|---|---|---|---|---|
-| 28 | Step 2 | Discover or request Figma URL | Procedural | **Default:** discover from skill arguments or Jira issue description. If not found, proceed without Figma analysis. Do not request. Note: the current skill already behaves this way — it never explicitly requests a Figma URL. The spec's "or request" is aspirational; the policy matches current behavior. |
-| 29 | Step 4 | "Approve impact map before task generation" | Approval gate | **Auto-proceed.** Validate: (1) every requirement from the Feature description maps to at least one change in the impact map, (2) all impacted repos are in the Repository Registry, (3) no repo outside the Registry is listed. If all three pass, proceed to task generation. If any fails, escalate (`requires-manual-review`). |
-| P-A | Step 0.5 | MCP failure → "Use REST API fallback?" | Exception handling | **XC-1** (see cross-cutting). |
+| # | Step | Current interaction | Category | Autonomous policy | Enforcement |
+|---|---|---|---|---|---|
+| 28 | Step 2 | Discover or request Figma URL | Procedural | **Default:** discover from skill arguments or Jira issue description. If not found, proceed without Figma analysis. Do not request. Note: the current skill already behaves this way — it never explicitly requests a Figma URL. The spec's "or request" is aspirational; the policy matches current behavior. | Agent definition |
+| 29 | Step 4 | "Approve impact map before task generation" | Approval gate | **Auto-proceed.** Validate: (1) every requirement from the Feature description maps to at least one change in the impact map, (2) all impacted repos are in the Repository Registry, (3) no repo outside the Registry is listed. If all three pass, proceed to task generation. If any fails, escalate (`requires-manual-review`). | Agent definition (semantic validation requires LLM judgment) + post-script (escalation) |
+| P-A | Step 0.5 | MCP failure → "Use REST API fallback?" | Exception handling | **XC-1** (see cross-cutting). | Pre-script |
 
 ---
 
 ## Implement-task (16 touchpoints)
 
-| # | Step | Current interaction | Category | Autonomous policy |
-|---|---|---|---|---|
-| 30 | Step 1 | "Task description missing required sections — clarify" | Exception handling | **Reject.** If required sections (Repository, Description, Files to Modify/Create, Acceptance Criteria, Test Requirements) are missing, flag `requires-manual-review` on the Jira issue and stop. The task is not ready for autonomous execution. |
-| 31 | Step 4 | "Convention conflict between task and codebase — which to follow?" | Exception handling | **Default:** follow CONVENTIONS.md. CONVENTIONS.md is the project authority for patterns and style. If the task contradicts a documented convention, follow the convention and log the deviation. If the conflict is with an undocumented codebase pattern (no CONVENTIONS.md entry), follow the task description — undocumented patterns are not binding. |
-| 32 | Step 6 | "API contract mismatch with backend — stop and report" | Exception handling | **Reject.** Do not implement with mismatched contracts. Create a sub-task on the parent Feature documenting the mismatch (affected endpoint, expected vs. actual, backend source file). Flag `requires-manual-review`. |
-| 33 | Step 9 | "Out-of-scope file modified — approve or revert?" | Exception handling | **Default:** revert out-of-scope changes, with exceptions. Auto-include if the file is: (a) a lockfile (`package-lock.json`, `Cargo.lock`, etc.), (b) a generated file from a code generation command listed in CONVENTIONS.md, or (c) a build artifact required by CI. Revert all others and log the reversion. |
-| 34 | Step 9 | "Untracked file found near modified files — stage for commit?" | Exception handling | **Default:** stage if referenced by code (compile-time includes, imports, config references found in the diff). Skip if not referenced. Log all decisions. |
-| 35 | Step 9 | "Secrets found in diff — do not proceed" | Exception handling | **Hard stop.** Remove the sensitive content from the staged diff. Do not commit. Flag `requires-manual-review`. This is non-negotiable — secrets must never be committed. |
-| 36 | Step 9 | "Data-flow trace incomplete — is missing stage intentionally out of scope?" | Exception handling | **Default:** if the missing stage is in a file listed in the task's Files to Modify/Create, implement it (the task intended it). If the missing stage is in files NOT in the task's scope, escalate (`requires-manual-review`). The task may be underspecified. |
-| 37 | Step 9 | "Sibling parity gap — is omission intentional?" | Exception handling | **Default:** implement the missing capability if it is mechanical (e.g., error handling, logging, input validation that all siblings have and requires no design decisions). Escalate if the gap requires design choices (e.g., choosing between implementation strategies, adding new API surface). |
-| 38 | Step 5 | Target PR flow depends on user-provided Target PR | Procedural | **Default:** follow the Target PR if present in the task description. Otherwise, create a new branch. The task description is authoritative — no human decision needed. |
-| I-A | Step 0.5 | MCP failure → "Use REST API fallback?" | Exception handling | **XC-1** (see cross-cutting). |
-| I-B | Step 6 | Sort order mismatch → "stop and report to user" | Exception handling | **Reject.** Same policy as #32 (API contract mismatch). Create a sub-task documenting the sort order discrepancy and escalate. Positional assumptions on unsorted data are a correctness bug. |
-| I-C | Step 9 | Cross-module shared entity anomaly → "confirm if intentional" | Exception handling | **Default:** align with the established cross-module pattern. The existing pattern is authoritative — other modules already interact with the shared entity safely. Deviating without explicit justification in the task is a defect. Log the alignment. |
-| I-D | Step 9 | Caller-site parity anomaly → "confirm if intentional" | Exception handling | **Default:** align with the established caller pattern. Same reasoning as I-C. If all existing callers use `queryClient.invalidateQueries()` and the new code uses `window.location.reload()`, the new code is wrong. Align and log. |
-| I-E | Rules | Same test fails 3× with same error → "stop and ask for guidance" | Exception handling | **Escalate.** Flag `requires-manual-review`. Three identical failures indicate a problem the agent cannot solve. Include the test name, error message, and the three attempted fixes in the escalation. |
-| I-F | Rules | Same file edited 5× for same change → "stop and present alternatives" | Exception handling | **Escalate.** Flag `requires-manual-review`. The agent is stuck in a loop. Include the file, the intended change, and the five attempts in the escalation. |
-| I-G | Rules | Build error persists after 2 fix attempts → "stop and present alternatives" | Exception handling | **Escalate.** Flag `requires-manual-review`. Include the error, the two attempted fixes, and their outcomes in the escalation. |
+| # | Step | Current interaction | Category | Autonomous policy | Enforcement |
+|---|---|---|---|---|---|
+| 30 | Step 1 | "Task description missing required sections — clarify" | Exception handling | **Reject.** If required sections (Repository, Description, Files to Modify/Create, Acceptance Criteria, Test Requirements) are missing, flag `requires-manual-review` on the Jira issue and stop. The task is not ready for autonomous execution. | Pre-script — validate task structure before launching agent |
+| 31 | Step 4 | "Convention conflict between task and codebase — which to follow?" | Exception handling | **Default:** follow CONVENTIONS.md. CONVENTIONS.md is the project authority for patterns and style. If the task contradicts a documented convention, follow the convention and log the deviation. If the conflict is with an undocumented codebase pattern (no CONVENTIONS.md entry), follow the task description — undocumented patterns are not binding. | Agent definition |
+| 32 | Step 6 | "API contract mismatch with backend — stop and report" | Exception handling | **Reject.** Do not implement with mismatched contracts. Create a sub-task on the parent Feature documenting the mismatch (affected endpoint, expected vs. actual, backend source file). Flag `requires-manual-review`. | Agent definition (detection requires LLM) + post-script (block push on mismatch flag in agent output) |
+| 33 | Step 9 | "Out-of-scope file modified — approve or revert?" | Exception handling | **Default:** revert out-of-scope changes, with exceptions. Auto-include if the file is: (a) a lockfile (`package-lock.json`, `Cargo.lock`, etc.), (b) a generated file from a code generation command listed in CONVENTIONS.md, or (c) a build artifact required by CI. Revert all others and log the reversion. | Post-script — compare `git diff --name-only` against task's file list; revert unlisted files before push |
+| 34 | Step 9 | "Untracked file found near modified files — stage for commit?" | Exception handling | **Default:** stage if referenced by code (compile-time includes, imports, config references found in the diff). Skip if not referenced. Log all decisions. | Agent definition (reference detection requires LLM) |
+| 35 | Step 9 | "Secrets found in diff — do not proceed" | Exception handling | **Hard stop.** Remove the sensitive content from the staged diff. Do not commit. Flag `requires-manual-review`. This is non-negotiable — secrets must never be committed. | Post-script — scan diff for secret patterns before push (like fullsend's gitleaks integration) |
+| 36 | Step 9 | "Data-flow trace incomplete — is missing stage intentionally out of scope?" | Exception handling | **Default:** if the missing stage is in a file listed in the task's Files to Modify/Create, implement it (the task intended it). If the missing stage is in files NOT in the task's scope, escalate (`requires-manual-review`). The task may be underspecified. | Agent definition (data-flow analysis requires LLM) |
+| 37 | Step 9 | "Sibling parity gap — is omission intentional?" | Exception handling | **Default:** implement the missing capability if it is mechanical (e.g., error handling, logging, input validation that all siblings have and requires no design decisions). Escalate if the gap requires design choices (e.g., choosing between implementation strategies, adding new API surface). | Agent definition (sibling analysis requires LLM) |
+| 38 | Step 5 | Target PR flow depends on user-provided Target PR | Procedural | **Default:** follow the Target PR if present in the task description. Otherwise, create a new branch. The task description is authoritative — no human decision needed. | Agent definition |
+| I-A | Step 0.5 | MCP failure → "Use REST API fallback?" | Exception handling | **XC-1** (see cross-cutting). | Pre-script |
+| I-B | Step 6 | Sort order mismatch → "stop and report to user" | Exception handling | **Reject.** Same policy as #32 (API contract mismatch). Create a sub-task documenting the sort order discrepancy and escalate. Positional assumptions on unsorted data are a correctness bug. | Agent definition (detection) + post-script (block push) |
+| I-C | Step 9 | Cross-module shared entity anomaly → "confirm if intentional" | Exception handling | **Default:** align with the established cross-module pattern. The existing pattern is authoritative — other modules already interact with the shared entity safely. Deviating without explicit justification in the task is a defect. Log the alignment. | Agent definition |
+| I-D | Step 9 | Caller-site parity anomaly → "confirm if intentional" | Exception handling | **Default:** align with the established caller pattern. Same reasoning as I-C. If all existing callers use `queryClient.invalidateQueries()` and the new code uses `window.location.reload()`, the new code is wrong. Align and log. | Agent definition |
+| I-E | Rules | Same test fails 3× with same error → "stop and ask for guidance" | Exception handling | **Escalate.** Flag `requires-manual-review`. Three identical failures indicate a problem the agent cannot solve. Include the test name, error message, and the three attempted fixes in the escalation. | Harness config — `max_iterations` in validation loop (like fullsend's ADR 0022) |
+| I-F | Rules | Same file edited 5× for same change → "stop and present alternatives" | Exception handling | **Escalate.** Flag `requires-manual-review`. The agent is stuck in a loop. Include the file, the intended change, and the five attempts in the escalation. | Agent definition (only the LLM tracks edit count) |
+| I-G | Rules | Build error persists after 2 fix attempts → "stop and present alternatives" | Exception handling | **Escalate.** Flag `requires-manual-review`. Include the error, the two attempted fixes, and their outcomes in the escalation. | Harness config — `max_iterations` in validation loop |
 
 ---
 
 ## Verify-pr (13 touchpoints)
 
-| # | Step | Current interaction | Category | Autonomous policy |
-|---|---|---|---|---|
-| 39 | Step 2 | "PR URL not in custom field — provide it" | Exception handling | **Default:** search for PRs on the task's branch name: `gh pr list --head <jira-issue-id> -R <owner/repo>`. If exactly one PR found, use it. If zero or multiple, escalate (`requires-manual-review`). |
-| 40 | Step 4c | Classify each comment (code change request / suggestion / question / nit) | Automated | **No change.** Already autonomous. |
-| 41 | Step 4c | Upgrade suggestion to code change request if matches CONVENTIONS.md | Automated | **No change.** Already autonomous. |
-| 42 | Step 4f | Post classification reasoning to each comment | Automated | **No change.** Already autonomous. |
-| 43 | Step 5a | "Would this knowledge apply to ANY repo, or only this one?" (universality test) | Sub-agent decision | **No change.** Already a sub-agent decision, not a human touchpoint. The universality test is a deterministic classification the sub-agent performs internally. |
-| 44 | Step 5a | "Can guidance be expressed as method without language-specific references?" (method-vs-fact) | Sub-agent decision | **No change.** Same as #43. |
-| 45 | Step 10b | Analyze CI failure logs; if inconclusive, ask user | Exception handling | **Default:** if the failure is deterministic (test assertion, compilation error, lint violation), create a sub-task with the fix. If the failure is non-deterministic or infrastructure-related (timeout, flaky test, network error, runner OOM), flag `requires-manual-review`. Heuristic: if re-running the same commit would produce the same failure, it is deterministic. |
-| 46 | Step 11 | Verify each acceptance criterion by inspecting code | Automated | **No change.** Already autonomous. |
-| 47 | Step 12 | Check for repetitive tests (Meszaros heuristic) | Automated | **No change.** Already autonomous. |
-| 48 | Step 12 | Check for doc comments on test functions | Automated | **No change.** Already autonomous. |
-| 49 | Step 14 | Compile and post verification report | Automated | **No change.** Already autonomous. |
-| 50 | Step 15 | Post report to Jira as comment | Automated | **No change.** Already autonomous. |
-| V-A | Step 0.5 | MCP failure → "Use REST API fallback?" | Exception handling | **XC-1** (see cross-cutting). |
+| # | Step | Current interaction | Category | Autonomous policy | Enforcement |
+|---|---|---|---|---|---|
+| 39 | Step 2 | "PR URL not in custom field — provide it" | Exception handling | **Default:** search for PRs on the task's branch name: `gh pr list --head <jira-issue-id> -R <owner/repo>`. If exactly one PR found, use it. If zero or multiple, escalate (`requires-manual-review`). | Pre-script — resolve PR URL before launching agent; fail if ambiguous |
+| 40 | Step 4c | Classify each comment (code change request / suggestion / question / nit) | Automated | **No change.** Already autonomous. | Agent definition |
+| 41 | Step 4c | Upgrade suggestion to code change request if matches CONVENTIONS.md | Automated | **No change.** Already autonomous. | Agent definition |
+| 42 | Step 4f | Post classification reasoning to each comment | Automated | **No change.** Already autonomous. | Post-script — post comments via write token (agent produces JSON, script posts) |
+| 43 | Step 5a | "Would this knowledge apply to ANY repo, or only this one?" (universality test) | Sub-agent decision | **No change.** Already a sub-agent decision, not a human touchpoint. The universality test is a deterministic classification the sub-agent performs internally. | Agent definition |
+| 44 | Step 5a | "Can guidance be expressed as method without language-specific references?" (method-vs-fact) | Sub-agent decision | **No change.** Same as #43. | Agent definition |
+| 45 | Step 10b | Analyze CI failure logs; if inconclusive, ask user | Exception handling | **Default:** if the failure is deterministic (test assertion, compilation error, lint violation), create a sub-task with the fix. If the failure is non-deterministic or infrastructure-related (timeout, flaky test, network error, runner OOM), flag `requires-manual-review`. Heuristic: if re-running the same commit would produce the same failure, it is deterministic. | Agent definition (failure classification requires LLM) + post-script (escalation) |
+| 46 | Step 11 | Verify each acceptance criterion by inspecting code | Automated | **No change.** Already autonomous. | Agent definition |
+| 47 | Step 12 | Check for repetitive tests (Meszaros heuristic) | Automated | **No change.** Already autonomous. | Agent definition |
+| 48 | Step 12 | Check for doc comments on test functions | Automated | **No change.** Already autonomous. | Agent definition |
+| 49 | Step 14 | Compile and post verification report | Automated | **No change.** Already autonomous. | Agent definition (compile report) + post-script (post to GitHub/Jira via write token) |
+| 50 | Step 15 | Post report to Jira as comment | Automated | **No change.** Already autonomous. | Post-script — post via write token |
+| V-A | Step 0.5 | MCP failure → "Use REST API fallback?" | Exception handling | **XC-1** (see cross-cutting). | Pre-script |
 
 ---
 
@@ -225,6 +231,18 @@ Define-feature collects strategic intent. All content-collection touchpoints rem
 | Reject/Escalate | 13 | Hard stop or `requires-manual-review`. Includes secrets detection, contract mismatches, retry exhaustion, and missing prerequisites. |
 | Cross-cutting (XC-1, XC-2) | 5 + 2 | MCP fallback (auto-use REST if configured, else escalate) and credential collection (must be pre-configured, else escalate). Counted per-skill but defined once. |
 | **Total** | **66** | |
+
+### Enforcement layer breakdown
+
+| Layer | Count | What it enforces |
+|---|---|---|
+| — (no enforcement needed) | 22 | Human-driven touchpoints. No autonomous agent definition exists for these. |
+| Agent definition | 24 | Procedural defaults, convention resolution, pattern analysis, semantic checks. Soft enforcement — the LLM follows instructions but could deviate. |
+| Pre-script | 12 | Credential setup (XC-1/XC-2), config validation (XC-3), task structure validation, PR resolution. Hard enforcement — agent doesn't launch if pre-script fails. |
+| Post-script | 6 | Scope containment, secret scanning, protected path enforcement, report posting. Hard enforcement — mutations are blocked if validation fails. |
+| Harness config | 2 | Retry limits (I-E, I-G). Enforced by the validation loop's `max_iterations`. |
+
+Policies with dual enforcement (agent definition + post-script) are counted under their primary layer. The post-script serves as a non-bypassable backstop for safety-critical policies where the agent definition alone is insufficient (#32, #33, #35, I-B).
 
 ### Escalation mechanism
 

--- a/docs/specs/2026-04-21-policy-mapping.md
+++ b/docs/specs/2026-04-21-policy-mapping.md
@@ -1,0 +1,192 @@
+# Policy Mapping: Human Touchpoints → Autonomous Policies
+
+**Date:** 2026-04-21
+**Prerequisite:** [Autonomous Readiness Plan](../superpowers/specs/2026-04-14-autonomous-readiness-plan.md)
+**Deliverable:** 30-day phase, item #1
+
+---
+
+## Context
+
+This document maps every human interaction point across the five sdlc-workflow skills to an autonomous policy equivalent. The audit identified **66 touchpoints** (up from the readiness plan's ~50 estimate), primarily because the MCP/REST API fallback flow and additional implement-task self-verification checks were added after the plan was written.
+
+Each touchpoint gets one of five policy types:
+
+| Policy type | Meaning |
+|---|---|
+| **Human-driven** | Stays human-driven. Strategic intent requires human input. No autonomous equivalent. |
+| **Automated** | Already runs without human input. No change needed. |
+| **Default** | Replace prompt with a deterministic default. Skip optional prompts, use configuration values. |
+| **Auto-proceed** | Replace approval gate with automated validation. Proceed if valid, escalate if not. |
+| **Reject/Escalate** | Replace exception prompt with a deterministic rule: fix automatically if safe, otherwise hard stop or flag `requires-manual-review`. |
+
+---
+
+## Cross-Cutting Policies
+
+These policies apply identically in every skill where the touchpoint appears.
+
+### XC-1: MCP Failure → REST API Fallback
+
+**Appears in:** setup (S-C), define-feature (D-A), plan-feature (P-A), implement-task (I-A), verify-pr (V-A)
+
+**Current behavior:** Prompt user with Yes/No/Retry options when Atlassian MCP fails.
+
+**Autonomous policy:** Attempt REST API automatically if credentials are pre-configured in CLAUDE.md (`## Jira Configuration` → `### REST API Credentials`). If credentials are not configured, escalate (`requires-manual-review`). Never retry MCP — if MCP failed once, it will fail again in the same session.
+
+### XC-2: REST API Credential Collection
+
+**Appears in:** setup (S-D), define-feature (D-B)
+
+**Current behavior:** Interactively collect Server URL, Email, API Token and ask storage preference.
+
+**Autonomous policy:** Credentials must be pre-configured. If missing, escalate (`requires-manual-review`). Autonomous agents must not collect or store secrets interactively.
+
+### XC-3: Project Configuration Validation
+
+**Appears in:** All skills (Step 0)
+
+**Current behavior:** If Project Configuration is missing, stop and tell user to run `/setup`.
+
+**Autonomous policy:** Same — hard stop. Project Configuration is a mandatory prerequisite. This is already autonomous-compatible.
+
+---
+
+## Setup (15 touchpoints)
+
+Setup is a one-time configuration skill. In autonomous mode, setup must have already been run — downstream skills require Project Configuration to exist. The autonomous policies below apply if setup is invoked programmatically (e.g., during automated project onboarding).
+
+| # | Step | Current interaction | Category | Autonomous policy |
+|---|---|---|---|---|
+| 1 | Step 2 | "What is the repository short name?" | Human-driven | **Human-driven.** Repository identity is a naming decision. |
+| 2 | Step 2 | "What is the repository role?" | Human-driven | **Human-driven.** Role is a classification decision. |
+| 3 | Step 3 | "Which Jira project do you want to use?" | Human-driven | **Human-driven.** Project selection is an organizational decision. |
+| 4 | Step 3 | "Which issue type is the Feature type?" | Human-driven | **Human-driven.** Issue type mapping is project-specific. |
+| 5 | Step 3.3 | "Do you have a Git Pull Request custom field ID?" | Procedural | **Default:** skip. If the field exists in Project Configuration from a prior run, preserve it. Otherwise, leave unconfigured — it is optional. |
+| 6 | Step 3.3 | "Do you have a GitHub Issue custom field ID?" | Procedural | **Default:** same as #5. |
+| 7 | Step 4 | "Are there any known limitations for Serena instances?" | Procedural | **Default:** assume no limitations. Write "No limitations known" in the Limitations section. If Serena tools fail during downstream skill execution, those failures will surface naturally. |
+| 8 | Step 7 | "Would you like to scaffold CONVENTIONS.md for this repo?" | Procedural | **Default:** always scaffold. CONVENTIONS.md is needed for convention checking in plan-feature and implement-task. Scaffolding is non-destructive (only creates if absent). |
+| 9 | Step 7 | "Would you like me to fill in CONVENTIONS.md now?" | Procedural | **Default:** always auto-populate using codebase analysis. The analysis is deterministic and best-effort. Content is refinable later via convention gap tasks. |
+| 10 | Step 5 | "Ready to write changes?" | Approval gate | **Auto-proceed.** Validate generated config: all required fields present (Project key, Cloud ID, Feature issue type ID), Repository Registry has ≥1 entry, Code Intelligence section exists. If valid, write. If validation fails, escalate. |
+| S-A | Step 2 | "Repo local path?" (when `get_diagnostics` fails) | Exception handling | **Reject/Escalate.** If `get_diagnostics` is unavailable, escalate (`requires-manual-review`). The local path cannot be safely guessed. |
+| S-B | Step 2 | "Continue without code intelligence or set up Serena first?" | Procedural | **Default:** continue without code intelligence. Downstream skills handle the absence of Serena gracefully (fallback to Glob/Grep/Read). |
+| S-C | Step 3.2 | MCP failure → "Use REST API fallback?" | Exception handling | **XC-1** (see cross-cutting). |
+| S-D | Step 3.3 | REST API credential collection + storage preference | Procedural | **XC-2** (see cross-cutting). |
+| S-E | Step 7 | "Review auto-populated CONVENTIONS.md before writing" | Approval gate | **Auto-proceed.** Auto-populated content is best-effort codebase analysis. Proceed without review. Content is validated and refined through convention gap tasks created by verify-pr's root-cause flywheel. |
+
+---
+
+## Define-feature (19 touchpoints)
+
+Define-feature collects strategic intent. All content-collection touchpoints remain human-driven — this is by design. An autonomous agent cannot invent product requirements.
+
+| # | Step | Current interaction | Category | Autonomous policy |
+|---|---|---|---|---|
+| 11 | Step 1 | "Are you ready to begin?" | Procedural | **Default:** skip. Proceed directly to content collection. |
+| 12 | Step 2 | Confirm or provide Feature title | Human-driven | **Human-driven.** Feature naming is a product decision. |
+| 13 | Step 3a | "Provide high-level description — the What & Why" | Human-driven | **Human-driven.** |
+| 14 | Step 3b | "How does this fit into product strategy?" | Human-driven | **Human-driven.** |
+| 15 | Step 3c | "Who benefits? Current vs. target state?" | Human-driven | **Human-driven.** |
+| 16 | Step 3d | "Which input mode: row-by-row or batch paste?" | Human-driven | **Human-driven.** |
+| 17 | Step 3d | "Add another requirement, or done?" | Human-driven | **Human-driven.** |
+| 18 | Step 3e | "Architecture characteristics and NFRs?" | Human-driven | **Human-driven.** |
+| 19 | Step 3f | "Success scenarios with personas, outcomes?" | Human-driven | **Human-driven.** |
+| 20 | Step 3g | "Prerequisites, dependencies, assumptions?" | Human-driven | **Human-driven.** |
+| 21 | Step 3h | "SRE metrics, observability, feedback?" | Human-driven | **Human-driven.** |
+| 22 | Step 3i | "Documentation impact categories?" | Human-driven | **Human-driven.** |
+| 23 | Step 4 | "Assign to yourself or leave unassigned?" | Procedural | **Default:** leave unassigned. Assignment happens when implement-task picks up the work (Step 3 of implement-task already auto-assigns). |
+| 24 | Step 5 | "Ready to create this Feature in Jira?" | Approval gate | **Human-driven.** This is the final approval for strategic content. Unlike technical approval gates, this guards product intent. Stays human-driven even in autonomous mode. |
+| 25 | Step 5 | "Which section(s) to revise?" | Human-driven | **Human-driven.** |
+| 26 | Step 5 | Re-display preview, re-ask "Ready to create?" | Approval gate | **Human-driven.** Same reasoning as #24. |
+| 27 | Step 5 | Re-collect content for revised section | Human-driven | **Human-driven.** |
+| D-A | Step 0.5 | MCP failure → "Use REST API fallback?" | Exception handling | **XC-1** (see cross-cutting). |
+| D-B | Step 0.5 | REST API credential collection | Procedural | **XC-2** (see cross-cutting). |
+
+---
+
+## Plan-feature (3 touchpoints)
+
+| # | Step | Current interaction | Category | Autonomous policy |
+|---|---|---|---|---|
+| 28 | Step 2 | Discover or request Figma URL | Procedural | **Default:** discover from skill arguments or Jira issue description. If not found, proceed without Figma analysis. Do not request. Note: the current skill already behaves this way — it never explicitly requests a Figma URL. The spec's "or request" is aspirational; the policy matches current behavior. |
+| 29 | Step 4 | "Approve impact map before task generation" | Approval gate | **Auto-proceed.** Validate: (1) every requirement from the Feature description maps to at least one change in the impact map, (2) all impacted repos are in the Repository Registry, (3) no repo outside the Registry is listed. If all three pass, proceed to task generation. If any fails, escalate (`requires-manual-review`). |
+| P-A | Step 0.5 | MCP failure → "Use REST API fallback?" | Exception handling | **XC-1** (see cross-cutting). |
+
+---
+
+## Implement-task (16 touchpoints)
+
+| # | Step | Current interaction | Category | Autonomous policy |
+|---|---|---|---|---|
+| 30 | Step 1 | "Task description missing required sections — clarify" | Exception handling | **Reject.** If required sections (Repository, Description, Files to Modify/Create, Acceptance Criteria, Test Requirements) are missing, flag `requires-manual-review` on the Jira issue and stop. The task is not ready for autonomous execution. |
+| 31 | Step 4 | "Convention conflict between task and codebase — which to follow?" | Exception handling | **Default:** follow CONVENTIONS.md. CONVENTIONS.md is the project authority for patterns and style. If the task contradicts a documented convention, follow the convention and log the deviation. If the conflict is with an undocumented codebase pattern (no CONVENTIONS.md entry), follow the task description — undocumented patterns are not binding. |
+| 32 | Step 6 | "API contract mismatch with backend — stop and report" | Exception handling | **Reject.** Do not implement with mismatched contracts. Create a sub-task on the parent Feature documenting the mismatch (affected endpoint, expected vs. actual, backend source file). Flag `requires-manual-review`. |
+| 33 | Step 9 | "Out-of-scope file modified — approve or revert?" | Exception handling | **Default:** revert out-of-scope changes, with exceptions. Auto-include if the file is: (a) a lockfile (`package-lock.json`, `Cargo.lock`, etc.), (b) a generated file from a code generation command listed in CONVENTIONS.md, or (c) a build artifact required by CI. Revert all others and log the reversion. |
+| 34 | Step 9 | "Untracked file found near modified files — stage for commit?" | Exception handling | **Default:** stage if referenced by code (compile-time includes, imports, config references found in the diff). Skip if not referenced. Log all decisions. |
+| 35 | Step 9 | "Secrets found in diff — do not proceed" | Exception handling | **Hard stop.** Remove the sensitive content from the staged diff. Do not commit. Flag `requires-manual-review`. This is non-negotiable — secrets must never be committed. |
+| 36 | Step 9 | "Data-flow trace incomplete — is missing stage intentionally out of scope?" | Exception handling | **Default:** if the missing stage is in a file listed in the task's Files to Modify/Create, implement it (the task intended it). If the missing stage is in files NOT in the task's scope, escalate (`requires-manual-review`). The task may be underspecified. |
+| 37 | Step 9 | "Sibling parity gap — is omission intentional?" | Exception handling | **Default:** implement the missing capability if it is mechanical (e.g., error handling, logging, input validation that all siblings have and requires no design decisions). Escalate if the gap requires design choices (e.g., choosing between implementation strategies, adding new API surface). |
+| 38 | Step 5 | Target PR flow depends on user-provided Target PR | Procedural | **Default:** follow the Target PR if present in the task description. Otherwise, create a new branch. The task description is authoritative — no human decision needed. |
+| I-A | Step 0.5 | MCP failure → "Use REST API fallback?" | Exception handling | **XC-1** (see cross-cutting). |
+| I-B | Step 6 | Sort order mismatch → "stop and report to user" | Exception handling | **Reject.** Same policy as #32 (API contract mismatch). Create a sub-task documenting the sort order discrepancy and escalate. Positional assumptions on unsorted data are a correctness bug. |
+| I-C | Step 9 | Cross-module shared entity anomaly → "confirm if intentional" | Exception handling | **Default:** align with the established cross-module pattern. The existing pattern is authoritative — other modules already interact with the shared entity safely. Deviating without explicit justification in the task is a defect. Log the alignment. |
+| I-D | Step 9 | Caller-site parity anomaly → "confirm if intentional" | Exception handling | **Default:** align with the established caller pattern. Same reasoning as I-C. If all existing callers use `queryClient.invalidateQueries()` and the new code uses `window.location.reload()`, the new code is wrong. Align and log. |
+| I-E | Rules | Same test fails 3× with same error → "stop and ask for guidance" | Exception handling | **Escalate.** Flag `requires-manual-review`. Three identical failures indicate a problem the agent cannot solve. Include the test name, error message, and the three attempted fixes in the escalation. |
+| I-F | Rules | Same file edited 5× for same change → "stop and present alternatives" | Exception handling | **Escalate.** Flag `requires-manual-review`. The agent is stuck in a loop. Include the file, the intended change, and the five attempts in the escalation. |
+| I-G | Rules | Build error persists after 2 fix attempts → "stop and present alternatives" | Exception handling | **Escalate.** Flag `requires-manual-review`. Include the error, the two attempted fixes, and their outcomes in the escalation. |
+
+---
+
+## Verify-pr (13 touchpoints)
+
+| # | Step | Current interaction | Category | Autonomous policy |
+|---|---|---|---|---|
+| 39 | Step 2 | "PR URL not in custom field — provide it" | Exception handling | **Default:** search for PRs on the task's branch name: `gh pr list --head <jira-issue-id> -R <owner/repo>`. If exactly one PR found, use it. If zero or multiple, escalate (`requires-manual-review`). |
+| 40 | Step 4c | Classify each comment (code change request / suggestion / question / nit) | Automated | **No change.** Already autonomous. |
+| 41 | Step 4c | Upgrade suggestion to code change request if matches CONVENTIONS.md | Automated | **No change.** Already autonomous. |
+| 42 | Step 4f | Post classification reasoning to each comment | Automated | **No change.** Already autonomous. |
+| 43 | Step 5a | "Would this knowledge apply to ANY repo, or only this one?" (universality test) | Sub-agent decision | **No change.** Already a sub-agent decision, not a human touchpoint. The universality test is a deterministic classification the sub-agent performs internally. |
+| 44 | Step 5a | "Can guidance be expressed as method without language-specific references?" (method-vs-fact) | Sub-agent decision | **No change.** Same as #43. |
+| 45 | Step 10b | Analyze CI failure logs; if inconclusive, ask user | Exception handling | **Default:** if the failure is deterministic (test assertion, compilation error, lint violation), create a sub-task with the fix. If the failure is non-deterministic or infrastructure-related (timeout, flaky test, network error, runner OOM), flag `requires-manual-review`. Heuristic: if re-running the same commit would produce the same failure, it is deterministic. |
+| 46 | Step 11 | Verify each acceptance criterion by inspecting code | Automated | **No change.** Already autonomous. |
+| 47 | Step 12 | Check for repetitive tests (Meszaros heuristic) | Automated | **No change.** Already autonomous. |
+| 48 | Step 12 | Check for doc comments on test functions | Automated | **No change.** Already autonomous. |
+| 49 | Step 14 | Compile and post verification report | Automated | **No change.** Already autonomous. |
+| 50 | Step 15 | Post report to Jira as comment | Automated | **No change.** Already autonomous. |
+| V-A | Step 0.5 | MCP failure → "Use REST API fallback?" | Exception handling | **XC-1** (see cross-cutting). |
+
+---
+
+## Summary
+
+### Revised category breakdown
+
+| Category | Count | Autonomous policy |
+|---|---|---|
+| Human-driven | 22 | Stays human-driven. All in define-feature (content collection) and setup (identity/naming). |
+| Automated | 9 | No change needed. Already runs without human input. |
+| Default | 14 | Replace with deterministic defaults. Includes all procedural prompts plus exception handling cases where the correct action is unambiguous. |
+| Auto-proceed | 3 | Replace approval gates with automated validation checks. Proceed if valid, escalate if not. |
+| Reject/Escalate | 13 | Hard stop or `requires-manual-review`. Includes secrets detection, contract mismatches, retry exhaustion, and missing prerequisites. |
+| Cross-cutting (XC-1, XC-2) | 5 + 2 | MCP fallback (auto-use REST if configured, else escalate) and credential collection (must be pre-configured, else escalate). Counted per-skill but defined once. |
+| **Total** | **66** | |
+
+### Escalation mechanism
+
+All policies that escalate use the `requires-manual-review` label on the Jira issue. This label is the single signal that autonomous execution could not complete and a human must intervene. The label should:
+
+1. Be added to the Jira issue via `jira.edit_issue(<id>, labels=["requires-manual-review"])`
+2. Include a Jira comment explaining what triggered the escalation
+3. Not be removed by any skill — only a human removes it after review
+
+### Prerequisites for autonomous execution
+
+For a task to be eligible for autonomous execution, the following must be true before the pipeline starts:
+
+1. **Project Configuration exists** — setup has been run, CLAUDE.md has all required sections
+2. **REST API credentials are configured** — if MCP is unreliable, the fallback path must work without interaction
+3. **CONVENTIONS.md exists** — either scaffolded by setup or manually created
+4. **Task description follows the template** — all required sections present (enforced by plan-feature)
+5. **Dependencies are Done** — all prerequisite tasks are completed
+
+If any prerequisite is missing, the first skill to encounter it will escalate immediately rather than attempting partial execution.

--- a/docs/specs/2026-04-21-policy-mapping.md
+++ b/docs/specs/2026-04-21-policy-mapping.md
@@ -26,6 +26,15 @@ Each touchpoint gets one of five policy types:
 
 This section explains how the policies in this document will be applied, so reviewers can evaluate each policy with the intended mechanism in mind.
 
+### fullsend references
+
+The three-layer model and enforcement concepts in this document are derived from fullsend's architecture:
+
+- [ADR 0002 — Initial fullsend design](https://github.com/fullsend-ai/fullsend/blob/main/docs/ADRs/0002-initial-fullsend-design.md) — label state machine, coordinator merge algorithm, shim dispatch
+- [ADR 0018 — Scripted pipeline for multi-agent orchestration](https://github.com/fullsend-ai/fullsend/blob/main/docs/ADRs/0018-scripted-pipeline-for-multi-agent-orchestration.md) — deterministic pipelines over LLM coordinators
+- [ADR 0020 — Composable single-responsibility agents](https://github.com/fullsend-ai/fullsend/blob/main/docs/ADRs/0020-composable-single-responsibility-agents-with-individual-sandboxes.md) — per-step agents with individual sandboxes
+- [ADR 0022 — Harness-level output schema enforcement](https://github.com/fullsend-ai/fullsend/blob/main/docs/ADRs/0022-harness-level-output-schema-enforcement.md) — validation loop with `max_iterations`, retry on schema failure
+
 ### How fullsend applies policies today
 
 Fullsend's agents run non-interactively (`claude --print --dangerously-skip-permissions --agent <agent.md>`). They never ask humans — they produce structured JSON output, and a deterministic harness decides what to do with it. Policy is enforced through three layers:

--- a/docs/specs/2026-04-21-policy-mapping.md
+++ b/docs/specs/2026-04-21-policy-mapping.md
@@ -26,39 +26,54 @@ Each touchpoint gets one of five policy types:
 
 This section explains how the policies in this document will be applied, so reviewers can evaluate each policy with the intended mechanism in mind.
 
-### Principle: skills don't decide autonomy
+### How fullsend applies policies today
 
-Following fullsend's architecture (ADR 0018 — scripted pipelines, ADR 0002 — label state machine), skills are deterministic specifications — they describe what an agent does at each step, not whether a human should be involved. The decision to prompt a human or let the agent proceed is made by the **orchestration layer** outside the skill, not by conditional branches inside it.
+Fullsend's agents run non-interactively (`claude --print --dangerously-skip-permissions --agent <agent.md>`). They never ask humans — they produce structured JSON output, and a deterministic harness decides what to do with it. Policy is enforced through three layers:
 
-This means the policies in this document are **not embedded into SKILL.md files as if/else branches**. Instead:
+1. **Agent definitions** encode what the agent should do. The agent doesn't choose between interactive and autonomous — it runs one way. Policies like "follow CONVENTIONS.md" or "reject if secrets found" are written directly into the agent's instructions.
+2. **Pre-scripts** supply context before the agent runs (reset labels, set up environment, provide credentials). They eliminate the need for the agent to ask for information.
+3. **Post-scripts** validate and gate the agent's output before mutations take effect (push code, apply labels, post comments). They enforce hard stops — e.g., blocking pushes that touch protected paths.
 
-1. **Skills stay unchanged.** Each SKILL.md continues to describe its steps as it does today — including the human interaction points. The skills don't gain a "mode" flag.
-2. **The orchestration layer consults this document.** When a pipeline invokes a skill autonomously, the pipeline is responsible for handling each touchpoint according to the policy defined here. At a touchpoint where the skill says "ask the user," the pipeline either supplies the answer prescribed by the policy (for Default and Auto-proceed types) or blocks execution and escalates (for Reject/Escalate types).
-3. **Escalation is platform-native.** The `requires-manual-review` label on a Jira issue is the escalation signal. The pipeline sets it; a human clears it. This aligns with fullsend's label state machine where labels govern workflow transitions, not agent-internal logic.
+The agent proposes; the harness disposes. There is no runtime policy engine that intercepts agent decisions — the policy is baked into how the agent is defined and what the harness allows.
+
+### What this means for sdlc-plugins
+
+sdlc-plugins' skills are fundamentally different from fullsend's agents. The skills are interactive Claude Code slash commands with ~66 human touchpoints — places where the skill stops and asks the user. Fullsend's agents have zero touchpoints by design; all input is pre-supplied via context.
+
+To make sdlc-plugins skills autonomous, the policies in this document would be applied through the same three-layer model:
+
+| Layer | What it does | Example from this document |
+|---|---|---|
+| **Agent definition** | Rewrite interactive touchpoints as deterministic instructions. Where the skill currently says "ask the user," the autonomous agent definition says what to do. | Touchpoint #31: instead of "ask user which convention to follow," the agent definition says "follow CONVENTIONS.md; it is the project authority." |
+| **Pre-script** | Supply context the agent needs so it doesn't have to ask. Set up environment, provide credentials, prepare inputs. | XC-1/XC-2: pre-script configures REST API credentials from the policy store, so the agent never encounters the MCP fallback prompt. |
+| **Post-script** | Validate the agent's output and gate mutations. Enforce hard stops that the agent cannot bypass. | Touchpoint #35: post-script scans the diff for secrets and blocks the commit regardless of what the agent decided. |
+
+This means the skills **do change** for autonomous use — but not by adding conditional branches. Instead, a separate autonomous agent definition is created for each skill, encoding the policies from this document as direct instructions. The interactive SKILL.md files stay unchanged for human use. The harness decides which definition to load based on the invocation context.
 
 ### Relationship to fullsend concepts
 
 | This document | fullsend equivalent |
 |---|---|
-| Human-driven touchpoints (define-feature) | Tier 2/3 intent — requires human authorization |
-| Default policies | Standing rules (Tier 0) — pre-authorized, no intent needed |
-| Auto-proceed policies | Tier 1 tactical — issue is sufficient intent, proceed if validation passes |
-| Reject/Escalate policies | `requires-manual-review` label — split verdict or safety concern |
-| Escalation mechanism | Label state machine transition to blocked state |
+| Human-driven touchpoints (define-feature) | Tier 2/3 intent — requires human authorization; no autonomous agent definition needed |
+| Default policies | Encoded in the autonomous agent definition as direct instructions |
+| Auto-proceed policies | Encoded in the agent definition + validated by post-script |
+| Reject/Escalate policies | Hard stops in the post-script; `requires-manual-review` label via post-script |
+| Escalation mechanism | Post-script applies label and blocks further pipeline stages |
+| Cross-cutting policies (XC-1, XC-2) | Pre-script supplies credentials and context before agent runs |
 
 ### What reviewers should evaluate
 
 For each policy, reviewers should ask:
 
-1. **Is the autonomous action safe?** Could it produce an irreversible bad outcome (data loss, security exposure, broken production)? If yes, the policy should escalate rather than auto-proceed.
+1. **Is the autonomous action safe?** Could it produce an irreversible bad outcome (data loss, security exposure, broken production)? If yes, the policy should be enforced by the post-script (hard stop), not just the agent definition (which an LLM could deviate from).
 2. **Is the autonomous action correct?** Does the deterministic default match what an experienced engineer would decide in >90% of cases? Edge cases should escalate, not guess.
-3. **Is the policy enforceable by an orchestration layer?** Could a scripted pipeline unambiguously apply this policy at the touchpoint without LLM judgment, or does it require interpretation that only the skill's agent could provide? Policies that require interpretation should be decomposed into deterministic checks.
+3. **Which layer should enforce it?** Agent definition (soft — the LLM follows instructions), pre-script (context setup — deterministic), or post-script (hard gate — deterministic and non-bypassable)? Safety-critical policies (#35 secrets, #32 API mismatches) must be post-script enforced. Procedural defaults (#8 scaffold CONVENTIONS.md) can be agent-definition only.
 
 ### What this document is NOT
 
-- **Not a skill modification.** The policies are consumed by the orchestration layer, not compiled into skill instructions. Skills remain the same for interactive use.
-- **Not a policy engine.** This document defines the policies; deliverable #12 (90-day phase — Policy Engine Integration) builds the mechanism that reads and enforces them at runtime.
-- **Not changing interactive mode.** When a human runs `/implement-task`, the skill behaves exactly as it does today. These policies only apply when an automated pipeline invokes the skill.
+- **Not a runtime policy engine.** The policies are compiled into autonomous agent definitions and harness scripts at authoring time, not evaluated at runtime by a policy service.
+- **Not changing interactive skills.** The SKILL.md files stay unchanged. The autonomous agent definitions are separate artifacts that encode these policies as direct instructions.
+- **Not yet implemented.** The autonomous agent definitions and harness scripts do not exist yet. This document defines the policies; the implementation creates the corresponding agent definitions, pre-scripts, and post-scripts — following fullsend's three-layer model.
 
 ---
 

--- a/docs/specs/2026-04-21-policy-mapping.md
+++ b/docs/specs/2026-04-21-policy-mapping.md
@@ -26,16 +26,25 @@ Each touchpoint gets one of five policy types:
 
 This section explains how the policies in this document will be applied, so reviewers can evaluate each policy with the intended mechanism in mind.
 
-### Mechanism: conditional behavior in SKILL.md
+### Principle: skills don't decide autonomy
 
-Each policy will be embedded directly into the corresponding skill's SKILL.md as a conditional branch at the touchpoint where the human interaction currently occurs. The skills will gain an **execution mode** — `interactive` (current behavior, human-in-the-loop) or `autonomous` (policy-driven, no human prompts). The mode is determined by the caller: a human running `/implement-task` operates in interactive mode; an automated pipeline triggering the same skill operates in autonomous mode.
+Following fullsend's architecture (ADR 0018 — scripted pipelines, ADR 0002 — label state machine), skills are deterministic specifications — they describe what an agent does at each step, not whether a human should be involved. The decision to prompt a human or let the agent proceed is made by the **orchestration layer** outside the skill, not by conditional branches inside it.
 
-At each touchpoint, the skill instructions will read:
+This means the policies in this document are **not embedded into SKILL.md files as if/else branches**. Instead:
 
-> **Interactive mode:** \<current behavior — ask the user\>
-> **Autonomous mode:** \<policy from this document\>
+1. **Skills stay unchanged.** Each SKILL.md continues to describe its steps as it does today — including the human interaction points. The skills don't gain a "mode" flag.
+2. **The orchestration layer consults this document.** When a pipeline invokes a skill autonomously, the pipeline is responsible for handling each touchpoint according to the policy defined here. At a touchpoint where the skill says "ask the user," the pipeline either supplies the answer prescribed by the policy (for Default and Auto-proceed types) or blocks execution and escalates (for Reject/Escalate types).
+3. **Escalation is platform-native.** The `requires-manual-review` label on a Jira issue is the escalation signal. The pipeline sets it; a human clears it. This aligns with fullsend's label state machine where labels govern workflow transitions, not agent-internal logic.
 
-This is a mechanical transformation — the policies below are the autonomous-mode instructions that get inserted alongside the existing interactive-mode instructions. No new infrastructure is needed; the skills are natural language specifications, and the conditional is just another paragraph.
+### Relationship to fullsend concepts
+
+| This document | fullsend equivalent |
+|---|---|
+| Human-driven touchpoints (define-feature) | Tier 2/3 intent — requires human authorization |
+| Default policies | Standing rules (Tier 0) — pre-authorized, no intent needed |
+| Auto-proceed policies | Tier 1 tactical — issue is sufficient intent, proceed if validation passes |
+| Reject/Escalate policies | `requires-manual-review` label — split verdict or safety concern |
+| Escalation mechanism | Label state machine transition to blocked state |
 
 ### What reviewers should evaluate
 
@@ -43,13 +52,13 @@ For each policy, reviewers should ask:
 
 1. **Is the autonomous action safe?** Could it produce an irreversible bad outcome (data loss, security exposure, broken production)? If yes, the policy should escalate rather than auto-proceed.
 2. **Is the autonomous action correct?** Does the deterministic default match what an experienced engineer would decide in >90% of cases? Edge cases should escalate, not guess.
-3. **Is the boundary between interactive and autonomous clear?** Could an implementer read the policy and unambiguously translate it into a skill instruction, or is it vague enough to invite interpretation?
+3. **Is the policy enforceable by an orchestration layer?** Could a scripted pipeline unambiguously apply this policy at the touchpoint without LLM judgment, or does it require interpretation that only the skill's agent could provide? Policies that require interpretation should be decomposed into deterministic checks.
 
 ### What this document is NOT
 
-- **Not a policy engine.** There is no runtime that evaluates policies. The policies are compiled into skill instructions at authoring time.
-- **Not a permissions system.** The execution mode is not configurable per-repo or per-team yet. That is deliverable #12 (90-day phase — Policy Engine Integration), which builds on this document.
-- **Not changing interactive mode.** Every policy preserves the current human-driven behavior as the interactive-mode path. Nothing changes for users running skills manually.
+- **Not a skill modification.** The policies are consumed by the orchestration layer, not compiled into skill instructions. Skills remain the same for interactive use.
+- **Not a policy engine.** This document defines the policies; deliverable #12 (90-day phase — Policy Engine Integration) builds the mechanism that reads and enforces them at runtime.
+- **Not changing interactive mode.** When a human runs `/implement-task`, the skill behaves exactly as it does today. These policies only apply when an automated pipeline invokes the skill.
 
 ---
 

--- a/docs/specs/2026-04-21-policy-mapping.md
+++ b/docs/specs/2026-04-21-policy-mapping.md
@@ -22,6 +22,37 @@ Each touchpoint gets one of five policy types:
 
 ---
 
+## Application Strategy
+
+This section explains how the policies in this document will be applied, so reviewers can evaluate each policy with the intended mechanism in mind.
+
+### Mechanism: conditional behavior in SKILL.md
+
+Each policy will be embedded directly into the corresponding skill's SKILL.md as a conditional branch at the touchpoint where the human interaction currently occurs. The skills will gain an **execution mode** — `interactive` (current behavior, human-in-the-loop) or `autonomous` (policy-driven, no human prompts). The mode is determined by the caller: a human running `/implement-task` operates in interactive mode; an automated pipeline triggering the same skill operates in autonomous mode.
+
+At each touchpoint, the skill instructions will read:
+
+> **Interactive mode:** \<current behavior — ask the user\>
+> **Autonomous mode:** \<policy from this document\>
+
+This is a mechanical transformation — the policies below are the autonomous-mode instructions that get inserted alongside the existing interactive-mode instructions. No new infrastructure is needed; the skills are natural language specifications, and the conditional is just another paragraph.
+
+### What reviewers should evaluate
+
+For each policy, reviewers should ask:
+
+1. **Is the autonomous action safe?** Could it produce an irreversible bad outcome (data loss, security exposure, broken production)? If yes, the policy should escalate rather than auto-proceed.
+2. **Is the autonomous action correct?** Does the deterministic default match what an experienced engineer would decide in >90% of cases? Edge cases should escalate, not guess.
+3. **Is the boundary between interactive and autonomous clear?** Could an implementer read the policy and unambiguously translate it into a skill instruction, or is it vague enough to invite interpretation?
+
+### What this document is NOT
+
+- **Not a policy engine.** There is no runtime that evaluates policies. The policies are compiled into skill instructions at authoring time.
+- **Not a permissions system.** The execution mode is not configurable per-repo or per-team yet. That is deliverable #12 (90-day phase — Policy Engine Integration), which builds on this document.
+- **Not changing interactive mode.** Every policy preserves the current human-driven behavior as the interactive-mode path. Nothing changes for users running skills manually.
+
+---
+
 ## Cross-Cutting Policies
 
 These policies apply identically in every skill where the touchpoint appears.


### PR DESCRIPTION
Readable version https://github.com/mrizzi/sdlc-plugins/blob/TC-4178/docs/specs/2026-04-21-policy-mapping.md

## Summary
- Audited all 5 sdlc-workflow skills against the autonomous readiness plan's touchpoint inventory
- Found 66 touchpoints (16 more than the plan's ~50 estimate) — new ones from MCP fallback flows and implement-task self-verification
- Defined per-touchpoint autonomous policies: 22 human-driven, 9 already automated, 14 deterministic defaults, 3 auto-proceed, 13 reject/escalate, 7 cross-cutting
- Deliverable #1 of the [Autonomous Readiness Plan](docs/superpowers/specs/2026-04-14-autonomous-readiness-plan.md) 30-day phase

Implements [TC-4178](https://redhat.atlassian.net/browse/TC-4178)

## Test plan
- [ ] Review policy mapping completeness against current SKILL.md files
- [ ] Verify cross-cutting policies (XC-1, XC-2, XC-3) cover all skill occurrences
- [ ] Confirm escalation mechanism (`requires-manual-review`) is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document autonomous policy mappings for all human interaction touchpoints across the five SDLC workflow skills to support autonomous skill execution.

Documentation:
- Add a policy mapping spec that classifies 66 SDLC workflow touchpoints and assigns autonomous policies or confirms they remain human-driven.
- Define cross-cutting MCP/REST fallback, credential, and project configuration policies shared across skills.
- Document per-skill autonomous behavior for setup, define-feature, plan-feature, implement-task, and verify-pr, including escalation via the requires-manual-review label and prerequisites for autonomous execution.