### PR TITLE
docs(constraints): re-scope verify-pr constraints for sub-agent decomposition

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -19,18 +19,23 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 1.7 | `define-feature` MUST NOT modify, create, or delete any files in any repository. Only Jira MCP tools are permitted for output. | `define-feature/SKILL.md` — Guardrails |
 | 1.8 | `define-feature` MUST NOT fabricate content. All Feature description content must come from user input. | `define-feature/SKILL.md` — Guardrails |
 | 1.9 | `define-feature` MUST NOT create a Jira issue without showing a full preview and receiving explicit user approval. | `define-feature/SKILL.md` — Important Rules |
-| 1.10 | `verify-pr` MUST read PR reviews and comments to identify code change requests from reviewers. | `verify-pr/SKILL.md` — Step 4 (Review Feedback Resolution) |
-| 1.11 | `verify-pr` MUST NOT modify code. It only verifies, creates sub-tasks, and reports. | `verify-pr/SKILL.md` — Important Rules |
-| 1.12 | `verify-pr` sub-tasks MUST follow the plan-feature task template structure and include Target PR and Review Context sections. | `verify-pr/SKILL.md` — Step 4d |
-| 1.13 | `verify-pr` MUST NOT auto-merge. Merging is always a human decision. | `verify-pr/SKILL.md` — Important Rules |
-| 1.14 | `verify-pr` root-cause tasks MUST target the workflow phase where the gap originated, not always the implementation phase. | `verify-pr/SKILL.md` — Step 5b |
+| 1.10 | `verify-pr` MUST read PR reviews and comments to identify code change requests from reviewers. | `verify-pr/SKILL.md` — Step 4a (orchestrator) |
+| 1.11 | `verify-pr` MUST NOT modify code. It only verifies, creates sub-tasks, and reports. | `verify-pr/SKILL.md` — Important Rules (orchestrator); `verify-pr/intent-alignment.md`, `security.md`, `correctness.md`, `style-conventions.md` — Constraints (all sub-agents) |
+| 1.12 | `verify-pr` sub-tasks MUST follow the plan-feature task template structure and include Target PR and Review Context sections. | `verify-pr/SKILL.md` — Step 4d (orchestrator) |
+| 1.13 | `verify-pr` MUST NOT auto-merge. Merging is always a human decision. | `verify-pr/SKILL.md` — Important Rules (orchestrator) |
+| 1.14 | `verify-pr` root-cause tasks MUST target the workflow phase where the gap originated, not always the implementation phase. | `verify-pr/SKILL.md` — Step 5b (orchestrator, root-cause) |
 | 1.15 | `implement-task` MUST check out the existing PR branch (instead of creating a new one) when a Target PR section is present in the task description. | `implement-task/SKILL.md` — Step 5 (Target PR flow) |
-| 1.16 | `verify-pr` MUST flag repetitive test functions that could be parameterized as a WARN finding, applying the Meszaros heuristic as the decision boundary. | `verify-pr/SKILL.md` — Step 12 |
-| 1.17 | `verify-pr` MUST flag test functions missing doc comments as a WARN finding. | `verify-pr/SKILL.md` — Step 12 |
-| 1.18 | `verify-pr` test change classification sub-agent MUST operate in complete isolation — it MUST NOT receive or access the Jira task description, review comments, PR metadata, or outputs from other verify-pr steps. | `verify-pr/SKILL.md` — Step 12 (sub-step 9) |
-| 1.19 | `verify-pr` MUST classify REDUCTIVE and MIXED test changes as WARN (advisory). Test Change Classification MUST NOT elevate the overall result to FAIL. | `verify-pr/SKILL.md` — Step 12 (sub-step 13), Step 14 |
-| 1.20 | `verify-pr` MUST classify new test files (not on base branch) as additive without sub-agent analysis. | `verify-pr/SKILL.md` — Step 12 (sub-step 8) |
-| 1.21 | `verify-pr` test change classification semantic assessment MUST override structural signals when they disagree. | `verify-pr/SKILL.md` — Step 12 (sub-step 11) |
+| 1.16 | `verify-pr` MUST flag repetitive test functions that could be parameterized as a WARN finding, applying the Meszaros heuristic as the decision boundary. | `verify-pr/style-conventions.md` — Check 2 (style-conventions sub-agent) |
+| 1.17 | `verify-pr` MUST flag test functions missing doc comments as a WARN finding. | `verify-pr/style-conventions.md` — Check 3 (style-conventions sub-agent) |
+| 1.18 | `verify-pr` test change classification sub-agent MUST operate in complete isolation — it MUST NOT receive or access the Jira task description, review comments, PR metadata, or outputs from other verify-pr steps. | `verify-pr/style-conventions.md` — Check 4, Step 4b (style-conventions sub-agent) |
+| 1.19 | `verify-pr` MUST classify REDUCTIVE and MIXED test changes as WARN (advisory). Test Change Classification MUST NOT elevate the overall result to FAIL. | `verify-pr/style-conventions.md` — Check 4, Verdict (style-conventions sub-agent); `verify-pr/SKILL.md` — Step 14 (orchestrator) |
+| 1.20 | `verify-pr` MUST classify new test files (not on base branch) as additive without sub-agent analysis. | `verify-pr/style-conventions.md` — Check 4, Step 4a (style-conventions sub-agent) |
+| 1.21 | `verify-pr` test change classification semantic assessment MUST override structural signals when they disagree. | `verify-pr/style-conventions.md` — Check 4, Step 4d (style-conventions sub-agent) |
+| 1.22 | `verify-pr` domain sub-agents MUST NOT perform Jira mutations (create sub-tasks, post comments, transition issues). | `verify-pr/SKILL.md` — Important Rules (orchestrator); `verify-pr/intent-alignment.md`, `security.md`, `correctness.md`, `style-conventions.md` — Constraints |
+| 1.23 | `verify-pr` domain sub-agents MUST NOT post PR comments or replies. | `verify-pr/SKILL.md` — Important Rules (orchestrator); `verify-pr/intent-alignment.md`, `security.md`, `correctness.md`, `style-conventions.md` — Constraints |
+| 1.24 | `verify-pr` domain sub-agents MUST return responses using the structured finding template (`finding-template.md`). | `verify-pr/intent-alignment.md`, `security.md`, `correctness.md`, `style-conventions.md` — Output Format |
+| 1.25 | `verify-pr` orchestrator MUST dispatch domain sub-agents in parallel. | `verify-pr/SKILL.md` — Step 4d (Dispatch), Important Rules (orchestrator) |
+| 1.26 | `verify-pr` root-cause investigation MUST receive aggregated findings from all domain sub-agents with source attribution. | `verify-pr/SKILL.md` — Step 5 (orchestrator), Important Rules |
 
 ---
 
@@ -97,6 +102,10 @@ Each constraint above references its source. The full source files are:
 
 - `plugins/sdlc-workflow/skills/plan-feature/SKILL.md` — Guardrails (§1.1–1.3), Task Description Template (§4.1–4.10), Step 5 Convention-aware task enrichment (§4.11)
 - `plugins/sdlc-workflow/skills/implement-task/SKILL.md` — Important Rules (§1.4–1.6, §5.1–5.3), Step 1 (§1.6), Step 4/6/9 (§5.4), Step 5 (§1.15, §3.1), Step 7 (§5.9–5.13), Step 9 (§2.1–2.3, §5.6–5.8), Step 10 (§3.2)
-- `plugins/sdlc-workflow/skills/verify-pr/SKILL.md` — Step 4 (§1.10, §1.12), Important Rules (§1.11, §1.13), Step 5b (§1.14), Step 12 (§1.16, §1.17, §1.18, §1.19, §1.20, §1.21)
+- `plugins/sdlc-workflow/skills/verify-pr/SKILL.md` — Step 4a (§1.10), Step 4d (§1.12, §1.25), Important Rules (§1.11, §1.13, §1.22, §1.23, §1.25, §1.26), Step 5b (§1.14), Step 5 (§1.26), Step 14 (§1.19)
+- `plugins/sdlc-workflow/skills/verify-pr/intent-alignment.md` — Constraints (§1.11, §1.22, §1.23), Output Format (§1.24)
+- `plugins/sdlc-workflow/skills/verify-pr/security.md` — Constraints (§1.11, §1.22, §1.23), Output Format (§1.24)
+- `plugins/sdlc-workflow/skills/verify-pr/correctness.md` — Constraints (§1.11, §1.22, §1.23), Output Format (§1.24)
+- `plugins/sdlc-workflow/skills/verify-pr/style-conventions.md` — Check 2 (§1.16), Check 3 (§1.17), Check 4 (§1.18, §1.19, §1.20, §1.21), Constraints (§1.11, §1.22, §1.23), Output Format (§1.24)
 - `plugins/sdlc-workflow/skills/define-feature/SKILL.md` — Guardrails (§1.7–1.8), Important Rules (§1.9)
 - `docs/methodology.md` — Core Principles (§2.1, §3.2, §5.5)


### PR DESCRIPTION
## Summary

- Re-scope constraints 1.10–1.21 Source column to reference specific sub-agent or orchestrator owners
- Add 5 new constraints (1.22–1.26) for decomposition boundaries (no Jira mutations, no PR posting, finding template, parallel dispatch, source-attributed root-cause input)
- Update Traceability Index to list sub-agent skill files (intent-alignment.md, security.md, correctness.md, style-conventions.md)

Implements [TC-4254](https://redhat.atlassian.net/browse/TC-4254)

## Test plan

- [x] All constraint numbers remain sequential (no gaps, no duplicates)
- [x] Every new constraint has a Source reference to a specific file
- [x] No existing constraint text changed — only Source/scope attribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update verify-pr constraints documentation to reflect sub-agent/orchestrator decomposition and clarify decomposition boundaries.

Enhancements:
- Scope existing verify-pr constraints to specific orchestrator and sub-agent owners.
- Add new constraints for verify-pr domain sub-agents covering Jira/PR mutation boundaries, structured finding templates, parallel dispatch, and root-cause inputs.
- Extend the traceability index to reference new verify-pr sub-agent skill files for intent alignment, security, correctness, and style conventions.