### PR TITLE
fix(conventions): resolve CONVENTIONS.md lookup via Repository Registry Path

### DIFF
--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -253,9 +253,13 @@ Goals:
 
 ### CONVENTIONS.md lookup
 
-Check for a `CONVENTIONS.md` file at the repository root (using `list_dir`, `search_for_pattern`,
-or Glob). If present, read it and follow its conventions throughout implementation. This includes
-naming rules, directory structure for new files, code patterns, and test conventions.
+Look up the task's target repository in the **Repository Registry** (CLAUDE.md) and use
+the **Path** column to locate the repository root. Check for a `CONVENTIONS.md` file at
+that root using the Serena instance for the repository (`list_dir`, `search_for_pattern`).
+If no Serena instance is available, use Read or Glob with the absolute path from the
+Registry (e.g., `<Path>/CONVENTIONS.md`). If present, read it and follow its conventions
+throughout implementation. This includes naming rules, directory structure for new files,
+code patterns, and test conventions.
 
 This step is optional — if `CONVENTIONS.md` does not exist, proceed normally.
 

--- a/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
@@ -321,10 +321,13 @@ use Explore agents with Glob, Grep, and Read tools.
 
 ### CONVENTIONS.md lookup
 
-For each target repository, check for a `CONVENTIONS.md` file at the repository root
-(using `list_dir` or Glob). If present, read it and use its conventions — naming rules,
-directory structure, code patterns, test conventions — to inform the **Implementation Notes**
-in generated task descriptions. Reference specific conventions by name when they apply to a task.
+For each target repository, look up its **Path** in the **Repository Registry** (CLAUDE.md)
+to locate the repository root. Check for a `CONVENTIONS.md` file at that root using the
+Serena instance for the repository (`list_dir`). If no Serena instance is available, use
+Glob or Read with the absolute path from the Registry (e.g., `<Path>/CONVENTIONS.md`).
+If present, read it and use its conventions — naming rules, directory structure, code
+patterns, test conventions — to inform the **Implementation Notes** in generated task
+descriptions. Reference specific conventions by name when they apply to a task.
 
 This step is optional — if `CONVENTIONS.md` does not exist, proceed normally.
 

--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -224,9 +224,12 @@ auditable that all threads were considered.
 Before classifying feedback, load the project's established conventions so they can
 inform classification decisions.
 
-1. **CONVENTIONS.md:** Check for a `CONVENTIONS.md` file at the repository root (using
-   `search_for_pattern`, Grep, or Glob). If present, read its contents. This provides
-   explicit, documented project conventions.
+1. **CONVENTIONS.md:** Look up the task's target repository in the **Repository Registry**
+   (CLAUDE.md) and use the **Path** column to locate the repository root. Check for a
+   `CONVENTIONS.md` file at that root using the Serena instance for the repository
+   (`search_for_pattern`). If no Serena instance is available, use Grep, Glob, or Read
+   with the absolute path from the Registry (e.g., `<Path>/CONVENTIONS.md`). If present,
+   read its contents. This provides explicit, documented project conventions.
 
 2. **Codebase convention cache:** This step does not perform exhaustive codebase analysis
    yet — that happens in the Style/Conventions sub-agent. The goal here is only to load


### PR DESCRIPTION
## Summary
- Update CONVENTIONS.md lookup in implement-task, verify-pr, and plan-feature to explicitly resolve the target repository root using the Path column from the Repository Registry in CLAUDE.md
- Add absolute path fallback (`<Path>/CONVENTIONS.md`) for the no-Serena case, ensuring cross-repo convention loading works when filesystem tools (Glob, Read) are the only option

## Jira
Implements [TC-4529](https://redhat.atlassian.net/browse/TC-4529)

## Summary by Sourcery

Clarify how SDLC workflow skills locate and load repository-specific CONVENTIONS.md files using the Repository Registry paths, with a fallback for environments without Serena.

Documentation:
- Update plan-feature skill documentation to resolve CONVENTIONS.md from the repository’s Registry Path with Serena-first and filesystem fallback lookup.
- Update implement-task skill documentation to use the Repository Registry Path for CONVENTIONS.md discovery, including non-Serena filesystem access.
- Update verify-pr skill documentation to load CONVENTIONS.md via the Repository Registry Path with appropriate Serena and filesystem lookup options.