### PR TITLE
docs(releasing): exclude eval baselines from changelog scope

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -68,6 +68,12 @@ These examples use real commit messages from this project to illustrate the dist
 - `feat(skills): add verify-pr skill for PR verification against Jira tasks` — introduces an entirely new skill that didn't exist before
 - `feat(plan-feature): add constraint-aware task generation` — adds a new capability (constraint awareness) that changes how tasks are generated, altering the task template output
 
+## Changelog Scope
+
+Not all commits belong in the changelog. Exclude commits that are purely internal housekeeping and have no user-facing impact:
+
+- **Eval baselines** (`chore(evals): create baselines for …`) — these record expected outputs for skill evaluations and do not change plugin behavior.
+
 ## Versioning Rules
 
 - The version in `marketplace.json` is what Claude Code uses to detect whether an update is available for relative-path plugins. If the version doesn't change, `/plugin marketplace update` will skip the plugin even if files have changed.


### PR DESCRIPTION
## Summary
- Adds a "Changelog Scope" section to `docs/releasing.md` clarifying that eval baseline commits are internal housekeeping and should not appear in release changelogs.

## Test plan
- [ ] Verify the new section renders correctly in the released docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Add a "Changelog Scope" section to the releasing guide explaining that eval baseline housekeeping commits are not user-facing and should be omitted from changelogs.