### PR TITLE
feat(plan-feature): add eval coverage detection to task generation

### DIFF
--- a/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
@@ -381,6 +381,7 @@ on the backend repo to locate route definitions and type definitions.
 - Search for reusable utilities, helpers, and shared modules that overlap with the planned feature — flag these as reuse opportunities in Implementation Notes rather than planning new code that duplicates them
 - Perform a systematic duplication-risk scan: for each planned change in the impact map, search for existing domain logic, similar components, and algorithmic patterns — not just utilities — that overlap with the planned work. Use `find_symbol`, `search_for_pattern`, or Grep to locate candidates. Record matches as reuse candidates for inclusion in the task description's **Reuse Candidates** section
 - Identify documentation files that may need updating when the feature changes public APIs, configuration, setup steps, or architectural patterns
+- Detect eval infrastructure for skills being modified: when a planned change targets a skill's `SKILL.md` (under `plugins/<plugin>/skills/<skill-name>/`), check whether `evals/<skill-name>/` exists. If found, record the eval directory and its contents (e.g., `evals.json`, fixture files in `files/`) as eval infrastructure that will need coverage updates in generated tasks
 
 ## Step 4 – Build Repository Impact Map
 
@@ -455,6 +456,50 @@ This applies equally to any convention pattern — error handling strategies, na
 test structure, API design patterns, logging conventions, etc. The goal is to make every
 relevant convention explicit in the task description rather than relying on the implementer
 to independently discover and apply it.
+
+### Eval coverage propagation
+
+When a task modifies a skill's `SKILL.md`, check whether eval infrastructure exists for
+that skill and propagate eval coverage requirements into the task description. This ensures
+that skill behavior changes are accompanied by eval assertion updates, preventing gaps
+where new behavior ships without eval coverage.
+
+**How to apply:**
+
+1. For each task, check whether its **Files to Modify** includes a file matching the
+   pattern `plugins/<plugin>/skills/<skill-name>/SKILL.md`.
+2. If it does, check whether `evals/<skill-name>/evals.json` exists (using the eval
+   infrastructure detected during Step 3's repository analysis).
+3. If eval infrastructure exists, enrich the task description:
+   - Add `evals/<skill-name>/evals.json` to **Files to Modify** with the reason:
+     "add or update eval assertions to cover the new behavior"
+   - Add to **Test Requirements**: "Update eval assertions in
+     `evals/<skill-name>/evals.json` to cover the behavior changes introduced by
+     this task. Add new eval cases if existing cases do not exercise the modified
+     behavior, or update assertions on existing cases if their expected output changes."
+   - Add existing eval fixture files (from `evals/<skill-name>/files/`) to
+     **Reuse Candidates** so the implementer follows the established fixture patterns.
+     List 2–3 representative fixture files with a brief description of what each
+     demonstrates (e.g., a passing scenario, a failing scenario, a scenario with
+     review comments).
+
+**Example — verify-pr skill with existing evals:**
+
+When a task modifies `plugins/sdlc-workflow/skills/verify-pr/SKILL.md` and
+`evals/verify-pr/evals.json` exists:
+
+> **Files to Modify** (appended):
+> - `evals/verify-pr/evals.json` — add or update eval assertions to cover the new behavior
+>
+> **Test Requirements** (appended):
+> - [ ] Update eval assertions in `evals/verify-pr/evals.json` to cover the behavior
+>   changes introduced by this task
+>
+> **Reuse Candidates** (appended):
+> - `evals/verify-pr/files/task-passing.md` — example task fixture for a passing
+>   verification scenario
+> - `evals/verify-pr/files/pr-diff-passing.md` — example PR diff fixture for a
+>   passing scenario
 
 ### Backend API contract enrichment for manual REST calls
 


### PR DESCRIPTION
## Summary
- Add eval infrastructure detection goal to plan-feature Step 3 (Repository Analysis)
- Add eval coverage propagation subsection to plan-feature Step 5 (Generate Tasks) that enriches task descriptions with `evals/<skill-name>/evals.json` in Files to Modify, eval assertion updates in Test Requirements, and fixture files in Reuse Candidates when a task modifies a skill's SKILL.md

## Test plan
- [ ] Manual verification: read updated plan-feature SKILL.md and confirm eval detection logic is present in Steps 3 and 5
- [ ] Verify example file references (`evals/verify-pr/evals.json`, `evals/verify-pr/files/task-passing.md`, `evals/verify-pr/files/pr-diff-passing.md`) exist in repo

Implements [TC-4237](https://redhat.atlassian.net/browse/TC-4237)

## Summary by Sourcery

Document eval infrastructure detection and eval coverage propagation in the plan-feature skill to ensure SKILL.md changes include corresponding eval updates.

Documentation:
- Extend repository analysis guidance to detect eval infrastructure associated with modified skills and record it for later use.
- Add instructions for propagating eval coverage requirements into generated tasks when a skill's SKILL.md is modified, including updating eval assertions and reusing existing fixtures.