### PR TITLE
feat(ci): migrate eval workflows to direct WIF

### DIFF
--- a/.github/workflows/eval-baseline.yml
+++ b/.github/workflows/eval-baseline.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -24,7 +25,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
 
       - name: Install Claude Code
         run: curl -fsSL https://claude.ai/install.sh | bash

--- a/.github/workflows/eval-pr-run.yml
+++ b/.github/workflows/eval-pr-run.yml
@@ -23,7 +23,6 @@ permissions:
   pull-requests: write
   actions: read
   statuses: write
-  id-token: write
 
 jobs:
   discover:
@@ -161,6 +160,10 @@ jobs:
       needs.discover.outputs.skills != '' &&
       (needs.discover.outputs.trusted == 'true' || needs.gate.result == 'success')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
       - name: Checkout PR merge commit
         uses: actions/checkout@v4

--- a/.github/workflows/eval-pr-run.yml
+++ b/.github/workflows/eval-pr-run.yml
@@ -23,6 +23,7 @@ permissions:
   pull-requests: write
   actions: read
   statuses: write
+  id-token: write
 
 jobs:
   discover:
@@ -170,7 +171,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
 
       - name: Install Claude Code
         run: curl -fsSL https://claude.ai/install.sh | bash


### PR DESCRIPTION
## Summary
- Replace JSON service account key authentication with direct Workload Identity Federation in both eval workflows
- Add `id-token: write` permission so GitHub mints an OIDC token for the WIF exchange
- Eliminates long-lived credentials — authentication is now keyless via GitHub's OIDC provider

## Test plan
- [ ] Trigger PR eval workflow by pushing a skill/eval change — confirm auth succeeds
- [ ] Merge to main — confirm baseline workflow auth succeeds and baselines commit
- [ ] Remove legacy SA key secret after both workflows verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Migrate evaluation workflows to use direct Workload Identity Federation for Google Cloud authentication and enable OIDC token issuance in GitHub Actions permissions.

CI:
- Update eval baseline and PR workflows to replace JSON service account key auth with Workload Identity Federation using project and provider secrets.
- Grant id-token write permissions in eval workflows so GitHub can mint OIDC tokens for federated authentication.