### PR TITLE
fix(plan-feature): correct issue link direction for Incorporates and Depend

### DIFF
--- a/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
@@ -678,12 +678,12 @@ For every created task, call:
 ```
 jira.create_issue_link(
   link_type="Incorporates",
-  inward_issue_key=<created-task-key>,
-  outward_issue_key=<feature-issue-key>
+  inward_issue_key=<feature-issue-key>,
+  outward_issue_key=<created-task-key>
 )
 ```
 
-This makes the feature show "incorporates TASK-X" on its outward side.
+This makes the feature show "incorporates TASK-X" and the task show "is incorporated by FEATURE-Y".
 
 **Task "depends on" other tasks:**
 
@@ -692,12 +692,12 @@ For each task whose Dependencies section references another task, resolve the re
 ```
 jira.create_issue_link(
   link_type="Depend",
-  inward_issue_key=<dependency-task-key>,
-  outward_issue_key=<dependent-task-key>
+  inward_issue_key=<dependent-task-key>,
+  outward_issue_key=<dependency-task-key>
 )
 ```
 
-This makes the dependent task show "depends on DEPENDENCY-TASK" on its outward side.
+This makes the dependent task show "depends on DEPENDENCY-TASK" and the dependency show "is depended on by DEPENDENT-TASK".
 
 ### 6c – Comment on the feature
 


### PR DESCRIPTION
## Summary
- Swapped inward/outward issue keys for **Incorporates** and **Depend** link types in the plan-feature skill
- Previously the links read backwards (e.g. "Task incorporates Feature" instead of "Feature incorporates Task")
- Now Jira displays the intended relationship on each issue's page

## Test plan
- [ ] Run plan-feature on a test feature and verify Incorporates links show "incorporates" on the feature and "is incorporated by" on each task
- [ ] Verify Depend links show "depends on" on the dependent task and "is depended on by" on the dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Update plan-feature skill documentation to describe the correct inward/outward issue keys for Incorporates and Depend Jira links and the resulting link text on each issue.