### PR TITLE
docs(constraints): add cross-phase integrity and convention applicability constraints

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -42,6 +42,18 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 1.30 | `verify-pr` Test Quality verdict MUST incorporate eval results: PASS when all evals pass and no traditional test issues, WARN when any eval assertions fail, N/A only when neither traditional tests nor eval results are present. | `verify-pr/SKILL.md` — Step 6a; `verify-pr/style-conventions.md` — Check 5 |
 | 1.31 | `verify-pr` MUST autonomously create sub-tasks for eval assertion failures with labels `["ai-generated-jira", "eval-failure"]`, grouped by eval ID. | `verify-pr/SKILL.md` — Step 6d |
 | 1.32 | `verify-pr` eval failure sub-tasks MUST enter the existing root-cause investigation pipeline (Step 7). | `verify-pr/SKILL.md` — Step 7 |
+| 1.33 | `plan-feature` MUST post a description digest comment after creating each task per `shared/description-digest-protocol.md`. | `plan-feature/SKILL.md` — Step 6a |
+| 1.34 | `implement-task` MUST verify the description digest before proceeding and pause if a mismatch is detected. | `implement-task/SKILL.md` — Step 1.5 |
+| 1.35 | `implement-task` MUST skip digest verification with a warning when no digest comment exists (backward compatibility). | `implement-task/SKILL.md` — Step 1.5 |
+| 1.36 | `verify-pr` convention upgrade MUST validate convention file-type applicability per `shared/convention-applicability-rules.md` before upgrading a suggestion. | `verify-pr/style-conventions.md` — Check 1 |
+
+### Prior Art — Cross-phase integrity (§1.33–1.35)
+
+> Implements the zero-trust inter-agent principle from fullsend's [security-threat-model.md §Zero Trust Between Agents](https://github.com/fullsend-ai/fullsend/blob/7f9cea122112e630eb9a40763c462a2c83b98543/docs/problems/security-threat-model.md#L201-L230) as a content-level detection mechanism. Fullsend handles stale workflow state preventively (clearing labels between phases — [architecture.md §Stale State Clearing](https://github.com/fullsend-ai/fullsend/blob/7f9cea122112e630eb9a40763c462a2c83b98543/docs/architecture.md#L266)); this constraint addresses stale data content detectively (comparing hashes). The temporal split-payload attack pattern ([security-threat-model.md §Temporal Split-Payload](https://github.com/fullsend-ai/fullsend/blob/7f9cea122112e630eb9a40763c462a2c83b98543/docs/problems/security-threat-model.md#L232-L296)) further motivates cross-phase integrity verification.
+
+### Prior Art — Convention applicability (§1.36)
+
+> Net-new; no fullsend counterpart. Fullsend's closest concept — independent tier classification by review agents ([intent-representation.md §Independent Tier Classification](https://github.com/fullsend-ai/fullsend/blob/7f9cea122112e630eb9a40763c462a2c83b98543/docs/problems/intent-representation.md#L251)) — addresses scope assessment, not file-type applicability of convention guidance. This constraint addresses a gap specific to sdlc-plugins' CONVENTIONS.md-driven convention application.
 
 ---
 
@@ -82,6 +94,11 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 4.10 | Tasks SHOULD include a **Reuse Candidates** section when overlapping code (domain logic, components, utilities, or patterns) was found during repository analysis, listing file paths, symbol names, and relevance descriptions. | `plan-feature/SKILL.md` — Task Description Template |
 | 4.11 | When a task's scope matches a convention from CONVENTIONS.md (e.g., migrations with FK columns requiring indexes), the Implementation Notes MUST include explicit guidance referencing the convention by section name with a concrete example file. | `plan-feature/SKILL.md` — Step 5 (Convention-aware task enrichment) |
 | 4.12 | Every generated task description MUST include a **Target Branch** section. The value is `main` for direct-to-main mode, or the feature issue ID for feature-branch mode intermediate tasks. | `plan-feature/SKILL.md` — Step 5 (Target Branch assignment); `task-description-template.md` — Rules |
+| 4.13 | `plan-feature` convention-aware enrichment MUST validate convention file-type applicability per `shared/convention-applicability-rules.md` before including a convention in Implementation Notes. | `plan-feature/SKILL.md` — Step 5 |
+
+### Prior Art — Convention applicability (§4.13)
+
+> Net-new; no fullsend counterpart. Fullsend's closest concept — independent tier classification by review agents ([intent-representation.md §Independent Tier Classification](https://github.com/fullsend-ai/fullsend/blob/7f9cea122112e630eb9a40763c462a2c83b98543/docs/problems/intent-representation.md#L251)) — addresses scope assessment, not file-type applicability of convention guidance. This constraint addresses a gap specific to sdlc-plugins' CONVENTIONS.md-driven convention application.
 
 ---
 
@@ -109,13 +126,15 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 
 Each constraint above references its source. The full source files are:
 
-- `plugins/sdlc-workflow/skills/plan-feature/SKILL.md` — Guardrails (§1.1–1.3), Step 4.5 Determine Workflow Mode (§1.27), Task Description Template (§4.1–4.10), Step 5 Convention-aware task enrichment (§4.11), Step 5 Target Branch assignment (§4.12), Step 5 Bookend task generation (§3.4)
-- `plugins/sdlc-workflow/skills/implement-task/SKILL.md` — Important Rules (§1.4–1.6, §5.1–5.3), Step 1 (§1.6), Step 4/6/9 (§5.4), Step 5 (§1.15, §3.1, §3.4), Step 7 (§5.9–5.13), Step 9 (§2.1–2.3, §5.6–5.8), Step 10 (§3.2, §3.3)
+- `plugins/sdlc-workflow/skills/plan-feature/SKILL.md` — Guardrails (§1.1–1.3), Step 4.5 Determine Workflow Mode (§1.27), Step 5 Convention-aware task enrichment (§4.11, §4.13), Step 5 Target Branch assignment (§4.12), Step 5 Bookend task generation (§3.4), Step 6a Digest posting (§1.33), Task Description Template (§4.1–4.10)
+- `plugins/sdlc-workflow/skills/implement-task/SKILL.md` — Important Rules (§1.4–1.6, §5.1–5.3), Step 1 (§1.6), Step 1.5 Digest verification (§1.34, §1.35), Step 4/6/9 (§5.4), Step 5 (§1.15, §3.1, §3.4), Step 7 (§5.9–5.13), Step 9 (§2.1–2.3, §5.6–5.8), Step 10 (§3.2, §3.3)
 - `plugins/sdlc-workflow/shared/task-description-template.md` — Rules (§4.12)
+- `plugins/sdlc-workflow/shared/description-digest-protocol.md` — Digest format and verification procedure (§1.33, §1.34, §1.35)
+- `plugins/sdlc-workflow/shared/convention-applicability-rules.md` — File-type applicability matching logic (§1.36, §4.13)
 - `plugins/sdlc-workflow/skills/verify-pr/SKILL.md` — Step 4a (§1.10), Step 4a.1 (§1.28, §1.29), Step 4d (§1.12, §1.25), Important Rules (§1.11, §1.13, §1.22, §1.23, §1.25, §1.26), Step 5b (§1.14), Step 5 (§1.26), Step 6a (§1.30), Step 6d (§1.31), Step 7 (§1.32), Step 14 (§1.19)
 - `plugins/sdlc-workflow/skills/verify-pr/intent-alignment.md` — Constraints (§1.11, §1.22, §1.23), Output Format (§1.24)
 - `plugins/sdlc-workflow/skills/verify-pr/security.md` — Constraints (§1.11, §1.22, §1.23), Output Format (§1.24)
 - `plugins/sdlc-workflow/skills/verify-pr/correctness.md` — Constraints (§1.11, §1.22, §1.23), Output Format (§1.24)
-- `plugins/sdlc-workflow/skills/verify-pr/style-conventions.md` — Check 2 (§1.16), Check 3 (§1.17), Check 4 (§1.18, §1.19, §1.20, §1.21), Check 5 (§1.30), Constraints (§1.11, §1.22, §1.23), Output Format (§1.24)
+- `plugins/sdlc-workflow/skills/verify-pr/style-conventions.md` — Check 1 Convention applicability (§1.36), Check 2 (§1.16), Check 3 (§1.17), Check 4 (§1.18, §1.19, §1.20, §1.21), Check 5 (§1.30), Constraints (§1.11, §1.22, §1.23), Output Format (§1.24)
 - `plugins/sdlc-workflow/skills/define-feature/SKILL.md` — Guardrails (§1.7–1.8), Important Rules (§1.9)
 - `docs/methodology.md` — Core Principles (§2.1, §3.2, §5.5)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -190,6 +190,64 @@ implement-task, conventions) to understand where gaps most frequently originate.
 
 ---
 
+### 9. Stale Task Detection Rate
+
+**What it measures:** The percentage of `implement-task` runs that detect a
+description change via the description digest verification (Step 1.5). A
+non-zero rate indicates that task descriptions are being modified after
+`plan-feature` creates them, which may signal process drift or manual
+editing of planned tasks.
+
+**Data source:** Agent conversation logs — `implement-task` logs a warning
+or pauses execution when the digest comparison detects a mismatch.
+
+**How to query:**
+
+1. Count the total number of `implement-task` invocations in the
+   measurement period (each invocation transitions a task to "In Progress"):
+   ```jql
+   labels = "ai-generated-jira" AND status changed to "In Progress" during (<start-date>, <end-date>)
+   ```
+2. From agent logs, count the number of invocations where the digest
+   verification reported a mismatch (the agent displayed the "description
+   has been modified" alert).
+
+**Calculation:** `(implement-task runs with digest mismatch / total implement-task runs) * 100`
+
+A rate of 0% is the expected steady state — descriptions should not change
+after planning. Rising rates may indicate a need to improve the plan-feature
+output or enforce stricter change controls on task descriptions.
+
+---
+
+### 10. Convention Applicability Rejection Rate
+
+**What it measures:** The percentage of conventions excluded by file-type
+filtering during `plan-feature` convention-aware task enrichment. This
+measures how effectively the applicability rules prevent irrelevant
+conventions from being included in task Implementation Notes.
+
+**Data source:** Agent conversation logs — `plan-feature` logs which
+conventions were evaluated and which were excluded due to file-type
+mismatch per `shared/convention-applicability-rules.md`.
+
+**How to query:**
+
+1. From agent logs for a `plan-feature` invocation, count the total number
+   of conventions evaluated against task file lists.
+2. Count the number of conventions excluded because their file-type scope
+   did not overlap with the task's Files to Modify/Create.
+
+**Calculation:** `(conventions excluded by file-type filtering / total conventions evaluated) * 100`
+
+Track this per feature to understand convention relevance. A very high rate
+(>80%) may indicate that the project's CONVENTIONS.md contains many
+narrowly-scoped conventions, which is healthy. A very low rate (<10%) may
+indicate that file-type scoping adds little value for the project's
+convention set.
+
+---
+
 ## Data Sources Summary
 
 | Source | What it provides |
@@ -198,6 +256,7 @@ implement-task, conventions) to understand where gaps most frequently originate.
 | Jira transitions | Status change history with timestamps |
 | GitHub PRs | PR creation time, merge status, commit authors |
 | Git trailers | `Assisted-by: Claude Code` identifies agent commits |
+| Agent conversation logs | Digest verification outcomes (mismatch/match), convention applicability filtering decisions |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add five new architectural constraints (§1.33–1.36, §4.13) covering description digest posting/verification and convention file-type applicability guardrails
- Add Prior Art subsections referencing fullsend's security-threat-model.md for cross-phase integrity and independent tier classification for convention applicability
- Add two new quality metrics: stale-task-detection-rate and convention-applicability-rejection-rate
- Update the Traceability Index to reference `shared/description-digest-protocol.md` and `shared/convention-applicability-rules.md`

Implements [TC-4288](https://redhat.atlassian.net/browse/TC-4288)

## Test plan

- [ ] Verify all new constraints are deterministic (pass/fail) — no subjective heuristics
- [ ] Verify constraint numbering continues sequentially from existing entries (§1.32→1.33, §4.12→4.13)
- [ ] Verify Prior Art subsections contain correct fullsend GitHub links
- [ ] Verify Traceability Index entries reference the correct constraint numbers
- [ ] Verify new metrics follow the existing format (What/Data source/How to query/Calculation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document new architectural constraints and metrics for cross-phase description integrity and convention file-type applicability, and align traceability references accordingly.

New Features:
- Introduce constraints requiring plan-feature to post description digests, implement-task to verify or skip them with warnings, and verify-pr/plan-feature to enforce convention file-type applicability.
- Add two quality metrics to track stale task detection via description digest mismatches and convention applicability rejection rates based on file-type filtering.

Enhancements:
- Clarify and extend convention applicability rules, including file-type extraction, multi-scope matching, and evidence requirements for upgrading reviewer suggestions to code change requests.
- Update the Traceability Index to reference new shared description-digest and convention-applicability documentation and map them to the new constraints.

Documentation:
- Add prior-art sections describing how cross-phase integrity and convention applicability constraints relate to or differ from fullsend design documents.