### PR TITLE
fix(implement-task): strengthen §1.6 to explicitly stop on incomplete input

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -15,7 +15,7 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 1.3 | `plan-feature` output goes to Jira (tasks, comments) — never to the filesystem. | `plan-feature/SKILL.md` — Guardrails |
 | 1.4 | `implement-task` MUST keep changes scoped to what the task describes — no unrelated refactoring. | `implement-task/SKILL.md` — Important Rules |
 | 1.5 | `implement-task` MUST NOT guess code structure — it must inspect code before modifying it using Serena or Read/Grep/Glob. | `implement-task/SKILL.md` — Important Rules |
-| 1.6 | `implement-task` MUST ask the user rather than improvising when the structured description is incomplete. | `implement-task/SKILL.md` — Important Rules |
+| 1.6 | `implement-task` MUST ask the user for clarification and stop execution when the structured description is incomplete — it MUST NOT draft an implementation plan or proceed with any subsequent steps until the user responds. | `implement-task/SKILL.md` — Important Rules, Step 1 |
 | 1.7 | `define-feature` MUST NOT modify, create, or delete any files in any repository. Only Jira MCP tools are permitted for output. | `define-feature/SKILL.md` — Guardrails |
 | 1.8 | `define-feature` MUST NOT fabricate content. All Feature description content must come from user input. | `define-feature/SKILL.md` — Guardrails |
 | 1.9 | `define-feature` MUST NOT create a Jira issue without showing a full preview and receiving explicit user approval. | `define-feature/SKILL.md` — Important Rules |
@@ -92,7 +92,7 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 Each constraint above references its source. The full source files are:
 
 - `plugins/sdlc-workflow/skills/plan-feature/SKILL.md` — Guardrails (§1.1–1.3), Task Description Template (§4.1–4.10), Step 5 Convention-aware task enrichment (§4.11)
-- `plugins/sdlc-workflow/skills/implement-task/SKILL.md` — Important Rules (§1.4–1.6, §5.1–5.3), Step 4/6/9 (§5.4), Step 5 (§1.15, §3.1), Step 7 (§5.9–5.13), Step 9 (§2.1–2.3, §5.6–5.8), Step 10 (§3.2)
+- `plugins/sdlc-workflow/skills/implement-task/SKILL.md` — Important Rules (§1.4–1.6, §5.1–5.3), Step 1 (§1.6), Step 4/6/9 (§5.4), Step 5 (§1.15, §3.1), Step 7 (§5.9–5.13), Step 9 (§2.1–2.3, §5.6–5.8), Step 10 (§3.2)
 - `plugins/sdlc-workflow/skills/verify-pr/SKILL.md` — Step 4 (§1.10, §1.12), Important Rules (§1.11, §1.13), Step 5b (§1.14), Step 12 (§1.16, §1.17)
 - `plugins/sdlc-workflow/skills/define-feature/SKILL.md` — Guardrails (§1.7–1.8), Important Rules (§1.9)
 - `docs/methodology.md` — Core Principles (§2.1, §3.2, §5.5)

--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -142,7 +142,10 @@ Steps 5, 10, and 11.
 When Target PR is present, the task is a review feedback fix — the implementation adds
 commits to the existing PR branch instead of creating a new branch and PR.
 
-If any required section is missing or the description doesn't follow the template, stop and ask the user for clarification.
+If any required section is missing or the description doesn't follow the template, list the
+gaps, ask the user for clarification, and **stop execution immediately** — do not proceed
+with any subsequent steps (branching, implementation planning, code changes) until the user
+provides the missing information.
 
 ### GitHub Issue extraction
 
@@ -951,7 +954,7 @@ jira.transition_issue → In Review
 
 - Do not guess — use the Serena instance specified in the project's **Repository Registry** (CLAUDE.md) for the target repo, with tools like `get_symbols_overview`, `find_symbol`, `find_referencing_symbols` to inspect code before modifying it. Check the **Code Intelligence** section for per-instance limitations. Fall back to Read/Grep/Glob for repos without a Serena instance.
 - Follow the Implementation Notes closely — they reference real code patterns.
-- If the structured description is incomplete, ask the user rather than improvising.
+- If the structured description is incomplete, ask the user for clarification and **stop execution**. Do not draft an implementation plan, create branches, or proceed with any subsequent steps until the user provides the missing information.
 - Keep changes scoped to what the task describes — no unrelated refactoring.
 - Every commit must reference the Jira issue ID.
 - If the same test fails 3 times with the same error, stop and ask the user for guidance — do not retry the same approach.


### PR DESCRIPTION
## Summary
- Strengthened the `implement-task` Important Rules bullet for incomplete descriptions to explicitly require **stopping execution** — not just asking questions
- Reinforced Step 1's "stop and ask" instruction to clarify that "stop" means halt all subsequent steps (branching, planning, code changes)
- Updated `constraints.md` §1.6 and its Traceability Index to match the strengthened language

Implements [TC-4232](https://redhat.atlassian.net/browse/TC-4232)

## Test plan
- [x] Eval-2 (incomplete task) passes — skill stops after asking questions without drafting a plan
- [x] All 4 implement-task evals pass with 100% pass rate (matching baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)