### PR TITLE
fix(plan-feature): reword eval-3 assertions for feature-branch workflow tolerance

### DIFF
--- a/evals/plan-feature/evals.json
+++ b/evals/plan-feature/evals.json
@@ -47,14 +47,14 @@
       "assertions": [
         "Tasks target both 'trustify-backend' and 'trustify-ui' repositories with at least one task per repo",
         "Backend tasks have lower task numbers than the frontend tasks that depend on them",
-        "Frontend tasks reference Figma design context mentioning specific PatternFly components and visual specifications",
-        "At least one frontend task explicitly depends on a backend task in its Dependencies section",
+        "UI-facing frontend tasks (pages, components) reference Figma design context mentioning specific PatternFly components and visual specifications — API-layer frontend tasks (API types, client functions, hooks) are exempt from this requirement",
+        "Cross-repo dependency ordering is enforced: either at least one frontend task explicitly depends on a backend task in its Dependencies section, or all tasks target a shared feature branch where backend tasks have lower task numbers than frontend tasks (implicit ordering via feature-branch workflow)",
         "Frontend tasks reference paths from repo-frontend.md; backend tasks reference paths from repo-backend.md",
         "Every generated task description contains a Repository section with a single repository name (not multiple repos per task)",
         "Every generated task description contains Target Branch, Description, Acceptance Criteria, and Test Requirements sections as required by the handoff contract in task-description-template.md",
         "File paths in Files to Modify and Files to Create reference paths from the corresponding mock repository structure manifests (repo-backend.md or repo-frontend.md), not invented paths",
-        "Implementation Notes in every task reference specific file paths and code patterns from the repository, not abstract or generic guidance",
-        "Every generated task description contains a Target Branch section set to 'main'",
+        "Implementation Notes in every non-bookend task reference specific file paths and code patterns from the repository, not abstract or generic guidance — bookend tasks (create-branch, merge-branch) are exempt as they omit Implementation Notes by design",
+        "Every generated task description contains a Target Branch section — either all set to 'main' (direct-to-main workflow) or bookend tasks set to 'main' with intermediate tasks set to the feature issue ID (feature-branch workflow)",
         "After each task is created, a description digest comment is posted following the protocol in shared/description-digest-protocol.md (marker: '[sdlc-workflow] Description digest: sha256:<hex>')"
       ]
     },


### PR DESCRIPTION
## Summary
- Reword 4 eval-3 assertions that incorrectly penalized valid feature-branch workflow behavior
- Index 2: exempt API-layer frontend tasks from Figma reference requirement
- Index 3: accept implicit ordering via feature-branch workflow as alternative to explicit Dependencies
- Index 8: exempt bookend tasks (create-branch, merge-branch) from Implementation Notes requirement
- Index 9: accept feature branch names (e.g., TC-9003) for intermediate tasks

Implements [TC-4562](https://redhat.atlassian.net/browse/TC-4562)

## Test plan
- [ ] Verify reworded assertions would pass against existing baseline grading evidence in `evals/plan-feature/baselines/latest/eval-3/grading.json`
- [ ] Confirm evals 1, 2, 4, 5 assertions are unaffected (only eval-3 indices 2, 3, 8, 9 changed)
- [ ] Run eval suite to confirm eval-3 score improves from 8/11 to 11/11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update plan-feature eval-3 assertions to better accommodate valid feature-branch workflows without penalizing acceptable patterns.

Bug Fixes:
- Adjust eval-3 assertion for Figma references to avoid penalizing API-layer frontend tasks that do not require design artifacts.
- Relax eval-3 dependency ordering assertion to accept implicit ordering via feature-branch workflows as an alternative to explicit dependency links.
- Refine eval-3 implementation-notes requirement to exempt bookend tasks such as branch creation and merge steps.
- Allow feature-branch-style task names (for intermediate tasks) to satisfy eval-3 naming assertions without being treated as violations.