### PR TITLE
feat(define-feature): add external API claim verification during section collection

### DIFF
--- a/evals/define-feature/evals.json
+++ b/evals/define-feature/evals.json
@@ -72,6 +72,37 @@
         "outputs/jira-comment.md contains 'sdlc-workflow/define-feature' (Comment Footnote is present)",
         "outputs/jira-comment.md contains 'https://github.com/mrizzi/sdlc-plugins' (Comment Footnote link is correct)"
       ]
+    },
+    {
+      "id": 5,
+      "prompt": "Define a Jira Feature using the define-feature skill. The project's CLAUDE.md is in claude-md-configured.md. The user input is in user-input-api-claim.md — it provides content for the 2 Required sections (Feature Overview and Requirements). All other sections are marked SKIP. The Requirements section contains a claim that 'PR reviews cannot be updated after initial submission' and that 'The GitHub API does not support modifying a submitted review'. This claim is incorrect — the GitHub REST API supports PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id} to update a submitted review. The Feature summary is 'Add automated PR review posting for eval results'. The user leaves the Feature unassigned. Do NOT call any actual MCP tools, Jira APIs, WebSearch, or WebFetch. Instead, simulate the External API Claim Verification step by writing the verification result to outputs/api-claim-verification.md. Also write: outputs/preview.md (the composed Feature description preview with corrected language if the claim was found incorrect), outputs/jira-create.md (the Jira create_issue call parameters), outputs/jira-comment.md (the comment with Comment Footnote). Do NOT modify any files outside outputs/.",
+      "expected_output": "The skill detects the incorrect API claim in the Requirements section, verifies it against the GitHub REST API documentation, finds that PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id} exists, and suggests corrected language. The api-claim-verification.md file documents the detected claim, the verification finding, and the suggested correction. The preview.md reflects the corrected language (not the original incorrect claim).",
+      "files": ["files/claude-md-configured.md", "files/user-input-api-claim.md"],
+      "assertions": [
+        "outputs/api-claim-verification.md exists",
+        "outputs/api-claim-verification.md contains the detected claim text (e.g., 'PR reviews cannot be updated' or 'does not support modifying a submitted review')",
+        "outputs/api-claim-verification.md contains a reference to the GitHub REST API endpoint PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id} or equivalent evidence that the claim is incorrect",
+        "outputs/api-claim-verification.md contains suggested corrected language for the Requirement",
+        "outputs/preview.md contains the heading '## Feature Overview'",
+        "outputs/preview.md contains the heading '## Requirements'",
+        "outputs/preview.md does NOT contain the heading '## Background and Strategic Fit'",
+        "outputs/jira-create.md references project key 'TC'",
+        "outputs/jira-comment.md contains 'sdlc-workflow/define-feature'"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Define a Jira Feature using the define-feature skill. The project's CLAUDE.md is in claude-md-configured.md. The user input is in user-input-api-claim.md — it provides content for the 2 Required sections (Feature Overview and Requirements). All other sections are marked SKIP. The Requirements section contains a claim about the GitHub API. IMPORTANT: For this eval, WebSearch and WebFetch are unavailable — simulate this by NOT performing any web lookups. The skill must follow its fallback path for unverified claims. The Feature summary is 'Add automated PR review posting for eval results'. The user leaves the Feature unassigned. Do NOT call any actual MCP tools, Jira APIs, WebSearch, or WebFetch. Write the fallback verification result to outputs/api-claim-verification.md. Also write: outputs/preview.md, outputs/jira-create.md, outputs/jira-comment.md. Do NOT modify any files outside outputs/.",
+      "expected_output": "The skill detects the API claim in the Requirements section but cannot verify it because WebSearch/WebFetch are unavailable. The api-claim-verification.md file flags the claim as unverified and indicates the user was asked whether to proceed as-is or verify manually. The preview.md retains the original claim wording (since it could not be verified and the user was not available to confirm).",
+      "files": ["files/claude-md-configured.md", "files/user-input-api-claim.md"],
+      "assertions": [
+        "outputs/api-claim-verification.md exists",
+        "outputs/api-claim-verification.md contains the detected claim text (e.g., 'PR reviews cannot be updated' or 'does not support modifying a submitted review')",
+        "outputs/api-claim-verification.md indicates the claim could not be verified (e.g., 'unverified', 'unavailable', 'cannot verify', or 'web tools unavailable')",
+        "outputs/api-claim-verification.md contains a prompt or indication that the user was asked to decide (e.g., 'proceed as-is', 'verify manually', or 'Would you like to')",
+        "outputs/preview.md contains the heading '## Requirements'",
+        "outputs/jira-comment.md contains 'sdlc-workflow/define-feature'"
+      ]
     }
   ]
 }

--- a/evals/define-feature/files/user-input-api-claim.md
+++ b/evals/define-feature/files/user-input-api-claim.md
@@ -1,0 +1,60 @@
+<!-- SYNTHETIC TEST DATA — user input containing an incorrect external API capability claim for eval testing -->
+
+# User Input: Feature with External API Claim
+
+Only Required sections are provided. The Requirements section contains an
+incorrect claim about the GitHub REST API: it states that PR reviews cannot
+be updated after submission. This is factually wrong — the GitHub REST API
+supports `PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}`
+to update a review. The define-feature skill's External API Claim
+Verification step should detect and flag this claim.
+
+**Feature Summary**: Add automated PR review posting for eval results
+
+---
+
+## Section 1 — Feature Overview (Required)
+
+Add a CI workflow step that posts eval results as a PR review comment on
+pull requests that modify skill definitions. When a PR changes a SKILL.md
+file, the CI pipeline should run the corresponding eval suite and post a
+summary of pass/fail assertions as a PR review. This gives reviewers
+immediate visibility into whether skill behavior changes break existing
+eval expectations.
+
+## Section 2 — Background and Strategic Fit (Recommended)
+
+SKIP
+
+## Section 3 — Goals (Recommended)
+
+SKIP
+
+## Section 4 — Requirements (Required)
+
+| Requirement | Notes | Is MVP? |
+|---|---|---|
+| Post eval results as a GitHub PR review when SKILL.md files change | Use the GitHub REST API to create a review with pass/fail summary | Yes |
+| Include per-assertion results in the review body | Format as a Markdown checklist | Yes |
+| Handle the case where no evals exist for the modified skill | Post an informational comment instead of a review | Yes |
+| PR reviews cannot be updated after initial submission so always create a new review | The GitHub API does not support modifying a submitted review | Yes |
+
+## Section 5 — Non-Functional Requirements (Recommended)
+
+SKIP
+
+## Section 6 — Use Cases (Recommended)
+
+SKIP
+
+## Section 7 — Customer Considerations (Optional)
+
+SKIP
+
+## Section 8 — Customer Information/Supportability (Optional)
+
+SKIP
+
+## Section 9 — Documentation Considerations (Optional)
+
+SKIP

--- a/plugins/sdlc-workflow/skills/define-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/define-feature/SKILL.md
@@ -176,6 +176,46 @@ Walk through each of the 9 sections in order. For each section:
 
 Skipped sections are recorded as skipped and will be **omitted** from the final description — they will not appear as empty headings.
 
+### External API Claim Verification
+
+After the user provides input for any section, scan their content for claims about
+external API capabilities or limitations. A claim is a statement asserting what an
+external API can or cannot do. Look for patterns such as:
+
+- "X cannot be updated / deleted / modified after creation"
+- "The API does not support Y"
+- "There is no endpoint for Z"
+- "X is read-only / immutable / write-once"
+- "You can only create X, not update it"
+
+When a claim is detected:
+
+1. **Notify the user** — state which claim was identified and that you will verify it
+   against official API documentation.
+2. **Verify against official documentation** — use WebSearch to locate the API's official
+   documentation for the specific capability referenced by the claim, then use WebFetch
+   to read the relevant page. Focus on whether the endpoint, method, or capability the
+   claim denies actually exists.
+3. **Present the verification result** before finalizing the section:
+   - If the claim is **confirmed** — the API genuinely lacks the capability — inform the
+     user and proceed with the original wording.
+   - If the claim is **incorrect** — the API does support the capability — present the
+     evidence (endpoint, method, documentation link) and suggest corrected language for
+     the Feature description. Ask the user to confirm the correction before moving on.
+   - If verification is **inconclusive** — the documentation is ambiguous or does not
+     clearly address the claim — state what you found and ask the user whether to keep
+     the original wording or revise it.
+4. **Fallback** — if WebSearch or WebFetch are unavailable or return no useful results,
+   flag the unverified claim to the user:
+
+   > "I detected a claim about an external API but cannot verify it right now
+   > (web tools unavailable). The claim is: **{claim}**. Would you like to proceed
+   > as-is, or verify it manually before continuing?"
+
+This verification applies to every section but is especially important in **Feature
+Overview** (Step 3a), **Requirements** (Step 3d), and **Use Cases** (Step 3f), where
+technical assumptions about API capabilities shape downstream planning and implementation.
+
 ### Step 3a – Feature Overview (Required)
 
 Ask for a high-level description of the feature — the executive summary covering the "What & Why".


### PR DESCRIPTION
## Summary

- Adds an **External API Claim Verification** subsection to the define-feature skill's Step 3 (Collect Template Sections)
- When users provide input containing claims about external API capabilities or limitations (e.g., "PR reviews cannot be updated"), the skill now detects these claims and verifies them against official API documentation using WebSearch/WebFetch
- Presents verification results to the user inline during section collection, suggesting corrected language when a claim is incorrect
- Includes a fallback flow when web tools are unavailable, flagging unverified claims for user decision
- Adds eval coverage for the new verification behavior: eval 5 (incorrect claim detection and correction) and eval 6 (fallback when web tools unavailable), with a synthetic fixture containing an incorrect GitHub API capability claim

Implements [TC-4280](https://redhat.atlassian.net/browse/TC-4280)
Implements [TC-4291](https://redhat.atlassian.net/browse/TC-4291)

## Test plan

- [ ] Verify the new subsection is present at `plugins/sdlc-workflow/skills/define-feature/SKILL.md` within Step 3
- [ ] Confirm the step integrates naturally with existing sub-steps 3a–3i (same heading level, positioned before 3a)
- [ ] Review that claim detection patterns cover common phrasings
- [ ] Confirm fallback behavior is documented for when WebSearch/WebFetch are unavailable
- [ ] Verify eval 5 assertions cover claim detection, verification, and corrected language suggestion
- [ ] Verify eval 6 assertions cover the fallback path (web tools unavailable)
- [ ] Run `claude plugin validate plugins/sdlc-workflow` — should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)