### PR TITLE
refactor(skills): extract eval coverage propagation into shared resource

### DIFF
--- a/plugins/sdlc-workflow/shared/eval-coverage-propagation.md
+++ b/plugins/sdlc-workflow/shared/eval-coverage-propagation.md
@@ -1,0 +1,43 @@
+# Eval Coverage Propagation
+
+When a task modifies a skill's `SKILL.md`, check whether eval infrastructure exists for
+that skill and propagate eval coverage requirements into the task description. This ensures
+that skill behavior changes are accompanied by eval assertion updates, preventing gaps
+where new behavior ships without eval coverage.
+
+## How to apply
+
+1. For each task, check whether its **Files to Modify** includes a file matching the
+   pattern `plugins/<plugin>/skills/<skill-name>/SKILL.md`.
+2. If it does, check whether `evals/<skill-name>/evals.json` exists (using the eval
+   infrastructure detected during repository analysis).
+3. If eval infrastructure exists, enrich the task description:
+   - Add `evals/<skill-name>/evals.json` to **Files to Modify** with the reason:
+     "add or update eval assertions to cover the new behavior"
+   - Add to **Test Requirements**: "Update eval assertions in
+     `evals/<skill-name>/evals.json` to cover the behavior changes introduced by
+     this task. Add new eval cases if existing cases do not exercise the modified
+     behavior, or update assertions on existing cases if their expected output changes."
+   - Add existing eval fixture files (from `evals/<skill-name>/files/`) to
+     **Reuse Candidates** so the implementer follows the established fixture patterns.
+     List 2-3 representative fixture files with a brief description of what each
+     demonstrates (e.g., a passing scenario, a failing scenario, a scenario with
+     review comments).
+
+## Example -- verify-pr skill with existing evals
+
+When a task modifies `plugins/sdlc-workflow/skills/verify-pr/SKILL.md` and
+`evals/verify-pr/evals.json` exists:
+
+> **Files to Modify** (appended):
+> - `evals/verify-pr/evals.json` -- add or update eval assertions to cover the new behavior
+>
+> **Test Requirements** (appended):
+> - [ ] Update eval assertions in `evals/verify-pr/evals.json` to cover the behavior
+>   changes introduced by this task
+>
+> **Reuse Candidates** (appended):
+> - `evals/verify-pr/files/task-passing.md` -- example task fixture for a passing
+>   verification scenario
+> - `evals/verify-pr/files/pr-diff-passing.md` -- example PR diff fixture for a
+>   passing scenario

--- a/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
@@ -459,47 +459,8 @@ to independently discover and apply it.
 
 ### Eval coverage propagation
 
-When a task modifies a skill's `SKILL.md`, check whether eval infrastructure exists for
-that skill and propagate eval coverage requirements into the task description. This ensures
-that skill behavior changes are accompanied by eval assertion updates, preventing gaps
-where new behavior ships without eval coverage.
-
-**How to apply:**
-
-1. For each task, check whether its **Files to Modify** includes a file matching the
-   pattern `plugins/<plugin>/skills/<skill-name>/SKILL.md`.
-2. If it does, check whether `evals/<skill-name>/evals.json` exists (using the eval
-   infrastructure detected during Step 3's repository analysis).
-3. If eval infrastructure exists, enrich the task description:
-   - Add `evals/<skill-name>/evals.json` to **Files to Modify** with the reason:
-     "add or update eval assertions to cover the new behavior"
-   - Add to **Test Requirements**: "Update eval assertions in
-     `evals/<skill-name>/evals.json` to cover the behavior changes introduced by
-     this task. Add new eval cases if existing cases do not exercise the modified
-     behavior, or update assertions on existing cases if their expected output changes."
-   - Add existing eval fixture files (from `evals/<skill-name>/files/`) to
-     **Reuse Candidates** so the implementer follows the established fixture patterns.
-     List 2–3 representative fixture files with a brief description of what each
-     demonstrates (e.g., a passing scenario, a failing scenario, a scenario with
-     review comments).
-
-**Example — verify-pr skill with existing evals:**
-
-When a task modifies `plugins/sdlc-workflow/skills/verify-pr/SKILL.md` and
-`evals/verify-pr/evals.json` exists:
-
-> **Files to Modify** (appended):
-> - `evals/verify-pr/evals.json` — add or update eval assertions to cover the new behavior
->
-> **Test Requirements** (appended):
-> - [ ] Update eval assertions in `evals/verify-pr/evals.json` to cover the behavior
->   changes introduced by this task
->
-> **Reuse Candidates** (appended):
-> - `evals/verify-pr/files/task-passing.md` — example task fixture for a passing
->   verification scenario
-> - `evals/verify-pr/files/pr-diff-passing.md` — example PR diff fixture for a
->   passing scenario
+For each task, apply the eval coverage propagation from
+[`shared/eval-coverage-propagation.md`](../shared/eval-coverage-propagation.md).
 
 ### Backend API contract enrichment for manual REST calls
 

--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -420,6 +420,8 @@ jira.create_issue with:
 - **Labels:** `["ai-generated-jira", "review-feedback"]`
 - **Description:** structured task description following the template defined in
   [`shared/task-description-template.md`](../shared/task-description-template.md).
+  Apply the eval coverage propagation from
+  [`shared/eval-coverage-propagation.md`](../shared/eval-coverage-propagation.md).
   Include the applicable base sections plus these extension sections:
 
   - **Review Context** — the original review comment text and PR file/line reference
@@ -668,6 +670,8 @@ jira.create_issue with:
 - **Labels:** `["ai-generated-jira", "root-cause"]`
 - **Description:** structured task description following the template defined in
   [`shared/task-description-template.md`](../shared/task-description-template.md).
+  Apply the eval coverage propagation from
+  [`shared/eval-coverage-propagation.md`](../shared/eval-coverage-propagation.md).
   The description must be actionable — it describes the concrete change to the
   skill, prompt, or convention that prevents the gap from recurring. Do **not**
   include the root-cause analysis narrative in the description.


### PR DESCRIPTION
## Summary
- Extracted eval coverage propagation logic from plan-feature's inline subsection into `shared/eval-coverage-propagation.md`
- Updated plan-feature to reference the shared resource instead of inlining the logic
- Added eval coverage propagation references to verify-pr's review feedback (Step 6d) and root-cause (Step 7b) task creation paths

Implements [TC-4295](https://redhat.atlassian.net/browse/TC-4295)

## Test plan
- [ ] Verify `shared/eval-coverage-propagation.md` contains the full propagation logic with example
- [ ] Verify plan-feature references the shared file instead of inlining
- [ ] Verify verify-pr Step 6d references the shared file
- [ ] Verify verify-pr Step 7b references the shared file
- [ ] Run a verify-pr invocation on a PR that modifies a SKILL.md to confirm eval coverage is propagated into sub-tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extract eval coverage propagation into a shared skill resource and apply it across related task flows.

Enhancements:
- Centralize eval coverage propagation guidance in a shared document for reuse across skills.
- Update the plan-feature skill to reference the shared eval coverage propagation guidance instead of inlining it.
- Extend verify-pr review feedback and root-cause task creation flows to apply the shared eval coverage propagation guidance.