### PR TITLE
test(evals): add plan-feature eval for feature-branch workflow mode

### DIFF
--- a/evals/plan-feature/evals.json
+++ b/evals/plan-feature/evals.json
@@ -68,6 +68,24 @@
         "Tasks follow the task-description-template.md format with individual task-N-slug.md files despite adversarial input",
         "Every generated task description contains a Target Branch section set to 'main'"
       ]
+    },
+    {
+      "id": 5,
+      "prompt": "Plan the implementation for feature TC-9005. The feature description is in feature-feature-branch.md and the target repository structure is in repo-backend.md. Write all outputs to the workspace outputs/ directory. For each task you would create, write a markdown file named task-N-slug.md with the full task description. Write the impact map to impact-map.md.",
+      "expected_output": "A structured implementation plan that determines feature-branch workflow mode due to atomicity constraints, generates bookend tasks for branch creation and merge, sets Target Branch to the feature issue ID in intermediate tasks, and includes correct dependency ordering.",
+      "files": ["files/feature-feature-branch.md", "files/repo-backend.md"],
+      "assertions": [
+        "The plan determines feature-branch workflow mode (not direct-to-main) based on the atomicity constraints in the feature description",
+        "A bookend task with Bookend Type create-branch is generated as the first task in the plan",
+        "A bookend task with Bookend Type merge-branch is generated as the last task in the plan",
+        "All intermediate tasks (between the create-branch and merge-branch bookend tasks) have Target Branch set to TC-9005",
+        "The create-branch bookend task has Target Branch set to main",
+        "The merge-branch bookend task has Target Branch set to main",
+        "All intermediate tasks list the create-branch bookend task as a dependency",
+        "The merge-branch bookend task lists all intermediate tasks as dependencies",
+        "Each task file contains all required template sections: Repository, Target Branch, Description, at least one of Files to Modify or Files to Create, Implementation Notes, Acceptance Criteria, Test Requirements",
+        "The plan includes a workflow:feature-branch label decision to be applied to the feature issue"
+      ]
     }
   ]
 }

--- a/evals/plan-feature/files/feature-feature-branch.md
+++ b/evals/plan-feature/files/feature-feature-branch.md
@@ -1,0 +1,82 @@
+<!-- SYNTHETIC TEST DATA — mock Jira feature issue for eval testing; names, URLs, and identifiers are fictional -->
+
+# Mock Jira Feature Issue
+
+**Key**: TC-9005
+**Summary**: Drop status table and migrate to enum column
+**Status**: New
+**Labels**: ai-generated-jira
+**Linked Issues**: None
+
+---
+
+## Feature Overview
+
+Replace the `advisory_status` lookup table with a PostgreSQL enum column on the `advisory` table. The current design stores advisory lifecycle status (New, Analyzing, Fixed, Rejected) as rows in a separate `advisory_status` table joined via foreign key. This adds unnecessary join overhead on every advisory query and complicates the advisory ingestion pipeline. Migrating to an enum column simplifies queries, improves performance, and reduces schema complexity.
+
+## Background and Strategic Fit
+
+The `advisory_status` table was introduced early in development when the set of statuses was expected to grow frequently. In practice, the four statuses have been stable for over a year. The join adds measurable latency to the advisory list endpoint (p95 increased 40ms after adding status filtering). Converting to an enum column aligns with the platform's strategy of reducing unnecessary indirection in the data model.
+
+## Goals
+
+- **Who benefits**: Backend team (simpler queries), frontend team (faster advisory list loads), DevOps (fewer migration edge cases)
+- **Current state**: `advisory.status_id` foreign key references `advisory_status(id)` lookup table; all advisory queries join this table
+- **Target state**: `advisory.status` enum column directly on the `advisory` table; `advisory_status` table dropped
+- **Goal statements**:
+  - Eliminate the `advisory_status` join from all advisory queries
+  - Reduce advisory list endpoint p95 latency by ~40ms
+  - Remove the `advisory_status` table and its migration history
+
+## Requirements
+
+| Requirement | Notes | Is MVP? |
+|---|---|---|
+| Create PostgreSQL enum type `advisory_status_enum` with values (New, Analyzing, Fixed, Rejected) | Migration must be reversible | Yes |
+| Add `status` enum column to `advisory` table, populated from the existing `status_id` join | Backfill in the same migration | Yes |
+| Drop `status_id` foreign key column from `advisory` table | After backfill completes | Yes |
+| Drop `advisory_status` lookup table | Only after all references removed | Yes |
+| Update all advisory queries to use the new `status` column instead of the join | Includes service layer and endpoints | Yes |
+| Update SeaORM entity definitions to reflect the new schema | `entity/advisory.rs` and remove `entity/advisory_status.rs` | Yes |
+| Update advisory ingestion pipeline to write enum values directly | Currently writes to lookup table first | Yes |
+
+## Non-Functional Requirements
+
+- Migration must be atomic: if any step fails, the entire migration rolls back — a partial migration (enum column exists but lookup table is already dropped, or vice versa) would leave the database in an inconsistent state
+- Zero downtime: migration must be safe to run while the application is serving traffic
+- All changes must land together: merging the migration without the code changes would break all advisory queries (they still join the now-dropped table), and merging the code changes without the migration would reference a column that does not exist
+
+## Use Cases (User Experience & Workflow)
+
+### UC-1: Advisory list with status filter
+
+**Persona**: Platform user browsing advisories
+**Pre-conditions**: Advisories have been ingested with various statuses
+**Steps**:
+1. User navigates to advisory list page
+2. User filters by status = "Fixed"
+3. Backend queries `advisory` table with `WHERE status = 'Fixed'` (no join)
+
+**Expected outcome**: Filtered results return faster due to eliminated join
+
+### UC-2: Advisory ingestion
+
+**Persona**: Ingestion pipeline processing new advisory feed
+**Pre-conditions**: Advisory feed contains status field
+**Steps**:
+1. Pipeline parses advisory from feed
+2. Pipeline maps status string to `advisory_status_enum` value
+3. Pipeline inserts advisory row with enum status directly
+
+**Expected outcome**: Ingestion writes enum value directly without lookup table insert
+
+## Customer Considerations
+
+- No user-facing API changes — the response shape remains identical (status is still a string)
+- Migration must be tested against a production-sized dataset before deployment
+
+## Documentation Considerations
+
+- **Doc Impact**: Minor — update internal architecture docs to reflect schema change
+- **User purpose**: No external API documentation changes needed
+- **Reference material**: SeaORM enum mapping documentation


### PR DESCRIPTION
## Summary

- Add eval case id 5 to `evals/plan-feature/evals.json` testing feature-branch workflow mode
- Create `evals/plan-feature/files/feature-feature-branch.md` fixture with atomicity constraints (coordinated DB migration + code changes)
- Assertions verify: workflow mode determination, bookend task generation, Target Branch values, dependency chain, and `workflow:feature-branch` label decision

Implements [TC-4424](https://redhat.atlassian.net/browse/TC-4424)

## Test plan

- [ ] Verify fixture follows the same mock Jira issue format as `feature-standard.md`
- [ ] Verify eval case 5 has correct id, prompt, expected_output, files, and assertions fields
- [ ] Run the new eval case and verify it produces meaningful outputs with bookend tasks and correct Target Branch values

## Summary by Sourcery

Add a new plan-feature evaluation scenario covering feature-branch workflow mode with atomic DB migration and code change constraints.

Documentation:
- Add a synthetic mock Jira feature issue fixture describing an atomic enum migration to support the new plan-feature evaluation scenario.

Tests:
- Introduce eval case 5 in plan-feature evals to exercise feature-branch workflow behavior, including workflow mode, bookend tasks, target branch selection, dependency chain, and labeling decisions.