### PR TITLE
feat(openshell): add base Dockerfile for OpenShell sandbox (UBI 10)

### DIFF
--- a/plugins/sdlc-workflow/sandboxes/base/.dockerignore
+++ b/plugins/sdlc-workflow/sandboxes/base/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.claude
+.idea
+.local
+.superpowers
+docs
+evals
+*.md
+!plugins/sdlc-workflow/**

--- a/plugins/sdlc-workflow/sandboxes/base/Dockerfile
+++ b/plugins/sdlc-workflow/sandboxes/base/Dockerfile
@@ -1,0 +1,46 @@
+FROM registry.access.redhat.com/ubi10/ubi:latest
+
+ARG NODE_MAJOR=22
+ARG GH_CLI_VERSION=2.74.1
+ARG CLAUDE_CODE_VERSION=latest
+
+RUN dnf install -y \
+      git \
+      openssh-clients \
+      python3 \
+      curl \
+      jq \
+      tar \
+      gzip \
+      findutils \
+      procps-ng \
+    && dnf clean all
+
+RUN curl -fsSL https://rpm.nodesource.com/setup_${NODE_MAJOR}.x | bash - \
+    && dnf install -y nodejs \
+    && dnf clean all
+
+RUN ARCH=$(uname -m) \
+    && if [ "$ARCH" = "x86_64" ]; then GH_ARCH="linux_amd64"; \
+       elif [ "$ARCH" = "aarch64" ]; then GH_ARCH="linux_arm64"; \
+       else echo "Unsupported architecture: $ARCH" && exit 1; fi \
+    && curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_${GH_ARCH}.tar.gz" \
+       | tar -xz --strip-components=1 -C /usr/local
+
+RUN if [ "$CLAUDE_CODE_VERSION" = "latest" ]; then \
+      npm install -g @anthropic-ai/claude-code; \
+    else \
+      npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"; \
+    fi
+
+RUN groupadd -r sandbox \
+    && useradd -r -g sandbox -m -d /home/sandbox -s /bin/bash sandbox
+
+COPY plugins/sdlc-workflow/ /home/sandbox/.claude/plugins/sdlc-workflow/
+
+RUN chown -R sandbox:sandbox /home/sandbox
+
+USER sandbox
+WORKDIR /home/sandbox
+
+CMD ["/bin/bash"]

--- a/plugins/sdlc-workflow/sandboxes/base/Dockerfile
+++ b/plugins/sdlc-workflow/sandboxes/base/Dockerfile
@@ -1,27 +1,19 @@
 FROM registry.access.redhat.com/hi/core-runtime:latest-builder
 
-ARG GH_CLI_VERSION=2.74.1
-
 USER root
 
 COPY plugins/sdlc-workflow/sandboxes/base/claude-code.repo /etc/yum.repos.d/claude-code.repo
 
-RUN dnf install -y \
+RUN dnf install -y dnf5-plugins \
+    && dnf config-manager addrepo --from-repofile=https://cli.github.com/packages/rpm/gh-cli.repo \
+    && dnf install -y \
       claude-code \
+      gh \
       git \
       openssh-clients \
       python3 \
       jq \
-      tar \
-      gzip \
     && dnf clean all
-
-RUN ARCH=$(uname -m) \
-    && if [ "$ARCH" = "x86_64" ]; then GH_ARCH="linux_amd64"; \
-       elif [ "$ARCH" = "aarch64" ]; then GH_ARCH="linux_arm64"; \
-       else echo "Unsupported architecture: $ARCH" && exit 1; fi \
-    && curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_${GH_ARCH}.tar.gz" \
-       | tar -xz --strip-components=1 -C /usr/local
 
 RUN groupadd -r sandbox \
     && useradd -r -g sandbox -m -d /home/sandbox -s /bin/bash sandbox

--- a/plugins/sdlc-workflow/sandboxes/base/Dockerfile
+++ b/plugins/sdlc-workflow/sandboxes/base/Dockerfile
@@ -1,23 +1,19 @@
-FROM registry.access.redhat.com/ubi10/ubi:latest
+FROM registry.access.redhat.com/hi/core-runtime:latest-builder
 
-ARG NODE_MAJOR=22
 ARG GH_CLI_VERSION=2.74.1
-ARG CLAUDE_CODE_VERSION=latest
+
+USER root
+
+COPY plugins/sdlc-workflow/sandboxes/base/claude-code.repo /etc/yum.repos.d/claude-code.repo
 
 RUN dnf install -y \
+      claude-code \
       git \
       openssh-clients \
       python3 \
-      curl \
       jq \
       tar \
       gzip \
-      findutils \
-      procps-ng \
-    && dnf clean all
-
-RUN curl -fsSL https://rpm.nodesource.com/setup_${NODE_MAJOR}.x | bash - \
-    && dnf install -y nodejs \
     && dnf clean all
 
 RUN ARCH=$(uname -m) \
@@ -26,12 +22,6 @@ RUN ARCH=$(uname -m) \
        else echo "Unsupported architecture: $ARCH" && exit 1; fi \
     && curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_${GH_ARCH}.tar.gz" \
        | tar -xz --strip-components=1 -C /usr/local
-
-RUN if [ "$CLAUDE_CODE_VERSION" = "latest" ]; then \
-      npm install -g @anthropic-ai/claude-code; \
-    else \
-      npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"; \
-    fi
 
 RUN groupadd -r sandbox \
     && useradd -r -g sandbox -m -d /home/sandbox -s /bin/bash sandbox

--- a/plugins/sdlc-workflow/sandboxes/base/claude-code.repo
+++ b/plugins/sdlc-workflow/sandboxes/base/claude-code.repo
@@ -1,0 +1,6 @@
+[claude-code]
+name=Claude Code
+baseurl=https://downloads.claude.ai/claude-code/rpm/stable
+enabled=1
+gpgcheck=1
+gpgkey=https://downloads.claude.ai/keys/claude-code.asc


### PR DESCRIPTION
## Summary

- Add Red Hat UBI 10 base Dockerfile for running sdlc-workflow skills inside OpenShell sandboxes
- Includes Claude Code CLI, Git, GH CLI, Python 3, curl, jq, and the sdlc-workflow plugin pre-installed
- Runs as non-root `sandbox` user per OpenShell requirements
- Build args for Node.js, GH CLI, and Claude Code version pinning

Build command: `podman build -f plugins/sdlc-workflow/sandboxes/base/Dockerfile -t sdlc-base .`

Implements [TC-4714](https://redhat.atlassian.net/browse/TC-4714)

## Test plan

- [ ] Build image: `podman build -f plugins/sdlc-workflow/sandboxes/base/Dockerfile -t sdlc-base .`
- [ ] Verify Claude Code: `podman run --rm sdlc-base claude --version`
- [ ] Verify Git: `podman run --rm sdlc-base git --version`
- [ ] Verify GH CLI: `podman run --rm sdlc-base gh --version`
- [ ] Verify Python: `podman run --rm sdlc-base python3 --version`
- [ ] Verify sandbox user: `podman run --rm sdlc-base whoami` → `sandbox`
- [ ] Verify plugin present: `podman run --rm sdlc-base ls ~/.claude/plugins/sdlc-workflow/skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a Red Hat UBI 10-based OpenShell sandbox image for running sdlc-workflow skills with required tooling preinstalled.

New Features:
- Add base Dockerfile for an OpenShell sandbox image built on Red Hat UBI 10 with non-root sandbox user.
- Preinstall Node.js, Claude Code CLI, Git, GH CLI, Python 3, curl, jq, and sdlc-workflow plugin in the sandbox image.

Build:
- Add Dockerfile and .dockerignore for building the sdlc-workflow OpenShell sandbox base image.