### PR TITLE
docs(verify-pr): add dispatch and finding templates for sub-agent contracts

### DIFF
--- a/plugins/sdlc-workflow/skills/verify-pr/dispatch-template.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/dispatch-template.md
@@ -1,0 +1,68 @@
+# Dispatch Template
+
+Structured input template for dispatching domain sub-agents during verify-pr
+execution. The orchestrator constructs one dispatch envelope per sub-agent,
+filling in the sections below. All sub-agents receive the same envelope
+structure; the Agent-Specific Inputs section varies per agent.
+
+## Template
+
+````markdown
+## Sub-Agent Dispatch: <agent name>
+
+### Context
+- **Jira Task:** <task key>
+- **PR:** <PR URL>
+- **Branch:** <branch name>
+- **Base Branch:** <base branch name>
+
+### Classified Review Comments
+
+<all classified comments with IDs, classifications, and file/line references>
+
+### Agent-Specific Inputs
+
+<varies per agent -- see Agent-Specific Input Sections below>
+
+### Instructions
+
+<sub-agent skill file content>
+
+### Output Template
+
+<finding-template.md content>
+````
+
+## Agent-Specific Input Sections
+
+### Intent Alignment
+
+- `### PR Diff Summary` — file list with per-file line counts (additions/deletions), not full diff content
+- `### Task Specification` — Repository, Files to Modify, Files to Create sections from Jira task description
+- `### Jira Task ID` — the task key for commit traceability checking
+- `### PR Commits` — commit list with hashes and messages
+
+### Security
+
+- `### PR Diff` — full diff content for line-level pattern scanning
+
+### Correctness
+
+- `### PR Diff` — full diff content for code inspection
+- `### Task Specification` — Acceptance Criteria, Test Requirements, Verification Commands sections from Jira task description
+- `### Repository Info` — repository path and Serena instance info for code inspection
+- `### CI Status` — note to fetch CI status via `gh` CLI (not pre-fetched; sub-agent fetches on demand)
+
+### Style/Conventions
+
+- `### PR Diff` — full diff content for code inspection
+- `### CONVENTIONS.md` — full content of the repository's CONVENTIONS.md
+- `### Test Files` — list of modified/deleted test file paths
+- `### Branch Names` — base branch and PR branch names for test change classification sub-agent
+
+## Rules
+
+- Context section and Classified Review Comments are mandatory for all sub-agents
+- Agent-Specific Inputs section includes only the sections listed for that sub-agent
+- Instructions section contains the full content of the sub-agent's skill file (e.g., `intent-alignment.md`)
+- Output Template section contains the full content of `finding-template.md`

--- a/plugins/sdlc-workflow/skills/verify-pr/finding-template.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/finding-template.md
@@ -1,0 +1,66 @@
+# Finding Template
+
+Structured output template for domain sub-agent results during verify-pr
+execution. Each sub-agent returns its analysis using this template. The
+orchestrator expects this exact structure.
+
+## Template
+
+````markdown
+## Verdicts
+
+| Check | Verdict | Summary |
+|---|---|---|
+| <check name> | <PASS|WARN|FAIL|N/A> | <one-line summary> |
+
+## Findings
+
+### <check name> -- <PASS|WARN|FAIL|N/A>
+
+**Details:** <what was found>
+
+**Evidence:**
+- <file path, line number, command output, or other concrete evidence>
+
+**Related review comments:** <comment IDs, or "none">
+
+## Actions
+
+### <action type>: <short title>
+
+**Type:** <create-sub-task | upgrade-comment>
+**Details:** <action-specific fields>
+````
+
+## Action Type Fields
+
+### create-sub-task
+
+Used when a check identifies an issue requiring tracked work (e.g., CI
+failures, acceptance criteria gaps).
+
+```markdown
+**Type:** create-sub-task
+**Title:** <suggested sub-task title>
+**Relevant files:** <file paths>
+**Root cause:** <what caused the issue>
+```
+
+### upgrade-comment
+
+Used when a classified suggestion matches a CONVENTIONS.md pattern, warranting
+escalation to a code change request.
+
+```markdown
+**Type:** upgrade-comment
+**Comment ID:** <PR comment ID>
+**Original classification:** suggestion
+**Matching convention:** <the CONVENTIONS.md section that matches>
+```
+
+## Rules
+
+- Verdicts table is mandatory, even if all checks are PASS
+- Findings section includes one subsection per check; PASS checks get a brief confirmation, non-PASS checks get full evidence
+- Actions section is omitted entirely if there are no actions (not an empty section -- omitted)
+- The template is the same for all 4 sub-agents; each fills in its own checks


### PR DESCRIPTION
## Summary
- Add `dispatch-template.md` — structured input envelope the orchestrator passes to each domain sub-agent (Context, Classified Review Comments, Agent-Specific Inputs, Instructions, Output Template)
- Add `finding-template.md` — structured output contract each sub-agent returns (Verdicts table, Findings per check, optional Actions with create-sub-task and upgrade-comment types)
- Documents agent-specific input sections for all 4 sub-agents: Intent Alignment, Security, Correctness, Style/Conventions

Implements [TC-4248](https://redhat.atlassian.net/browse/TC-4248)

## Test plan
- [ ] Template markdown renders correctly on GitHub
- [ ] Template section names match the design spec (`docs/specs/2026-04-24-verify-pr-decomposition-design.md`)
- [ ] dispatch-template.md contains all 5 sections and all 4 agent-specific input blocks
- [ ] finding-template.md contains Verdicts, Findings, Actions sections and both action types
- [ ] Both templates include Rules sections for mandatory/optional behavior

## Summary by Sourcery

Document structured dispatch and finding templates for verify-pr sub-agents, defining their input envelopes, output contracts, and shared rules across domain agents.

Documentation:
- Add dispatch-template.md describing the standardized input envelope and agent-specific input sections for verify-pr sub-agents.
- Add finding-template.md defining the structured output contract, including verdicts, findings, and optional actions with supported action types.
- Document mandatory vs optional sections and rules governing how orchestrator and sub-agents use these templates.