### PR TITLE
fix(ci): add pull-rebase retry loop to eval-baseline push

### DIFF
--- a/.github/workflows/eval-baseline.yml
+++ b/.github/workflows/eval-baseline.yml
@@ -113,7 +113,10 @@ jobs:
               exit 0
             fi
             echo "Push failed (attempt ${attempt}/3), rebasing on latest main..."
-            git pull --rebase origin main
+            if ! git pull --rebase origin main; then
+              echo "::error::Rebase failed on attempt ${attempt} — manual intervention required"
+              exit 1
+            fi
           done
           echo "::error::Push failed after 3 attempts"
           exit 1

--- a/.github/workflows/eval-baseline.yml
+++ b/.github/workflows/eval-baseline.yml
@@ -104,7 +104,16 @@ jobs:
           git add evals/*/baselines/
           if git diff --cached --quiet; then
             echo "No baseline changes to commit"
-          else
-            git commit -m "chore(evals): create baselines for ${{ steps.discover.outputs.commit_hash }}"
-            git push
+            exit 0
           fi
+          git commit -m "chore(evals): create baselines for ${{ steps.discover.outputs.commit_hash }}"
+          for attempt in 1 2 3; do
+            if git push; then
+              echo "Push succeeded on attempt ${attempt}"
+              exit 0
+            fi
+            echo "Push failed (attempt ${attempt}/3), rebasing on latest main..."
+            git pull --rebase origin main
+          done
+          echo "::error::Push failed after 3 attempts"
+          exit 1


### PR DESCRIPTION
## Summary

- The `eval-baseline` workflow's `git push` fails when `main` receives commits during the long-running eval job ([failed run](https://github.com/mrizzi/sdlc-plugins/actions/runs/24844922234/job/72729159944))
- Replaces the bare `git push` with a retry loop: up to 3 attempts, each preceded by `git pull --rebase origin main`
- Safe because baseline commits only touch `evals/*/baselines/` — no other workflow writes there, so rebases will never conflict

## Test plan

- [ ] Merge another commit to `main` while `eval-baseline` is running to confirm the retry succeeds
- [ ] Verify the workflow still skips cleanly when there are no baseline changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update eval-baseline workflow to retry git push up to three times with git pull --rebase origin main between attempts, and to exit early when no baseline changes are detected.