### PR TITLE
feat(run-evals): add skill name to eval result summary headings

### DIFF
--- a/plugins/sdlc-workflow/skills/run-evals/SKILL.md
+++ b/plugins/sdlc-workflow/skills/run-evals/SKILL.md
@@ -166,12 +166,14 @@ Write `<workspace>/feedback.json` with empty strings for each eval:
 
 Determine the baseline path: `evals/<skill-name>/baselines/latest/`.
 
-Run the render script:
+Run the render script, passing the skill name so the heading identifies
+which skill the results belong to:
 
 ```bash
 python3 <skill-dir>/scripts/render_summary.py \
   --results <workspace> \
-  --baseline <baseline-path>
+  --baseline <baseline-path> \
+  --skill <skill-name>
 ```
 
 If the baseline path does not exist, omit `--baseline` — the script

--- a/plugins/sdlc-workflow/skills/run-evals/scripts/render_summary.py
+++ b/plugins/sdlc-workflow/skills/run-evals/scripts/render_summary.py
@@ -20,13 +20,14 @@ def load_grading_files(results_dir: Path) -> list[dict]:
     return gradings
 
 
-def render(results_dir: Path, baseline_dir: Path | None) -> str:
+def render(results_dir: Path, baseline_dir: Path | None, skill: str | None = None) -> str:
     gradings = load_grading_files(results_dir)
 
     if not gradings:
         return "> No eval results found.\n"
 
-    lines = ["## Eval Results", ""]
+    heading = f"## Eval Results: {skill}" if skill else "## Eval Results"
+    lines = [heading, ""]
 
     # Per-eval table
     lines.append("| Eval | Passed | Failed | Pass Rate |")
@@ -106,6 +107,12 @@ def main():
         "--baseline", type=Path, default=None, help="Baseline directory"
     )
     parser.add_argument(
+        "--skill",
+        type=str,
+        default=None,
+        help="Skill name to include in the heading",
+    )
+    parser.add_argument(
         "--output",
         type=Path,
         default=None,
@@ -122,7 +129,7 @@ def main():
         print(f"Warning: baseline not found: {baseline}", file=sys.stderr)
         baseline = None
 
-    md = render(args.results, baseline)
+    md = render(args.results, baseline, args.skill)
 
     output_path = args.output or (args.results / "summary.md")
     output_path.write_text(md)


### PR DESCRIPTION
## Summary

- Add optional `--skill` argument to `render_summary.py` that qualifies the heading as `## Eval Results: <skill-name>`
- When `--skill` is omitted, the heading stays as `## Eval Results` for backward compatibility
- Update SKILL.md Step 6 to pass `--skill <skill-name>` when invoking the render script

Implements [TC-4299](https://redhat.atlassian.net/browse/TC-4299)

## Test plan

- [x] `render_summary.py --results <dir> --skill define-feature` produces heading `## Eval Results: define-feature`
- [x] `render_summary.py --results <dir>` without `--skill` produces heading `## Eval Results`
- [x] CI workflow's existing-review detection (`startsWith('## Eval Results')`) prefix-matches skill-qualified headings

## Summary by Sourcery

Add optional skill qualification to eval result summaries and update documentation to use it.

New Features:
- Allow render_summary.py to accept an optional --skill argument to qualify eval result headings with the skill name.

Enhancements:
- Preserve backward-compatible default eval heading when no skill is provided.
- Include the skill-qualified heading in the generated markdown summary when a skill is specified.

Documentation:
- Update SKILL.md instructions to pass the --skill argument so eval summaries indicate which skill the results belong to.