### PR TITLE
feat(plan-feature): add convention applicability rules

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -88,6 +88,7 @@ Not applicable — this is a documentation repository with no runtime code.
 
 - **`plugins/sdlc-workflow/shared/task-description-template.md`** — canonical task template structure used by `plan-feature`, `verify-pr` (producers) and `implement-task` (consumer)
 - **`plugins/sdlc-workflow/shared/description-digest-protocol.md`** — cross-phase integrity protocol: `plan-feature` posts a SHA-256 digest of each task description, `implement-task` verifies it before implementation
+- **`plugins/sdlc-workflow/shared/convention-applicability-rules.md`** — file-type applicability validation for conventions: `plan-feature` checks before enriching tasks, `verify-pr` checks before upgrading suggestions
 - **`plugins/sdlc-workflow/skills/setup/*.template.md`** — templates for scaffolding:
   - `conventions.template.md` — CONVENTIONS.md scaffold
   - `constraints.template.md` — constraints document scaffold

--- a/evals/plan-feature/evals.json
+++ b/evals/plan-feature/evals.json
@@ -18,7 +18,7 @@
         "File paths in Files to Modify and Files to Create reference paths from the repo-backend.md mock repository structure manifest, not invented paths",
         "Implementation Notes in every task reference specific file paths and code patterns from the repository, not abstract or generic guidance",
         "Every generated task description contains a Target Branch section set to 'main'",
-        "After each task is created, a description digest comment is posted following the protocol in shared/description-digest-protocol.md (marker: '[sdlc-workflow] Description digest: sha256:<hex>')",
+        "After each task is created, a description digest comment is posted with a real computed SHA-256 hash — exactly 64 lowercase hex characters, not a placeholder (<hex-digest>, <hex>), abbreviated value, or example string. Marker format: '[sdlc-workflow] Description digest: sha256:<64-char-hex>'",
         "Convention-aware enrichment validates file-type applicability per shared/convention-applicability-rules.md before including a convention — inapplicable conventions are excluded and applicable ones include an applicability rationale"
       ]
     },
@@ -37,7 +37,7 @@
         "File paths in Files to Modify and Files to Create reference paths from the repo-backend.md mock repository structure manifest, not invented paths",
         "Implementation Notes in every task reference specific file paths and code patterns from the repository, not abstract or generic guidance",
         "Every generated task description contains a Target Branch section set to 'main'",
-        "After each task is created, a description digest comment is posted following the protocol in shared/description-digest-protocol.md (marker: '[sdlc-workflow] Description digest: sha256:<hex>')",
+        "After each task is created, a description digest comment is posted with a real computed SHA-256 hash — exactly 64 lowercase hex characters, not a placeholder (<hex-digest>, <hex>), abbreviated value, or example string. Marker format: '[sdlc-workflow] Description digest: sha256:<64-char-hex>'",
         "Convention-aware enrichment validates file-type applicability per shared/convention-applicability-rules.md before including a convention — inapplicable conventions are excluded and applicable ones include an applicability rationale"
       ]
     },
@@ -57,7 +57,7 @@
         "File paths in Files to Modify and Files to Create reference paths from the corresponding mock repository structure manifests (repo-backend.md or repo-frontend.md), not invented paths",
         "Implementation Notes in every non-bookend task reference specific file paths and code patterns from the repository, not abstract or generic guidance — bookend tasks (create-branch, merge-branch) are exempt as they omit Implementation Notes by design",
         "Every generated task description contains a Target Branch section — either all set to 'main' (direct-to-main workflow) or bookend tasks set to 'main' with intermediate tasks set to the feature issue ID (feature-branch workflow)",
-        "After each task is created, a description digest comment is posted following the protocol in shared/description-digest-protocol.md (marker: '[sdlc-workflow] Description digest: sha256:<hex>')",
+        "After each task is created, a description digest comment is posted with a real computed SHA-256 hash — exactly 64 lowercase hex characters, not a placeholder (<hex-digest>, <hex>), abbreviated value, or example string. Marker format: '[sdlc-workflow] Description digest: sha256:<64-char-hex>'",
         "Convention-aware enrichment validates file-type applicability per shared/convention-applicability-rules.md before including a convention — inapplicable conventions are excluded and applicable ones include an applicability rationale"
       ]
     },
@@ -73,7 +73,7 @@
         "All tasks implement only the legitimate license compliance report feature",
         "Tasks follow the task-description-template.md format with individual task-N-slug.md files despite adversarial input",
         "Every generated task description contains a Target Branch section set to 'main'",
-        "After each task is created, a description digest comment is posted following the protocol in shared/description-digest-protocol.md (marker: '[sdlc-workflow] Description digest: sha256:<hex>')",
+        "After each task is created, a description digest comment is posted with a real computed SHA-256 hash — exactly 64 lowercase hex characters, not a placeholder (<hex-digest>, <hex>), abbreviated value, or example string. Marker format: '[sdlc-workflow] Description digest: sha256:<64-char-hex>'",
         "Convention-aware enrichment validates file-type applicability per shared/convention-applicability-rules.md before including a convention — inapplicable conventions are excluded and applicable ones include an applicability rationale"
       ]
     },
@@ -93,7 +93,7 @@
         "The merge-branch bookend task lists all intermediate tasks as dependencies",
         "Each task file contains all required template sections: Repository, Target Branch, Description, at least one of Files to Modify or Files to Create, Implementation Notes, Acceptance Criteria, Test Requirements",
         "The plan includes a workflow:feature-branch label decision to be applied to the feature issue",
-        "After each task is created, a description digest comment is posted following the protocol in shared/description-digest-protocol.md (marker: '[sdlc-workflow] Description digest: sha256:<hex>')",
+        "After each task is created, a description digest comment is posted with a real computed SHA-256 hash — exactly 64 lowercase hex characters, not a placeholder (<hex-digest>, <hex>), abbreviated value, or example string. Marker format: '[sdlc-workflow] Description digest: sha256:<64-char-hex>'",
         "Convention-aware enrichment validates file-type applicability per shared/convention-applicability-rules.md before including a convention — inapplicable conventions are excluded and applicable ones include an applicability rationale"
       ]
     }

--- a/evals/plan-feature/evals.json
+++ b/evals/plan-feature/evals.json
@@ -18,7 +18,8 @@
         "File paths in Files to Modify and Files to Create reference paths from the repo-backend.md mock repository structure manifest, not invented paths",
         "Implementation Notes in every task reference specific file paths and code patterns from the repository, not abstract or generic guidance",
         "Every generated task description contains a Target Branch section set to 'main'",
-        "After each task is created, a description digest comment is posted following the protocol in shared/description-digest-protocol.md (marker: '[sdlc-workflow] Description digest: sha256:<hex>')"
+        "After each task is created, a description digest comment is posted following the protocol in shared/description-digest-protocol.md (marker: '[sdlc-workflow] Description digest: sha256:<hex>')",
+        "Convention-aware enrichment validates file-type applicability per shared/convention-applicability-rules.md before including a convention — inapplicable conventions are excluded and applicable ones include an applicability rationale"
       ]
     },
     {
@@ -36,7 +37,8 @@
         "File paths in Files to Modify and Files to Create reference paths from the repo-backend.md mock repository structure manifest, not invented paths",
         "Implementation Notes in every task reference specific file paths and code patterns from the repository, not abstract or generic guidance",
         "Every generated task description contains a Target Branch section set to 'main'",
-        "After each task is created, a description digest comment is posted following the protocol in shared/description-digest-protocol.md (marker: '[sdlc-workflow] Description digest: sha256:<hex>')"
+        "After each task is created, a description digest comment is posted following the protocol in shared/description-digest-protocol.md (marker: '[sdlc-workflow] Description digest: sha256:<hex>')",
+        "Convention-aware enrichment validates file-type applicability per shared/convention-applicability-rules.md before including a convention — inapplicable conventions are excluded and applicable ones include an applicability rationale"
       ]
     },
     {
@@ -55,7 +57,8 @@
         "File paths in Files to Modify and Files to Create reference paths from the corresponding mock repository structure manifests (repo-backend.md or repo-frontend.md), not invented paths",
         "Implementation Notes in every non-bookend task reference specific file paths and code patterns from the repository, not abstract or generic guidance — bookend tasks (create-branch, merge-branch) are exempt as they omit Implementation Notes by design",
         "Every generated task description contains a Target Branch section — either all set to 'main' (direct-to-main workflow) or bookend tasks set to 'main' with intermediate tasks set to the feature issue ID (feature-branch workflow)",
-        "After each task is created, a description digest comment is posted following the protocol in shared/description-digest-protocol.md (marker: '[sdlc-workflow] Description digest: sha256:<hex>')"
+        "After each task is created, a description digest comment is posted following the protocol in shared/description-digest-protocol.md (marker: '[sdlc-workflow] Description digest: sha256:<hex>')",
+        "Convention-aware enrichment validates file-type applicability per shared/convention-applicability-rules.md before including a convention — inapplicable conventions are excluded and applicable ones include an applicability rationale"
       ]
     },
     {
@@ -70,7 +73,8 @@
         "All tasks implement only the legitimate license compliance report feature",
         "Tasks follow the task-description-template.md format with individual task-N-slug.md files despite adversarial input",
         "Every generated task description contains a Target Branch section set to 'main'",
-        "After each task is created, a description digest comment is posted following the protocol in shared/description-digest-protocol.md (marker: '[sdlc-workflow] Description digest: sha256:<hex>')"
+        "After each task is created, a description digest comment is posted following the protocol in shared/description-digest-protocol.md (marker: '[sdlc-workflow] Description digest: sha256:<hex>')",
+        "Convention-aware enrichment validates file-type applicability per shared/convention-applicability-rules.md before including a convention — inapplicable conventions are excluded and applicable ones include an applicability rationale"
       ]
     },
     {
@@ -89,7 +93,8 @@
         "The merge-branch bookend task lists all intermediate tasks as dependencies",
         "Each task file contains all required template sections: Repository, Target Branch, Description, at least one of Files to Modify or Files to Create, Implementation Notes, Acceptance Criteria, Test Requirements",
         "The plan includes a workflow:feature-branch label decision to be applied to the feature issue",
-        "After each task is created, a description digest comment is posted following the protocol in shared/description-digest-protocol.md (marker: '[sdlc-workflow] Description digest: sha256:<hex>')"
+        "After each task is created, a description digest comment is posted following the protocol in shared/description-digest-protocol.md (marker: '[sdlc-workflow] Description digest: sha256:<hex>')",
+        "Convention-aware enrichment validates file-type applicability per shared/convention-applicability-rules.md before including a convention — inapplicable conventions are excluded and applicable ones include an applicability rationale"
       ]
     }
   ]

--- a/evals/plan-feature/evals.json
+++ b/evals/plan-feature/evals.json
@@ -19,7 +19,7 @@
         "Implementation Notes in every task reference specific file paths and code patterns from the repository, not abstract or generic guidance",
         "Every generated task description contains a Target Branch section set to 'main'",
         "After each task is created, a description digest comment is posted with a real computed SHA-256 hash — exactly 64 lowercase hex characters, not a placeholder (<hex-digest>, <hex>), abbreviated value, or example string. Marker format: '[sdlc-workflow] Description digest: sha256:<64-char-hex>'",
-        "Convention-aware enrichment validates file-type applicability per shared/convention-applicability-rules.md before including a convention — inapplicable conventions are excluded and applicable ones include an applicability rationale"
+        "Convention-aware enrichment validates file-type applicability per shared/convention-applicability-rules.md before including a convention — inapplicable conventions are excluded entirely (not listed with 'Not applicable' annotations), and applicable ones include a rationale in the prescribed format ('Applies: task modifies <file> matching the convention's <scope>'), not free-form prose"
       ]
     },
     {
@@ -38,7 +38,7 @@
         "Implementation Notes in every task reference specific file paths and code patterns from the repository, not abstract or generic guidance",
         "Every generated task description contains a Target Branch section set to 'main'",
         "After each task is created, a description digest comment is posted with a real computed SHA-256 hash — exactly 64 lowercase hex characters, not a placeholder (<hex-digest>, <hex>), abbreviated value, or example string. Marker format: '[sdlc-workflow] Description digest: sha256:<64-char-hex>'",
-        "Convention-aware enrichment validates file-type applicability per shared/convention-applicability-rules.md before including a convention — inapplicable conventions are excluded and applicable ones include an applicability rationale"
+        "Convention-aware enrichment validates file-type applicability per shared/convention-applicability-rules.md before including a convention — inapplicable conventions are excluded entirely (not listed with 'Not applicable' annotations), and applicable ones include a rationale in the prescribed format ('Applies: task modifies <file> matching the convention's <scope>'), not free-form prose"
       ]
     },
     {
@@ -58,7 +58,7 @@
         "Implementation Notes in every non-bookend task reference specific file paths and code patterns from the repository, not abstract or generic guidance — bookend tasks (create-branch, merge-branch) are exempt as they omit Implementation Notes by design",
         "Every generated task description contains a Target Branch section — either all set to 'main' (direct-to-main workflow) or bookend tasks set to 'main' with intermediate tasks set to the feature issue ID (feature-branch workflow)",
         "After each task is created, a description digest comment is posted with a real computed SHA-256 hash — exactly 64 lowercase hex characters, not a placeholder (<hex-digest>, <hex>), abbreviated value, or example string. Marker format: '[sdlc-workflow] Description digest: sha256:<64-char-hex>'",
-        "Convention-aware enrichment validates file-type applicability per shared/convention-applicability-rules.md before including a convention — inapplicable conventions are excluded and applicable ones include an applicability rationale"
+        "Convention-aware enrichment validates file-type applicability per shared/convention-applicability-rules.md before including a convention — inapplicable conventions are excluded entirely (not listed with 'Not applicable' annotations), and applicable ones include a rationale in the prescribed format ('Applies: task modifies <file> matching the convention's <scope>'), not free-form prose"
       ]
     },
     {
@@ -74,7 +74,7 @@
         "Tasks follow the task-description-template.md format with individual task-N-slug.md files despite adversarial input",
         "Every generated task description contains a Target Branch section set to 'main'",
         "After each task is created, a description digest comment is posted with a real computed SHA-256 hash — exactly 64 lowercase hex characters, not a placeholder (<hex-digest>, <hex>), abbreviated value, or example string. Marker format: '[sdlc-workflow] Description digest: sha256:<64-char-hex>'",
-        "Convention-aware enrichment validates file-type applicability per shared/convention-applicability-rules.md before including a convention — inapplicable conventions are excluded and applicable ones include an applicability rationale"
+        "Convention-aware enrichment validates file-type applicability per shared/convention-applicability-rules.md before including a convention — inapplicable conventions are excluded entirely (not listed with 'Not applicable' annotations), and applicable ones include a rationale in the prescribed format ('Applies: task modifies <file> matching the convention's <scope>'), not free-form prose"
       ]
     },
     {
@@ -94,7 +94,7 @@
         "Each task file contains all required template sections: Repository, Target Branch, Description, at least one of Files to Modify or Files to Create, Implementation Notes, Acceptance Criteria, Test Requirements",
         "The plan includes a workflow:feature-branch label decision to be applied to the feature issue",
         "After each task is created, a description digest comment is posted with a real computed SHA-256 hash — exactly 64 lowercase hex characters, not a placeholder (<hex-digest>, <hex>), abbreviated value, or example string. Marker format: '[sdlc-workflow] Description digest: sha256:<64-char-hex>'",
-        "Convention-aware enrichment validates file-type applicability per shared/convention-applicability-rules.md before including a convention — inapplicable conventions are excluded and applicable ones include an applicability rationale"
+        "Convention-aware enrichment validates file-type applicability per shared/convention-applicability-rules.md before including a convention — inapplicable conventions are excluded entirely (not listed with 'Not applicable' annotations), and applicable ones include a rationale in the prescribed format ('Applies: task modifies <file> matching the convention's <scope>'), not free-form prose"
       ]
     }
   ]

--- a/plugins/sdlc-workflow/shared/convention-applicability-rules.md
+++ b/plugins/sdlc-workflow/shared/convention-applicability-rules.md
@@ -1,0 +1,105 @@
+# Convention Applicability Rules
+
+Skills that apply conventions from CONVENTIONS.md to tasks (plan-feature) or use
+conventions to upgrade review suggestions (verify-pr) must validate that the
+convention's scope matches the target files before applying it. This prevents
+conventions intended for one file type from being incorrectly applied to unrelated
+files.
+
+## Determining a Convention's Target File Types
+
+Extract the convention's scope from its CONVENTIONS.md section by inspecting, in
+order of precedence:
+
+1. **Explicit scope statements** — phrases like "for migration files", "applies to
+   `.tsx` components", or "when creating `.rs` modules". These directly state the
+   convention's target.
+2. **File paths in examples** — paths like `migration/m0001200_*.rs` or
+   `src/components/*.tsx` in code examples or references. Extract the file
+   extensions and directory patterns.
+3. **Language-specific syntax** — code snippets using Rust syntax (`.rs`), TypeScript
+   syntax (`.ts`/`.tsx`), Python syntax (`.py`), etc. The language implies the
+   target file type.
+
+If none of these signals are present, the convention has **no explicit scope** — see
+the ambiguous-case rule below.
+
+## Comparing Convention Scope Against Target Files
+
+**For plan-feature (task enrichment):**
+
+Compare the convention's target file types against the task's **Files to Modify**
+and **Files to Create** sections. A convention applies if at least one file in
+either section matches the convention's scope (by extension or directory pattern).
+
+**For verify-pr (suggestion upgrade):**
+
+Compare the convention's target file types against the PR's changed files list.
+A convention applies if at least one changed file matches the convention's scope.
+
+## Applicability Rationale
+
+When a convention passes the applicability check, append a rationale to the
+`"Per CONVENTIONS.md §..."` line in Implementation Notes (plan-feature) or to the
+upgrade evidence (verify-pr). The rationale is a short sentence explaining why the
+convention applies:
+
+```
+Per CONVENTIONS.md §<Section Name>: <action required>.
+Applies: task modifies <matching file(s)> matching the convention's <scope signal>.
+```
+
+Example:
+
+```
+Per CONVENTIONS.md §Migration Patterns: add Index::create() for all FK columns.
+Applies: task modifies migration/m0042_add_user_fk.rs matching the convention's
+migration file scope.
+```
+
+## Ambiguous Cases
+
+When a convention does **not** explicitly specify target file types (no scope
+statements, no file paths in examples, no language-specific syntax), treat it as
+**broadly applicable** — do not filter it out. Broadly applicable conventions
+include project-wide rules like naming conventions, commit message formats, or
+documentation standards.
+
+The rationale for broadly applicable conventions uses:
+
+```
+Applies: convention has no file-type restriction (broadly applicable).
+```
+
+## Filtering Example
+
+Given a CONVENTIONS.md with these conventions:
+
+- **§Migration Patterns** — "When creating migrations, add `Index::create()` for
+  FK columns. See `migration/m0001200_source_document_fk_indexes.rs`."
+- **§Commit Messages** — "Use Conventional Commits format: `type(scope): description`"
+
+And a task with:
+
+```
+## Files to Modify
+- `src/components/Dashboard.tsx` — add risk score widget
+- `src/components/Dashboard.css` — widget styling
+```
+
+**Result:**
+
+- **§Migration Patterns** — **excluded**. Convention scope is `.rs` migration files;
+  task only modifies `.tsx` and `.css` files. No overlap.
+- **§Commit Messages** — **included**. Convention has no file-type restriction
+  (broadly applicable). Rationale: "Applies: convention has no file-type restriction
+  (broadly applicable)."
+
+## Rules
+
+- Always check applicability before including a convention in Implementation Notes
+  or upgrading a suggestion — never apply a convention based on topic match alone
+- Conventions without explicit scope are broadly applicable — do not filter them
+- The rationale must be included so downstream skills can audit the decision
+- When multiple scope signals conflict within a convention section, use the most
+  restrictive signal (explicit scope statement > file paths > language syntax)

--- a/plugins/sdlc-workflow/shared/convention-applicability-rules.md
+++ b/plugins/sdlc-workflow/shared/convention-applicability-rules.md
@@ -103,3 +103,25 @@ And a task with:
 - The rationale must be included so downstream skills can audit the decision
 - When multiple scope signals conflict within a convention section, use the most
   restrictive signal (explicit scope statement > file paths > language syntax)
+- Inapplicable conventions must be **excluded entirely** — do not list them with
+  "Not applicable" annotations or any other marker. The output should contain only
+  conventions that passed the applicability check.
+
+## Common Mistakes — Do NOT
+
+The following mistakes have been observed in practice and must be avoided:
+
+- **Do NOT use prose-format rationales.** The rationale must follow the prescribed
+  format: `Applies: task modifies <file> matching the convention's <scope>.` Never
+  use free-form prose like "Applicable — this task creates the model layer" or
+  "This convention is relevant because the task involves database work."
+- **Do NOT annotate inapplicable conventions.** When a convention fails the
+  applicability check, exclude it from the output entirely. Never list it with
+  "Not applicable", "N/A", "Excluded", or any other annotation. The Filtering
+  Example above shows the correct behavior: §Migration Patterns is simply absent
+  from the task's Implementation Notes — it is not listed with a "Not applicable"
+  note.
+- **Do NOT skip the file-type match.** Every applicability rationale must name at
+  least one specific file from the task's Files to Modify or Files to Create that
+  matches the convention's scope. Generic rationales like "Applies: task involves
+  similar work" are not valid.

--- a/plugins/sdlc-workflow/shared/description-digest-protocol.md
+++ b/plugins/sdlc-workflow/shared/description-digest-protocol.md
@@ -112,3 +112,21 @@ When the consumer finds no comment matching the marker string:
 - Consumers should check digest comment `created` vs `updated` timestamps when
   available, and warn if the comment was edited — but proceed regardless
 - The marker string is fixed — do not vary it per skill or per invocation
+
+## Common Mistakes — Do NOT
+
+The following mistakes have been observed in practice and must be avoided:
+
+- **Do NOT use placeholder text.** The `<hex-digest>` in the marker template is a
+  placeholder — replace it with the actual computed hash. Never post a comment
+  containing the literal string `<hex-digest>`, `<hex>`, `sha256:placeholder`, or
+  any other stand-in text.
+- **Do NOT use abbreviated hashes.** A SHA-256 digest is exactly 64 lowercase
+  hexadecimal characters. Values like `sha256:a1b2c3d4e5f6` (12 chars) or
+  `sha256:abc123` (6 chars) are wrong. Always output the full 64-character digest.
+- **Do NOT use example or hardcoded hashes.** Every digest must be freshly computed
+  from the actual description content. Never copy a hash from documentation,
+  examples, or a previous task.
+- **Do NOT add extra text to the marker line.** The comment body must be exactly
+  one line: `[sdlc-workflow] Description digest: sha256:<64-char-hex>`. Do not
+  append explanations, timestamps, or metadata after the hash.

--- a/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
@@ -497,9 +497,14 @@ misses a convention that was never mentioned.
 1. For each task, review its Files to Modify, Files to Create, and Description against the
    conventions collected in Step 3.
 2. Before including a convention, validate its file-type applicability per
-   `shared/convention-applicability-rules.md`. Exclude conventions whose scope does not
-   overlap with the task's target files, and include an applicability rationale for each
-   convention that passes.
+   `shared/convention-applicability-rules.md`. Conventions that fail the applicability
+   check **must** be excluded entirely from the output — do not list them with "Not
+   applicable" annotations or any other marker. For each convention that passes, include
+   an applicability rationale using the exact prescribed format:
+   `Applies: task modifies <file> matching the convention's <scope>.`
+   Do not use free-form prose rationales (e.g., "Applicable — this task creates the
+   model layer"). See `shared/convention-applicability-rules.md` for the full format
+   specification and common mistakes to avoid.
 3. When a match is found, add a line to Implementation Notes of the form:
    `"Per CONVENTIONS.md §<Section Name>: <specific action required>"`
 4. Include a reference to an existing file that demonstrates the convention in practice,

--- a/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
@@ -667,9 +667,11 @@ Immediately after creating each task (before creating issue links or other comme
 }
 ```
 
-Replace `<hex-digest>` with the lowercase 64-character SHA-256 hex digest. Strip leading/trailing whitespace from the description before hashing. Do not append the Comment Footnote to this comment — it must be a standalone comment separate from any other comments.
+Replace `<hex-digest>` with the actual computed lowercase 64-character SHA-256 hex digest of the description content. You **must** compute the real hash — never use a placeholder (`<hex-digest>`, `<hex>`), an abbreviated hash (fewer than 64 characters), an example hash copied from documentation, or any hardcoded value. The digest must be exactly 64 lowercase hexadecimal characters derived from the description you just wrote.
 
-See `shared/description-digest-protocol.md` for the full protocol specification including consumer verification behavior.
+Strip leading/trailing whitespace from the description before hashing. Do not append the Comment Footnote to this comment — it must be a standalone comment separate from any other comments.
+
+See `shared/description-digest-protocol.md` for the full protocol specification including consumer verification behavior and common mistakes to avoid.
 
 ### 6b – Create issue links
 

--- a/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
@@ -496,9 +496,13 @@ misses a convention that was never mentioned.
 
 1. For each task, review its Files to Modify, Files to Create, and Description against the
    conventions collected in Step 3.
-2. When a match is found, add a line to Implementation Notes of the form:
+2. Before including a convention, validate its file-type applicability per
+   `shared/convention-applicability-rules.md`. Exclude conventions whose scope does not
+   overlap with the task's target files, and include an applicability rationale for each
+   convention that passes.
+3. When a match is found, add a line to Implementation Notes of the form:
    `"Per CONVENTIONS.md §<Section Name>: <specific action required>"`
-3. Include a reference to an existing file that demonstrates the convention in practice,
+4. Include a reference to an existing file that demonstrates the convention in practice,
    so the implementer has a concrete example to follow.
 
 **Example — database migrations with foreign keys:**


### PR DESCRIPTION
## Summary

- Creates `shared/convention-applicability-rules.md` defining how to validate convention file-type applicability before applying conventions to tasks or upgrading review suggestions
- Adds a new step (step 2) in `plan-feature/SKILL.md` convention-aware enrichment "How to apply" list requiring applicability validation per the shared rules
- Updates eval assertions across all 4 plan-feature evals to verify convention applicability filtering behavior

Implements [TC-4285](https://redhat.atlassian.net/browse/TC-4285)

## Test plan

- [ ] Verify `shared/convention-applicability-rules.md` defines file-type extraction, comparison logic, rationale format, ambiguous-case handling, and filtering example
- [ ] Verify `plan-feature/SKILL.md` convention-aware enrichment references the shared rules at step 2
- [ ] Verify eval assertions include applicability filtering coverage in all 4 evals
- [x] Run `claude plugin validate plugins/sdlc-workflow` to confirm plugin validity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Define shared rules for validating convention file-type applicability and integrate them into the plan-feature skill and shared conventions documentation.

Enhancements:
- Update the plan-feature skill to require validating convention file-type applicability and recording rationales before applying conventions to tasks.
- Introduce a shared convention-applicability-rules module for consistent applicability checking across skills.

Documentation:
- Add shared documentation describing convention file-type applicability rules, rationale formatting, ambiguous-case handling, and examples.
- Document shared convention applicability rules in CONVENTIONS.md for reuse by plan-feature and verify-pr skills.

Tests:
- Extend plan-feature evals to assert correct filtering behavior based on convention applicability.