### PR TITLE
feat(implement-task): add eval coverage currency check to Step 9

### DIFF
--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -620,6 +620,33 @@ If a doc file describes behavior that was changed and was not already updated in
 Step 6, update it now. This check is lightweight — only flag docs that directly
 describe the modified behavior.
 
+### Eval coverage currency
+
+If any modified file is a skill's `SKILL.md`, check whether corresponding eval
+coverage exists and is current:
+
+1. **Detect skill changes**: scan the `git diff --name-only` output for files
+   matching the pattern `skills/<skill-name>/SKILL.md`.
+2. **Derive skill name**: extract `<skill-name>` from the file path.
+3. **Check for eval infrastructure**: look for `evals/<skill-name>/evals.json`
+   in the repository. If the file does not exist, skip silently — not all skills
+   have eval suites.
+4. **Identify new behavior**: if `evals.json` exists, compare the SKILL.md diff
+   (`git diff` on the file) against the existing eval assertions. Look for new
+   behavior introduced in the SKILL.md that would be observable in eval outputs:
+   - New steps or sub-steps
+   - New report rows, classification outcomes, or verification checks
+   - Changed output formats or new output sections
+   - New decision branches (conditions that change which action the skill takes)
+5. **Flag coverage gaps**: for each new behavior that has no corresponding
+   assertion in `evals.json`, report the gap to the user. Include:
+   - The new behavior (quote the relevant SKILL.md diff)
+   - Which eval scenarios could cover it
+   - Whether an existing eval could be extended or a new one is needed
+6. **Ask, don't block**: present the gaps and ask the user whether to add eval
+   coverage now, defer it, or skip. Do **not** auto-create eval files or block
+   the commit — this is advisory, like Documentation currency.
+
 ### Example consistency
 
 If the implementation wrote or modified documentation that includes examples combining


### PR DESCRIPTION
## Summary
- Add "Eval coverage currency" sub-section to implement-task Step 9 (Self-Verification), placed after the existing Documentation currency check
- When a skill's SKILL.md is modified and `evals/<skill-name>/evals.json` exists, the check verifies new behavior has corresponding eval assertions
- Advisory only — flags gaps and asks the user, does not block or auto-create files

Implements [TC-4239](https://redhat.atlassian.net/browse/TC-4239)

## Test plan
- [ ] Read the updated SKILL.md and confirm the eval coverage currency check follows the Documentation currency pattern
- [ ] Verify the sub-section is positioned after Documentation currency and before Example consistency
- [ ] Verify the check describes a 6-step process: detect, derive, lookup, identify, flag, ask

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add an advisory eval coverage currency check to the implement-task skill’s self-verification step when SKILL.md changes are detected.

New Features:
- Introduce an eval coverage currency sub-section in implement-task Step 9 to ensure SKILL.md changes are reflected in existing eval suites when present.

Enhancements:
- Align eval coverage guidance with the existing documentation currency pattern, including user-facing prompts that highlight coverage gaps without blocking changes.