### PR TITLE
chore: validate WIF auth

### DIFF
--- a/plugins/sdlc-workflow/skills/setup/SKILL.md
+++ b/plugins/sdlc-workflow/skills/setup/SKILL.md
@@ -247,3 +247,4 @@ Report the validation results to the user.
 - **Always present changes** to the user for review before writing to CLAUDE.md.
 - **Ask only for what is missing** — do not re-ask for information that is already configured.
 - If no changes are needed, report it clearly and stop.
+


### PR DESCRIPTION
Trivial whitespace change to trigger eval workflows and verify WIF authentication works after merge of #125. Revert after verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Add a trailing blank line to the SKILL setup documentation for formatting consistency.