### PR TITLE
feat(plan-feature): offload digest SHA-256 computation to a script

### DIFF
--- a/plugins/sdlc-workflow/shared/description-digest-protocol.md
+++ b/plugins/sdlc-workflow/shared/description-digest-protocol.md
@@ -47,11 +47,12 @@ construction.
 ## Hashing
 
 - **Algorithm:** SHA-256
-- **Input:** The full Jira description field text as returned by the API (ADF JSON
-  string when using MCP, or the raw text when using REST API). Normalize the input
-  by parsing it as JSON and re-serializing with compact separators
-  (`json.dumps(parsed, separators=(',', ':'))`). This ensures consistent hashing
-  regardless of input formatting.
+- **Input:** The full Jira description field text as returned by the API.
+  Normalization depends on the input format:
+  - **ADF JSON** (MCP path): parse as JSON and re-serialize with compact separators
+    (`json.dumps(parsed, separators=(',', ':'))`). This ensures consistent hashing
+    regardless of whitespace or key formatting in the original JSON.
+  - **Raw text** (REST API path): strip leading and trailing whitespace only.
 - **Output:** Lowercase hexadecimal digest (64 characters)
 
 The producer computes the hash from the description content it wrote to the issue,

--- a/plugins/sdlc-workflow/shared/description-digest-protocol.md
+++ b/plugins/sdlc-workflow/shared/description-digest-protocol.md
@@ -20,17 +20,46 @@ The full comment body is a single line:
 [sdlc-workflow] Description digest: sha256:<hex-digest>
 ```
 
+## Tool-Based Computation (Preferred)
+
+Use the `scripts/sha256-digest.py` script to compute the digest. The script reads
+ADF JSON from a file path argument or stdin, normalizes it with compact JSON
+separators, computes SHA-256, and prints the 64-character lowercase hex digest to
+stdout.
+
+**Usage:**
+
+```bash
+# From a file
+python3 scripts/sha256-digest.py /tmp/desc.json
+
+# From stdin
+cat /tmp/desc.json | python3 scripts/sha256-digest.py
+```
+
+The script exits non-zero with an error message on stderr if the input is not valid
+JSON or is empty. Always check the exit code before using the output.
+
+This is the preferred method because it eliminates LLM hashing errors (placeholders,
+abbreviated hashes, incorrect computation). The script output is correct by
+construction.
+
 ## Hashing
 
 - **Algorithm:** SHA-256
 - **Input:** The full Jira description field text as returned by the API (ADF JSON
   string when using MCP, or the raw text when using REST API). Normalize the input
-  by stripping leading/trailing whitespace before hashing.
+  by parsing it as JSON and re-serializing with compact separators
+  (`json.dumps(parsed, separators=(',', ':'))`). This ensures consistent hashing
+  regardless of input formatting.
 - **Output:** Lowercase hexadecimal digest (64 characters)
 
 The producer computes the hash from the description content it wrote to the issue,
 immediately after creating it. This ensures the digest reflects exactly what was
 persisted.
+
+When the `scripts/sha256-digest.py` script is available, use it instead of manual
+computation — see **Tool-Based Computation** above.
 
 ## Jira Comment Format
 

--- a/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
@@ -652,19 +652,41 @@ jira.edit_issue(
 Preserve any existing labels on the feature issue — append `workflow:feature-branch` to
 the current label list rather than replacing it.
 
-Immediately after creating each task (before creating issue links or other comments), you **must** post a description digest comment on the created issue. Compute the SHA-256 hash using the `scripts/sha256-digest.py` script — do **not** compute the hash yourself.
+Immediately after creating each task (before creating issue links or other comments), you **must** produce a description digest for the task. The digest is a SHA-256 hash of the description content you wrote.
 
 **Digest computation steps:**
 
-1. **Write the description JSON to a temp file.** Use the Write tool to save the exact ADF JSON description you passed to `jira.create_issue` (the `description` field value) to a temporary file (e.g., `/tmp/desc-<issue-key>.json`).
+1. **Save the description content to a temp file.** Use the Write tool to save the
+   task description content to a temporary file (e.g., `/tmp/desc-<issue-key>.json`).
+   Save whatever form of the description you have — ADF JSON if you posted to Jira,
+   or the raw markdown text if you wrote to a file.
 
-2. **Run the digest script.** Invoke the script via Bash and capture its output:
+2. **Compute the hash via Bash.** Use the digest script if available, or an inline
+   Python command as fallback. Both produce identical results for JSON input.
+
+   **Primary — digest script:**
    ```
    python3 scripts/sha256-digest.py /tmp/desc-<issue-key>.json
    ```
-   The script outputs only the 64-character lowercase hex digest to stdout — no labels, no prefixes. If the script exits non-zero, report the error and stop.
 
-3. **Post the digest comment.** Use the script's output as the `<hex-digest>` value in this ADF comment:
+   **Fallback — inline Python** (if the script is not available):
+   ```
+   python3 -c "
+   import hashlib, json, sys
+   raw = open(sys.argv[1]).read().strip()
+   try:
+       d = json.loads(raw)
+       normalized = json.dumps(d, separators=(',', ':'))
+   except json.JSONDecodeError:
+       normalized = raw
+   print(hashlib.sha256(normalized.encode('utf-8')).hexdigest())
+   " /tmp/desc-<issue-key>.json
+   ```
+
+   Both output only the 64-character lowercase hex digest to stdout. Do **not**
+   compute SHA-256 yourself — always use Bash to run one of the commands above.
+
+3. **Post the digest comment.** Use the hash output as `<hex-digest>` in this ADF comment:
 
 ```json
 {
@@ -684,7 +706,14 @@ Immediately after creating each task (before creating issue links or other comme
 }
 ```
 
-Replace `<hex-digest>` with the exact output from the script. Do not append the Comment Footnote to this comment — it must be a standalone comment separate from any other comments.
+Replace `<hex-digest>` with the exact Bash output. Do not append the Comment Footnote
+to this comment — it must be a standalone comment separate from any other comments.
+
+If posting to Jira is not available (e.g., in eval or dry-run mode), append the
+digest line directly to the task output file instead:
+```
+[sdlc-workflow] Description digest: sha256:<hex-digest>
+```
 
 4. **Clean up.** Delete the temp file after posting the comment.
 

--- a/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
@@ -652,7 +652,19 @@ jira.edit_issue(
 Preserve any existing labels on the feature issue — append `workflow:feature-branch` to
 the current label list rather than replacing it.
 
-Immediately after creating each task (before creating issue links or other comments), you **must** post a description digest comment on the created issue. Compute a SHA-256 hash of the description you wrote, then post a standalone ADF comment with this exact format:
+Immediately after creating each task (before creating issue links or other comments), you **must** post a description digest comment on the created issue. Compute the SHA-256 hash using the `scripts/sha256-digest.py` script — do **not** compute the hash yourself.
+
+**Digest computation steps:**
+
+1. **Write the description JSON to a temp file.** Use the Write tool to save the exact ADF JSON description you passed to `jira.create_issue` (the `description` field value) to a temporary file (e.g., `/tmp/desc-<issue-key>.json`).
+
+2. **Run the digest script.** Invoke the script via Bash and capture its output:
+   ```
+   python3 scripts/sha256-digest.py /tmp/desc-<issue-key>.json
+   ```
+   The script outputs only the 64-character lowercase hex digest to stdout — no labels, no prefixes. If the script exits non-zero, report the error and stop.
+
+3. **Post the digest comment.** Use the script's output as the `<hex-digest>` value in this ADF comment:
 
 ```json
 {
@@ -672,9 +684,9 @@ Immediately after creating each task (before creating issue links or other comme
 }
 ```
 
-Replace `<hex-digest>` with the actual computed lowercase 64-character SHA-256 hex digest of the description content. You **must** compute the real hash — never use a placeholder (`<hex-digest>`, `<hex>`), an abbreviated hash (fewer than 64 characters), an example hash copied from documentation, or any hardcoded value. The digest must be exactly 64 lowercase hexadecimal characters derived from the description you just wrote.
+Replace `<hex-digest>` with the exact output from the script. Do not append the Comment Footnote to this comment — it must be a standalone comment separate from any other comments.
 
-Strip leading/trailing whitespace from the description before hashing. Do not append the Comment Footnote to this comment — it must be a standalone comment separate from any other comments.
+4. **Clean up.** Delete the temp file after posting the comment.
 
 See `shared/description-digest-protocol.md` for the full protocol specification including consumer verification behavior and common mistakes to avoid.
 

--- a/scripts/sha256-digest.py
+++ b/scripts/sha256-digest.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Compute SHA-256 digest of ADF JSON for the description-digest protocol."""
+
+import hashlib
+import json
+import sys
+
+
+def compute_digest(raw: str) -> str:
+    """Parse JSON input, re-serialize with compact separators, and return the SHA-256 hex digest."""
+    parsed = json.loads(raw)
+    normalized = json.dumps(parsed, separators=(",", ":"))
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def main() -> int:
+    try:
+        if len(sys.argv) > 1:
+            with open(sys.argv[1], "r", encoding="utf-8") as f:
+                raw = f.read()
+        else:
+            raw = sys.stdin.read()
+
+        if not raw.strip():
+            print("error: empty input", file=sys.stderr)
+            return 1
+
+        print(compute_digest(raw))
+        return 0
+
+    except json.JSONDecodeError as e:
+        print(f"error: invalid JSON: {e}", file=sys.stderr)
+        return 1
+    except FileNotFoundError:
+        print(f"error: file not found: {sys.argv[1]}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add `scripts/sha256-digest.py` — a standalone Python script that reads ADF JSON, normalizes it with compact separators, and outputs the SHA-256 hex digest to stdout
- Update plan-feature SKILL.md to instruct the LLM to use the script instead of computing SHA-256 itself (write JSON to temp file, run script, use output)
- Update `description-digest-protocol.md` with a new "Tool-Based Computation" section documenting the script as the preferred hashing method
- Clarify Hashing section normalization rules: JSON parse+re-serialize for ADF input, strip whitespace for raw text input (review feedback fix)

Implements [TC-4606](https://redhat.atlassian.net/browse/TC-4606)
Implements [TC-4608](https://redhat.atlassian.net/browse/TC-4608)

## Test plan

- [x] Script produces correct SHA-256 matching Python `hashlib.sha256` for sample ADF JSON
- [x] Script handles stdin input correctly
- [x] Script handles file path argument correctly
- [x] Script outputs exactly 64 lowercase hex chars (no labels or prefixes)
- [x] Script exits 1 with stderr message for invalid JSON input
- [x] Script exits 1 with stderr message for empty input
- [x] Script exits 1 with stderr message for missing file
- [ ] Run plan-feature evals to verify digest assertion still passes at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)