### PR TITLE
fix(ci): auto-resolve latest symlink conflicts in eval-baseline rebase

### DIFF
--- a/.github/workflows/eval-baseline.yml
+++ b/.github/workflows/eval-baseline.yml
@@ -114,8 +114,9 @@ jobs:
             fi
             echo "Push failed (attempt ${attempt}/3), rebasing on latest main..."
             if ! git pull --rebase -X theirs origin main; then
-              # Resolve any remaining 'latest' symlink conflicts (ours is always newer after rebase)
-              for conflict in $(git diff --name-only --diff-filter=U 2>/dev/null); do
+              # In rebase, --theirs = the commit being replayed (our local baseline commit).
+              # Resolve 'latest' symlink conflicts in favor of our commit since it's newer.
+              while IFS= read -r conflict; do
                 case "$conflict" in
                   evals/*/baselines/latest)
                     git checkout --theirs "$conflict"
@@ -127,7 +128,7 @@ jobs:
                     exit 1
                     ;;
                 esac
-              done
+              done < <(git diff --name-only --diff-filter=U 2>/dev/null)
               if ! git rebase --continue --no-edit 2>/dev/null; then
                 echo "::error::Rebase --continue failed on attempt ${attempt}"
                 git rebase --abort 2>/dev/null || true

--- a/.github/workflows/eval-baseline.yml
+++ b/.github/workflows/eval-baseline.yml
@@ -113,9 +113,26 @@ jobs:
               exit 0
             fi
             echo "Push failed (attempt ${attempt}/3), rebasing on latest main..."
-            if ! git pull --rebase origin main; then
-              echo "::error::Rebase failed on attempt ${attempt} — manual intervention required"
-              exit 1
+            if ! git pull --rebase -X theirs origin main; then
+              # Resolve any remaining 'latest' symlink conflicts (ours is always newer after rebase)
+              for conflict in $(git diff --name-only --diff-filter=U 2>/dev/null); do
+                case "$conflict" in
+                  evals/*/baselines/latest)
+                    git checkout --theirs "$conflict"
+                    git add "$conflict"
+                    ;;
+                  *)
+                    echo "::error::Unexpected conflict in ${conflict} on attempt ${attempt}"
+                    git rebase --abort 2>/dev/null || true
+                    exit 1
+                    ;;
+                esac
+              done
+              if ! git rebase --continue --no-edit 2>/dev/null; then
+                echo "::error::Rebase --continue failed on attempt ${attempt}"
+                git rebase --abort 2>/dev/null || true
+                exit 1
+              fi
             fi
           done
           echo "::error::Push failed after 3 attempts"


### PR DESCRIPTION
## Summary
- Fixes eval-baseline CI job failure caused by race condition when two pushes to main trigger concurrent baseline jobs ([failed run](https://github.com/mrizzi/sdlc-plugins/actions/runs/24897013625/job/72904430885))
- The `evals/*/baselines/latest` symlinks conflict during rebase because both jobs update the same files
- Adds `-X theirs` to the rebase strategy and a fallback that explicitly resolves symlink conflicts while failing hard on unexpected ones

## Test plan
- [ ] Push two rapid commits to main that touch skill files — verify the second baseline job's rebase succeeds
- [ ] Verify unexpected (non-symlink) conflicts still cause the job to fail with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve eval-baseline workflow robustness when rebasing concurrent baseline updates on main.

Bug Fixes:
- Handle eval-baseline CI job failures caused by rebase conflicts when concurrent pushes update baseline symlinks.

CI:
- Update eval-baseline workflow rebase step to prefer remote changes and auto-resolve expected 'latest' symlink conflicts while failing on unexpected ones.