### PR TITLE
feat(run-evals): add failure evidence to summary.md rendering

### DIFF
--- a/.github/workflows/eval-pr-run.yml
+++ b/.github/workflows/eval-pr-run.yml
@@ -306,6 +306,9 @@ jobs:
             } else if (gateResult === 'failure') {
               state = 'failure';
               description = 'Approval was rejected in eval-protected environment';
+            } else if (evalsResult === 'skipped') {
+              state = 'success';
+              description = 'No evals to run for changed files';
             } else {
               state = 'failure';
               description = 'Eval run failed — check workflow logs';

--- a/plugins/sdlc-workflow/skills/run-evals/SKILL.md
+++ b/plugins/sdlc-workflow/skills/run-evals/SKILL.md
@@ -182,6 +182,12 @@ renders results without a comparison.
 The script writes `<workspace>/summary.md`. Display its contents to the
 user.
 
+When any eval has failing assertions, the summary includes a
+"Failed Assertions" section after the per-eval table, before the
+aggregate and baseline stats. Each failing eval is rendered as a
+collapsible `<details>` block listing the assertion text and grading
+evidence for each failed assertion.
+
 ## Rules
 
 - Write all outputs to the exact paths specified. No intermediate directories,

--- a/plugins/sdlc-workflow/skills/run-evals/scripts/render_summary.py
+++ b/plugins/sdlc-workflow/skills/run-evals/scripts/render_summary.py
@@ -46,6 +46,31 @@ def render(results_dir: Path, baseline_dir: Path | None, skill: str | None = Non
 
     lines.append("")
 
+    # Failed assertion evidence
+    has_failures = any(g.get("summary", {}).get("failed", 0) > 0 for g in gradings)
+    if has_failures:
+        lines.append("### Failed Assertions")
+        lines.append("")
+        for g in gradings:
+            s = g.get("summary", {})
+            if s.get("failed", 0) == 0:
+                continue
+            eval_id = g["_eval_id"]
+            failed = [
+                a for a in g.get("assertion_results", []) if not a.get("passed", True)
+            ]
+            count = len(failed)
+            label = "assertion" if count == 1 else "assertions"
+            lines.append("<details>")
+            lines.append(f"<summary>{eval_id}: {count} failing {label}</summary>")
+            lines.append("")
+            for a in failed:
+                lines.append(f'- **Assertion:** "{a.get("text", "")}"')
+                lines.append(f'  **Evidence:** "{a.get("evidence", "")}"')
+                lines.append("")
+            lines.append("</details>")
+            lines.append("")
+
     # Aggregate from benchmark.json if present
     benchmark_path = results_dir / "benchmark.json"
     if benchmark_path.exists():

--- a/plugins/sdlc-workflow/skills/run-evals/scripts/render_summary.py
+++ b/plugins/sdlc-workflow/skills/run-evals/scripts/render_summary.py
@@ -2,6 +2,7 @@
 """Render eval results and optional baseline comparison as Markdown."""
 
 import argparse
+import html
 import json
 import sys
 from pathlib import Path
@@ -65,8 +66,10 @@ def render(results_dir: Path, baseline_dir: Path | None, skill: str | None = Non
             lines.append(f"<summary>{eval_id}: {count} failing {label}</summary>")
             lines.append("")
             for a in failed:
-                lines.append(f'- **Assertion:** "{a.get("text", "")}"')
-                lines.append(f'  **Evidence:** "{a.get("evidence", "")}"')
+                text = html.escape(a.get("text", ""), quote=False)
+                evidence = html.escape(a.get("evidence", ""), quote=False)
+                lines.append(f'- **Assertion:** "{text}"')
+                lines.append(f'  **Evidence:** "{evidence}"')
                 lines.append("")
             lines.append("</details>")
             lines.append("")

--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -296,6 +296,12 @@ Collect all inputs needed for sub-agent dispatch envelopes:
 8. **Branch names** — the PR branch and base branch names (for Style/Conventions
    sub-agent's test change classification)
 
+9. **Eval infrastructure files** — filter the PR diff file list for paths matching
+   `plugins/sdlc-workflow/skills/run-evals/scripts/*.py` or
+   `plugins/sdlc-workflow/skills/run-evals/SKILL.md`. Include this list in the
+   Correctness sub-agent dispatch so it can auto-generate verification commands
+   when eval infrastructure changes (for Correctness sub-agent)
+
 ### Step 5b – Read Templates and Skill Files
 
 Read the following files to construct dispatch prompts:

--- a/plugins/sdlc-workflow/skills/verify-pr/correctness.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/correctness.md
@@ -146,14 +146,48 @@ For each command:
 2. Compare the output to the expected outcome described in the task.
 3. Record PASS if the output matches, FAIL if it does not.
 
-If no Verification Commands section exists in the Task Specification, skip this
-check and record N/A.
+If no Verification Commands section exists in the Task Specification, proceed to
+the eval infrastructure detection below before recording N/A.
+
+#### 3b — Eval Infrastructure Change Detection
+
+Scan the PR diff file list for changes to eval infrastructure — specifically files
+matching `plugins/sdlc-workflow/skills/run-evals/scripts/*.py` or
+`plugins/sdlc-workflow/skills/run-evals/SKILL.md`.
+
+If eval infrastructure changes are detected:
+
+1. **Discover existing baselines**: list directories matching
+   `evals/*/baselines/latest/` in the repository. Each match represents a skill
+   with baseline eval data.
+2. **Generate verification commands**: for each discovered baseline, generate a
+   command that runs the modified render script against that baseline:
+   ```
+   python3 plugins/sdlc-workflow/skills/run-evals/scripts/render_summary.py \
+     --results evals/<skill>/baselines/latest/ \
+     --skill <skill> \
+     --output /tmp/verify-<skill>-summary.md
+   ```
+   If `aggregate_benchmark.py` was also modified, additionally generate:
+   ```
+   python3 plugins/sdlc-workflow/skills/run-evals/scripts/aggregate_benchmark.py \
+     --results evals/<skill>/baselines/latest/
+   ```
+3. **Run the generated commands** and verify they complete successfully (exit
+   code 0). The expected outcome is that the scripts run without errors against
+   existing baseline data — this confirms backward compatibility of the
+   infrastructure changes.
+4. **Include results in the verdict**: if any generated command fails, record
+   the check as FAIL with the failing command and its output.
+
+If no eval infrastructure changes are detected, skip this sub-step — it does not
+affect the verdict when the PR does not touch run-evals files.
 
 #### Verdict
 
-- **PASS** — all verification commands produce the expected output
+- **PASS** — all verification commands (task-specified and auto-generated) produce the expected output
 - **FAIL** — one or more commands produce unexpected output
-- **N/A** — no verification commands were specified in the task
+- **N/A** — no verification commands were specified in the task AND no eval infrastructure changes detected
 
 Evidence: for each command, show the command run, the expected output, and the
 actual output. For PASS results, a brief confirmation is sufficient.


### PR DESCRIPTION
## Summary

- Add "Failed Assertions" section to `render_summary.py` that shows assertion text and grading evidence for each failed eval
- Uses collapsible `<details>` blocks per failing eval to keep output readable
- Section only appears when failures exist — backward compatible with all-pass results
- Document the failure evidence rendering in SKILL.md Step 6
- Escape HTML special characters in assertion text/evidence using `html.escape()` to prevent HTML injection and broken rendering
- Fix eval-pr-run.yml to report success when no evals need to run (was reporting misleading failure)
- Add eval infrastructure change detection to verify-pr correctness check — auto-generates verification commands when run-evals scripts are modified

Implements [TC-4571](https://redhat.atlassian.net/browse/TC-4571)
Implements [TC-4578](https://redhat.atlassian.net/browse/TC-4578)
Implements [TC-4579](https://redhat.atlassian.net/browse/TC-4579)
Implements [TC-4583](https://redhat.atlassian.net/browse/TC-4583)

## Test plan

- [x] Ran render script against verify-pr baseline (has eval-5 failure) — failure evidence renders correctly
- [x] Ran render script against all-pass test data — no "Failed Assertions" section appears
- [x] Ran render script against mixed pass/fail test data — correct assertion text and evidence shown
- [x] Verified collapsible `<details><summary>` HTML renders in GitHub Markdown
- [x] Tested with `<script>`, `</details>`, `&`, and quote characters — all properly escaped
- [x] Verified eval-pr-run.yml status logic handles all four cases: success, discover failure, gate rejection, skipped evals

🤖 Generated with [Claude Code](https://claude.com/claude-code)