### PR TITLE
test(evals): add implement-task eval for Target Branch and bookend handling

### DIFF
--- a/evals/implement-task/evals.json
+++ b/evals/implement-task/evals.json
@@ -58,6 +58,21 @@
         "The plan implements only the legitimate SBOM CycloneDX export feature — files modified/created align with the task's Files to Modify and Files to Create sections",
         "The plan scopes changes to the files listed in Files to Modify and Files to Create — no files outside those sections are modified (constraint 1.4, 5.1)"
       ]
+    },
+    {
+      "id": 5,
+      "prompt": "Implement task TC-9205. The task description is in task-feature-branch.md, the target repository structure is in repo-backend.md, and the project CLAUDE.md is in claude-md-mock.md. Do NOT actually modify repository files or call external tools (Jira, git, Serena). Instead, write your implementation plan to the workspace outputs/ directory: write outputs/plan.md describing which files you would modify and create, what changes you would make to each, what branch operations you would perform (checkout, branch creation, PR targeting), and the commit message you would use. For each file you would create or modify, write outputs/file-N-description.md with the detailed changes. Write outputs/conventions.md listing the conventions you discovered from sibling analysis.",
+      "expected_output": "A structured implementation plan that demonstrates the skill correctly extracts the Target Branch (TC-9005) from the task description, bases the task branch on TC-9005 instead of main, targets the PR at TC-9005, and names the task branch after the task issue ID (TC-9205). The plan should still perform normal code inspection steps and follow all commit conventions.",
+      "files": ["files/task-feature-branch.md", "files/repo-backend.md", "files/claude-md-mock.md"],
+      "assertions": [
+        "The plan references checking out TC-9005 (the Target Branch) before creating the task branch — includes git checkout TC-9005 or equivalent, not git checkout main (constraint 3.1, Step 5)",
+        "The plan specifies opening a PR with --base TC-9005 targeting the feature branch, not --base main (Step 10)",
+        "The plan names the task branch TC-9205 (the task issue ID), not TC-9005 (the feature branch) — the task branch is distinct from the Target Branch (constraint 3.1)",
+        "The plan references inspecting existing code before modifying it — mentions reading or analyzing at least 1 of: migration/src/m0001_initial/mod.rs, entity/src/advisory.rs, migration/src/lib.rs (constraint 1.5, Steps 4-9 unaffected by Target Branch)",
+        "The plan includes --trailer='Assisted-by: Claude Code' in the commit (constraint 2.3)",
+        "The planned commit message follows Conventional Commits format (type(scope): description) and references TC-9205 in the footer (constraint 2.1, 2.2)",
+        "The plan extracts and references the Target Branch section from the task description, identifying TC-9005 as the target branch"
+      ]
     }
   ]
 }

--- a/evals/implement-task/files/task-feature-branch.md
+++ b/evals/implement-task/files/task-feature-branch.md
@@ -1,0 +1,50 @@
+<!-- SYNTHETIC TEST DATA — task fixture with Target Branch set to a feature branch for implement-task eval testing -->
+
+# Mock Jira Task
+
+**Key**: TC-9205
+**Summary**: Add migration to drop status table column
+**Status**: To Do
+**Labels**: ai-generated-jira
+**Linked Issues**: is incorporated by TC-9005
+
+---
+
+## Repository
+trustify-backend
+
+## Target Branch
+TC-9005
+
+## Description
+Add a database migration that drops the deprecated `status` column from the `advisory`
+table. The column was replaced by the `severity` enum field in a previous migration and
+is no longer read or written by any service code. Removing it reduces confusion and
+prevents accidental usage.
+
+## Files to Modify
+- `migration/src/lib.rs` — register the new migration module in the migration list
+
+## Files to Create
+- `migration/src/m0002_drop_advisory_status/mod.rs` — migration that drops the `status` column from the `advisory` table
+
+## Implementation Notes
+- Follow the existing migration pattern in `migration/src/m0001_initial/mod.rs` — implement `MigrationTrait` with `up` (drop column) and `down` (re-add column) methods
+- The `advisory` entity in `entity/src/advisory.rs` no longer references the `status` column — verify this before proceeding
+- Use SeaORM's `TableAlterStatement` to drop the column: `manager.alter_table(Table::alter().table(Advisory::Table).drop_column(Advisory::Status).to_owned()).await`
+- Register the new migration in `migration/src/lib.rs` by adding it to the `vec![]` in the `migrations()` function, following the pattern of `m0001_initial`
+- The `down` method should re-add the column as `ColumnDef::new(Advisory::Status).string().null()` to allow rollback
+
+## Acceptance Criteria
+- [ ] Migration drops the `status` column from the `advisory` table
+- [ ] Migration `down` method re-adds the column as nullable string for rollback
+- [ ] Migration is registered in `migration/src/lib.rs`
+- [ ] No service or entity code references the `status` column
+
+## Test Requirements
+- [ ] Test that the migration runs successfully against a test database
+- [ ] Test that the rollback (down) re-adds the column
+- [ ] Verify that existing advisory queries still work after the column is dropped
+
+## Dependencies
+- Depends on: None


### PR DESCRIPTION
## Summary
- Add eval case 5 to `evals/implement-task/evals.json` testing Target Branch feature-branch targeting
- Create `task-feature-branch.md` fixture with Target Branch set to `TC-9005` (not `main`)
- 7 assertions verify: branch checkout from Target Branch, PR `--base` targeting, task branch naming, code inspection, commit conventions

## Test plan
- [ ] Run eval case 5 and verify it produces a plan with feature-branch targeting
- [ ] Verify fixture follows the mock Jira task format matching sibling fixtures
- [ ] Verify all existing eval cases (1-4) remain unaffected

Implements [TC-4425](https://redhat.atlassian.net/browse/TC-4425)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a new implement-task eval scenario to cover feature-branch target handling for Jira-style tasks.

Tests:
- Add a fifth implement-task eval case validating feature-branch target branch behavior, including branch checkout, PR base targeting, branch naming, code inspection, and commit conventions.
- Introduce a new synthetic Jira task fixture with a non-main Target Branch to drive the new eval scenario.