### PR TITLE
fix(ci): set ANTHROPIC_VERTEX_PROJECT_ID and fail on eval errors

### DIFF
--- a/.github/workflows/eval-baseline.yml
+++ b/.github/workflows/eval-baseline.yml
@@ -50,6 +50,7 @@ jobs:
         if: steps.discover.outputs.skills != ''
         env:
           CLAUDE_CODE_USE_VERTEX: "1"
+          ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           CLOUD_ML_REGION: ${{ secrets.GCP_CLOUD_ML_REGION }}
           ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-6"
           ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-6"
@@ -57,6 +58,7 @@ jobs:
         run: |
           COMMIT_HASH="${{ steps.discover.outputs.commit_hash }}"
           IFS=',' read -ra SKILLS <<< "${{ steps.discover.outputs.skills }}"
+          failed=0
 
           for skill in "${SKILLS[@]}"; do
             workspace="/tmp/${skill}-eval-baseline"
@@ -74,7 +76,8 @@ jobs:
             )" --permission-mode dontAsk \
               --allowedTools Read Write Bash Skill Agent Glob \
               --verbose 2>&1 || {
-              echo "::warning::Eval run failed for ${skill} (exit $?)"
+              echo "::error::Eval run failed for ${skill} (exit $?)"
+              failed=1
               continue
             }
 
@@ -97,6 +100,11 @@ jobs:
             echo "--- Baseline contents ---"
             find "${baseline_dir}" -type f 2>/dev/null || true
           done
+
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::One or more eval runs failed"
+            exit 1
+          fi
 
       - name: Commit baselines
         if: steps.discover.outputs.skills != ''

--- a/.github/workflows/eval-pr-run.yml
+++ b/.github/workflows/eval-pr-run.yml
@@ -184,12 +184,14 @@ jobs:
         env:
           SKILLS_CSV: ${{ needs.discover.outputs.skills }}
           CLAUDE_CODE_USE_VERTEX: "1"
+          ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           CLOUD_ML_REGION: ${{ secrets.GCP_CLOUD_ML_REGION }}
           ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-6"
           ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-6"
           ANTHROPIC_MODEL: "claude-opus-4-6"
         run: |
           IFS=',' read -ra SKILLS <<< "$SKILLS_CSV"
+          failed=0
 
           for skill in "${SKILLS[@]}"; do
             eval_count=$(jq '.evals | length' "evals/${skill}/evals.json")
@@ -207,13 +209,19 @@ jobs:
             )" --permission-mode dontAsk \
               --allowedTools Read Write Bash Skill Agent Glob \
               2>&1 || {
-              echo "::warning::PR eval run failed for ${skill} (exit $?)"
+              echo "::error::PR eval run failed for ${skill} (exit $?)"
+              failed=1
               continue
             }
 
             echo "--- Workspace contents ---"
             find "${workspace}" -type f 2>/dev/null | head -80 || true
           done
+
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::One or more eval runs failed"
+            exit 1
+          fi
 
       - name: Post eval results review
         env:


### PR DESCRIPTION
## Summary
- Add `ANTHROPIC_VERTEX_PROJECT_ID` env var — WIF federated tokens don't embed the project ID like SA key JSON did, so Claude Code's Vertex client needs it explicitly
- Stop swallowing eval run failures — track errors across all skills and `exit 1` after the loop if any failed (previously logged `::warning` and continued silently)

## Test plan
- [ ] Merge, then re-trigger PR #126 eval to confirm evals authenticate and execute
- [ ] Intentionally break an eval to verify the job now fails instead of succeeding silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update eval workflows to provide Vertex project ID and fail CI when eval runs error.

CI:
- Set ANTHROPIC_VERTEX_PROJECT_ID from GCP project secret in eval baseline and PR eval workflows.
- Track eval run failures across skills and make workflows exit non-zero when any eval run fails instead of only logging warnings.