### PR TITLE
feat(openshell): add per-skill sandbox configurations

### DIFF
--- a/plugins/sdlc-workflow/sandboxes/README.md
+++ b/plugins/sdlc-workflow/sandboxes/README.md
@@ -1,0 +1,58 @@
+# OpenShell Sandboxes for sdlc-workflow
+
+Pre-built sandbox images for running sdlc-workflow skills inside [OpenShell](https://github.com/NVIDIA/OpenShell) with least-privilege network and filesystem policies.
+
+## Quick Start
+
+```bash
+openshell sandbox create \
+  --from ghcr.io/mrizzi/sdlc-plugins/sdlc-workflow:latest
+```
+
+## Available Sandboxes
+
+| Sandbox | Image | Jira | GitHub | Figma | Filesystem |
+|---|---|---|---|---|---|
+| [sdlc-workflow](sdlc-workflow/) | `ghcr.io/mrizzi/sdlc-plugins/sdlc-workflow` | full | full | read-only | read-write |
+| [plan-feature](plan-feature/) | `ghcr.io/mrizzi/sdlc-plugins/plan-feature` | full | — | read-only | read-only |
+| [implement-task](implement-task/) | `ghcr.io/mrizzi/sdlc-plugins/implement-task` | full | full | — | read-write |
+| [verify-pr](verify-pr/) | `ghcr.io/mrizzi/sdlc-plugins/verify-pr` | full | read-only | — | read-only |
+| [define-feature](define-feature/) | `ghcr.io/mrizzi/sdlc-plugins/define-feature` | full | — | — | read-only |
+| [setup](setup/) | `ghcr.io/mrizzi/sdlc-plugins/setup` | read-only | — | — | read-write |
+
+All sandboxes include LLM API access (Anthropic, Google Vertex AI, Amazon Bedrock).
+
+## Custom Registry Shorthand
+
+```bash
+export OPENSHELL_COMMUNITY_REGISTRY=ghcr.io/mrizzi/sdlc-plugins
+openshell sandbox create --from implement-task
+```
+
+## Extending the Base Image
+
+Add project-specific build tools by extending the base image:
+
+```dockerfile
+FROM ghcr.io/mrizzi/sdlc-plugins/sdlc-base:latest
+RUN dnf install -y rust cargo && dnf clean all
+```
+
+```bash
+openshell sandbox create --from ./my-custom-sandbox/
+```
+
+## Building Locally
+
+```bash
+podman build -f plugins/sdlc-workflow/sandboxes/base/Dockerfile -t sdlc-base .
+podman build -t implement-task plugins/sdlc-workflow/sandboxes/implement-task/
+```
+
+## Overriding Policies
+
+```bash
+openshell sandbox create \
+  --from ghcr.io/mrizzi/sdlc-plugins/sdlc-base:latest \
+  --policy plugins/sdlc-workflow/sandboxes/implement-task/policy.yaml
+```

--- a/plugins/sdlc-workflow/sandboxes/base/Dockerfile
+++ b/plugins/sdlc-workflow/sandboxes/base/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/hi/core-runtime:latest-builder
 
 USER root
+WORKDIR /sandbox
 
 COPY plugins/sdlc-workflow/sandboxes/base/claude-code.repo /etc/yum.repos.d/claude-code.repo
 
@@ -11,18 +12,19 @@ RUN dnf install -y dnf5-plugins \
       gh \
       git \
       openssh-clients \
+      openssh-server \
       python3 \
       jq \
+      iproute \
+      procps-ng \
     && dnf clean all
 
-RUN groupadd -r sandbox \
-    && useradd -r -g sandbox -m -d /home/sandbox -s /bin/bash sandbox
+RUN groupadd -r supervisor && useradd -r -g supervisor -s /usr/sbin/nologin supervisor \
+    && groupadd -r sandbox && useradd -r -g sandbox -d /sandbox -s /bin/bash sandbox
 
-COPY plugins/sdlc-workflow/ /home/sandbox/.claude/plugins/sdlc-workflow/
+COPY plugins/sdlc-workflow/ /sandbox/.claude/plugins/sdlc-workflow/
 
-RUN chown -R sandbox:sandbox /home/sandbox
+RUN chown -R sandbox:sandbox /sandbox
 
 USER sandbox
-WORKDIR /home/sandbox
-
-CMD ["/bin/bash"]
+ENTRYPOINT ["/bin/bash"]

--- a/plugins/sdlc-workflow/sandboxes/define-feature/Dockerfile
+++ b/plugins/sdlc-workflow/sandboxes/define-feature/Dockerfile
@@ -1,0 +1,2 @@
+FROM ghcr.io/mrizzi/sdlc-plugins/sdlc-base:latest
+COPY policy.yaml /etc/openshell/policy.yaml

--- a/plugins/sdlc-workflow/sandboxes/define-feature/README.md
+++ b/plugins/sdlc-workflow/sandboxes/define-feature/README.md
@@ -1,0 +1,33 @@
+# define-feature Sandbox
+
+Sandbox for the define-feature skill. Interactively defines Jira features by walking through description template sections. Read-only filesystem, Jira-only network access.
+
+## Allowed Endpoints
+
+| Endpoint | Access |
+|---|---|
+| LLM API (Anthropic, Vertex AI, Bedrock) | full |
+| Jira (`*.atlassian.net`) | full |
+| Filesystem workspace | read-only |
+
+## Usage
+
+```bash
+openshell sandbox create \
+  --from ghcr.io/mrizzi/sdlc-plugins/define-feature:latest
+```
+
+## Extending
+
+```dockerfile
+FROM ghcr.io/mrizzi/sdlc-plugins/define-feature:latest
+# Add tools if needed
+```
+
+## Custom Policy
+
+```bash
+openshell sandbox create \
+  --from ghcr.io/mrizzi/sdlc-plugins/sdlc-base:latest \
+  --policy plugins/sdlc-workflow/sandboxes/define-feature/policy.yaml
+```

--- a/plugins/sdlc-workflow/sandboxes/define-feature/policy.yaml
+++ b/plugins/sdlc-workflow/sandboxes/define-feature/policy.yaml
@@ -3,6 +3,7 @@ version: 1
 filesystem_policy:
   include_workdir: false
   read_only:
+    - /var/log
     - /usr
     - /lib
     - /lib64
@@ -10,10 +11,13 @@ filesystem_policy:
     - /dev/urandom
     - /etc
     - /opt
-    - /home/sandbox
+    - /sandbox
   read_write:
     - /tmp
     - /dev/null
+
+landlock:
+  compatibility: best_effort
 
 process:
   run_as_user: sandbox

--- a/plugins/sdlc-workflow/sandboxes/define-feature/policy.yaml
+++ b/plugins/sdlc-workflow/sandboxes/define-feature/policy.yaml
@@ -1,0 +1,40 @@
+version: 1
+
+filesystem_policy:
+  include_workdir: false
+  read_only:
+    - /usr
+    - /lib
+    - /lib64
+    - /proc
+    - /dev/urandom
+    - /etc
+    - /opt
+    - /home/sandbox
+  read_write:
+    - /tmp
+    - /dev/null
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  llm_api:
+    endpoints:
+      - host: api.anthropic.com
+        port: 443
+      - host: "*-aiplatform.googleapis.com"
+        port: 443
+      - host: "bedrock-runtime.*.amazonaws.com"
+        port: 443
+    binaries:
+      - { path: /usr/local/bin/* }
+      - { path: /usr/bin/* }
+  jira:
+    endpoints:
+      - host: "*.atlassian.net"
+        port: 443
+    binaries:
+      - { path: /usr/local/bin/* }
+      - { path: /usr/bin/* }

--- a/plugins/sdlc-workflow/sandboxes/implement-task/Dockerfile
+++ b/plugins/sdlc-workflow/sandboxes/implement-task/Dockerfile
@@ -1,0 +1,2 @@
+FROM ghcr.io/mrizzi/sdlc-plugins/sdlc-base:latest
+COPY policy.yaml /etc/openshell/policy.yaml

--- a/plugins/sdlc-workflow/sandboxes/implement-task/README.md
+++ b/plugins/sdlc-workflow/sandboxes/implement-task/README.md
@@ -1,0 +1,38 @@
+# implement-task Sandbox
+
+Sandbox for the implement-task skill. Implements Jira tasks by modifying code, running tests, and creating PRs. Read-write filesystem and full GitHub access.
+
+## Allowed Endpoints
+
+| Endpoint | Access |
+|---|---|
+| LLM API (Anthropic, Vertex AI, Bedrock) | full |
+| Jira (`*.atlassian.net`) | full |
+| GitHub API (`api.github.com`) | full |
+| GitHub (`github.com`, SSH) | full |
+| npm registry (`registry.npmjs.org`) | read-only |
+| crates.io | read-only |
+| PyPI (`pypi.org`) | read-only |
+| Filesystem workspace | read-write |
+
+## Usage
+
+```bash
+openshell sandbox create \
+  --from ghcr.io/mrizzi/sdlc-plugins/implement-task:latest
+```
+
+## Extending
+
+```dockerfile
+FROM ghcr.io/mrizzi/sdlc-plugins/implement-task:latest
+RUN dnf install -y rust cargo && dnf clean all
+```
+
+## Custom Policy
+
+```bash
+openshell sandbox create \
+  --from ghcr.io/mrizzi/sdlc-plugins/sdlc-base:latest \
+  --policy plugins/sdlc-workflow/sandboxes/implement-task/policy.yaml
+```

--- a/plugins/sdlc-workflow/sandboxes/implement-task/policy.yaml
+++ b/plugins/sdlc-workflow/sandboxes/implement-task/policy.yaml
@@ -3,6 +3,7 @@ version: 1
 filesystem_policy:
   include_workdir: true
   read_only:
+    - /var/log
     - /usr
     - /lib
     - /lib64
@@ -13,7 +14,10 @@ filesystem_policy:
   read_write:
     - /tmp
     - /dev/null
-    - /home/sandbox
+    - /sandbox
+
+landlock:
+  compatibility: best_effort
 
 process:
   run_as_user: sandbox

--- a/plugins/sdlc-workflow/sandboxes/implement-task/policy.yaml
+++ b/plugins/sdlc-workflow/sandboxes/implement-task/policy.yaml
@@ -1,0 +1,79 @@
+version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /lib64
+    - /proc
+    - /dev/urandom
+    - /etc
+    - /opt
+  read_write:
+    - /tmp
+    - /dev/null
+    - /home/sandbox
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  llm_api:
+    endpoints:
+      - host: api.anthropic.com
+        port: 443
+      - host: "*-aiplatform.googleapis.com"
+        port: 443
+      - host: "bedrock-runtime.*.amazonaws.com"
+        port: 443
+    binaries:
+      - { path: /usr/local/bin/* }
+      - { path: /usr/bin/* }
+  jira:
+    endpoints:
+      - host: "*.atlassian.net"
+        port: 443
+    binaries:
+      - { path: /usr/local/bin/* }
+      - { path: /usr/bin/* }
+  github_api:
+    endpoints:
+      - host: api.github.com
+        port: 443
+    binaries:
+      - { path: /usr/local/bin/* }
+      - { path: /usr/bin/* }
+  github_git:
+    endpoints:
+      - host: github.com
+        port: 443
+      - host: github.com
+        port: 22
+    binaries:
+      - { path: /usr/bin/git }
+      - { path: /usr/bin/ssh }
+  npm_registry:
+    endpoints:
+      - host: registry.npmjs.org
+        port: 443
+    binaries:
+      - { path: /usr/local/bin/* }
+      - { path: /usr/bin/* }
+  crates_io:
+    endpoints:
+      - host: crates.io
+        port: 443
+      - host: static.crates.io
+        port: 443
+    binaries:
+      - { path: /usr/bin/* }
+  pypi:
+    endpoints:
+      - host: pypi.org
+        port: 443
+      - host: files.pythonhosted.org
+        port: 443
+    binaries:
+      - { path: /usr/bin/* }

--- a/plugins/sdlc-workflow/sandboxes/plan-feature/Dockerfile
+++ b/plugins/sdlc-workflow/sandboxes/plan-feature/Dockerfile
@@ -1,0 +1,2 @@
+FROM ghcr.io/mrizzi/sdlc-plugins/sdlc-base:latest
+COPY policy.yaml /etc/openshell/policy.yaml

--- a/plugins/sdlc-workflow/sandboxes/plan-feature/README.md
+++ b/plugins/sdlc-workflow/sandboxes/plan-feature/README.md
@@ -1,0 +1,34 @@
+# plan-feature Sandbox
+
+Sandbox for the plan-feature skill. Reads Jira features and Figma designs to generate implementation tasks. Read-only filesystem access.
+
+## Allowed Endpoints
+
+| Endpoint | Access |
+|---|---|
+| LLM API (Anthropic, Vertex AI, Bedrock) | full |
+| Jira (`*.atlassian.net`) | full |
+| Figma (`api.figma.com`, `*.figma.com`) | read-only |
+| Filesystem workspace | read-only |
+
+## Usage
+
+```bash
+openshell sandbox create \
+  --from ghcr.io/mrizzi/sdlc-plugins/plan-feature:latest
+```
+
+## Extending
+
+```dockerfile
+FROM ghcr.io/mrizzi/sdlc-plugins/plan-feature:latest
+# Add tools needed for code analysis
+```
+
+## Custom Policy
+
+```bash
+openshell sandbox create \
+  --from ghcr.io/mrizzi/sdlc-plugins/sdlc-base:latest \
+  --policy plugins/sdlc-workflow/sandboxes/plan-feature/policy.yaml
+```

--- a/plugins/sdlc-workflow/sandboxes/plan-feature/policy.yaml
+++ b/plugins/sdlc-workflow/sandboxes/plan-feature/policy.yaml
@@ -3,6 +3,7 @@ version: 1
 filesystem_policy:
   include_workdir: false
   read_only:
+    - /var/log
     - /usr
     - /lib
     - /lib64
@@ -10,10 +11,13 @@ filesystem_policy:
     - /dev/urandom
     - /etc
     - /opt
-    - /home/sandbox
+    - /sandbox
   read_write:
     - /tmp
     - /dev/null
+
+landlock:
+  compatibility: best_effort
 
 process:
   run_as_user: sandbox

--- a/plugins/sdlc-workflow/sandboxes/plan-feature/policy.yaml
+++ b/plugins/sdlc-workflow/sandboxes/plan-feature/policy.yaml
@@ -1,0 +1,49 @@
+version: 1
+
+filesystem_policy:
+  include_workdir: false
+  read_only:
+    - /usr
+    - /lib
+    - /lib64
+    - /proc
+    - /dev/urandom
+    - /etc
+    - /opt
+    - /home/sandbox
+  read_write:
+    - /tmp
+    - /dev/null
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  llm_api:
+    endpoints:
+      - host: api.anthropic.com
+        port: 443
+      - host: "*-aiplatform.googleapis.com"
+        port: 443
+      - host: "bedrock-runtime.*.amazonaws.com"
+        port: 443
+    binaries:
+      - { path: /usr/local/bin/* }
+      - { path: /usr/bin/* }
+  jira:
+    endpoints:
+      - host: "*.atlassian.net"
+        port: 443
+    binaries:
+      - { path: /usr/local/bin/* }
+      - { path: /usr/bin/* }
+  figma:
+    endpoints:
+      - host: api.figma.com
+        port: 443
+      - host: "*.figma.com"
+        port: 443
+    binaries:
+      - { path: /usr/local/bin/* }
+      - { path: /usr/bin/* }

--- a/plugins/sdlc-workflow/sandboxes/sdlc-workflow/Dockerfile
+++ b/plugins/sdlc-workflow/sandboxes/sdlc-workflow/Dockerfile
@@ -1,0 +1,2 @@
+FROM ghcr.io/mrizzi/sdlc-plugins/sdlc-base:latest
+COPY policy.yaml /etc/openshell/policy.yaml

--- a/plugins/sdlc-workflow/sandboxes/sdlc-workflow/README.md
+++ b/plugins/sdlc-workflow/sandboxes/sdlc-workflow/README.md
@@ -1,0 +1,39 @@
+# sdlc-workflow Sandbox (General Purpose)
+
+Combined sandbox for running any sdlc-workflow skill. Use this when invoking multiple skills in a single session.
+
+## Allowed Endpoints
+
+| Endpoint | Access |
+|---|---|
+| LLM API (Anthropic, Vertex AI, Bedrock) | full |
+| Jira (`*.atlassian.net`) | full |
+| GitHub API (`api.github.com`) | full |
+| GitHub (`github.com`, SSH) | full |
+| Figma (`api.figma.com`, `*.figma.com`) | read-only |
+| npm registry (`registry.npmjs.org`) | read-only |
+| crates.io | read-only |
+| PyPI (`pypi.org`) | read-only |
+| Filesystem workspace | read-write |
+
+## Usage
+
+```bash
+openshell sandbox create \
+  --from ghcr.io/mrizzi/sdlc-plugins/sdlc-workflow:latest
+```
+
+## Extending
+
+```dockerfile
+FROM ghcr.io/mrizzi/sdlc-plugins/sdlc-workflow:latest
+RUN dnf install -y rust cargo && dnf clean all
+```
+
+## Custom Policy
+
+```bash
+openshell sandbox create \
+  --from ghcr.io/mrizzi/sdlc-plugins/sdlc-base:latest \
+  --policy path/to/custom-policy.yaml
+```

--- a/plugins/sdlc-workflow/sandboxes/sdlc-workflow/policy.yaml
+++ b/plugins/sdlc-workflow/sandboxes/sdlc-workflow/policy.yaml
@@ -3,6 +3,7 @@ version: 1
 filesystem_policy:
   include_workdir: true
   read_only:
+    - /var/log
     - /usr
     - /lib
     - /lib64
@@ -13,7 +14,10 @@ filesystem_policy:
   read_write:
     - /tmp
     - /dev/null
-    - /home/sandbox
+    - /sandbox
+
+landlock:
+  compatibility: best_effort
 
 process:
   run_as_user: sandbox

--- a/plugins/sdlc-workflow/sandboxes/sdlc-workflow/policy.yaml
+++ b/plugins/sdlc-workflow/sandboxes/sdlc-workflow/policy.yaml
@@ -1,0 +1,88 @@
+version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /lib64
+    - /proc
+    - /dev/urandom
+    - /etc
+    - /opt
+  read_write:
+    - /tmp
+    - /dev/null
+    - /home/sandbox
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  llm_api:
+    endpoints:
+      - host: api.anthropic.com
+        port: 443
+      - host: "*-aiplatform.googleapis.com"
+        port: 443
+      - host: "bedrock-runtime.*.amazonaws.com"
+        port: 443
+    binaries:
+      - { path: /usr/local/bin/* }
+      - { path: /usr/bin/* }
+  jira:
+    endpoints:
+      - host: "*.atlassian.net"
+        port: 443
+    binaries:
+      - { path: /usr/local/bin/* }
+      - { path: /usr/bin/* }
+  github_api:
+    endpoints:
+      - host: api.github.com
+        port: 443
+    binaries:
+      - { path: /usr/local/bin/* }
+      - { path: /usr/bin/* }
+  github_git:
+    endpoints:
+      - host: github.com
+        port: 443
+      - host: github.com
+        port: 22
+    binaries:
+      - { path: /usr/bin/git }
+      - { path: /usr/bin/ssh }
+  figma:
+    endpoints:
+      - host: api.figma.com
+        port: 443
+      - host: "*.figma.com"
+        port: 443
+    binaries:
+      - { path: /usr/local/bin/* }
+      - { path: /usr/bin/* }
+  npm_registry:
+    endpoints:
+      - host: registry.npmjs.org
+        port: 443
+    binaries:
+      - { path: /usr/local/bin/* }
+      - { path: /usr/bin/* }
+  crates_io:
+    endpoints:
+      - host: crates.io
+        port: 443
+      - host: static.crates.io
+        port: 443
+    binaries:
+      - { path: /usr/bin/* }
+  pypi:
+    endpoints:
+      - host: pypi.org
+        port: 443
+      - host: files.pythonhosted.org
+        port: 443
+    binaries:
+      - { path: /usr/bin/* }

--- a/plugins/sdlc-workflow/sandboxes/setup/Dockerfile
+++ b/plugins/sdlc-workflow/sandboxes/setup/Dockerfile
@@ -1,0 +1,2 @@
+FROM ghcr.io/mrizzi/sdlc-plugins/sdlc-base:latest
+COPY policy.yaml /etc/openshell/policy.yaml

--- a/plugins/sdlc-workflow/sandboxes/setup/README.md
+++ b/plugins/sdlc-workflow/sandboxes/setup/README.md
@@ -1,0 +1,33 @@
+# setup Sandbox
+
+Sandbox for the setup skill. Configures CLAUDE.md Project Configuration for use with sdlc-workflow skills. Read-write filesystem for CLAUDE.md modifications, read-only Jira for configuration verification.
+
+## Allowed Endpoints
+
+| Endpoint | Access |
+|---|---|
+| LLM API (Anthropic, Vertex AI, Bedrock) | full |
+| Jira (`*.atlassian.net`) | read-only |
+| Filesystem workspace | read-write |
+
+## Usage
+
+```bash
+openshell sandbox create \
+  --from ghcr.io/mrizzi/sdlc-plugins/setup:latest
+```
+
+## Extending
+
+```dockerfile
+FROM ghcr.io/mrizzi/sdlc-plugins/setup:latest
+# Add tools if needed
+```
+
+## Custom Policy
+
+```bash
+openshell sandbox create \
+  --from ghcr.io/mrizzi/sdlc-plugins/sdlc-base:latest \
+  --policy plugins/sdlc-workflow/sandboxes/setup/policy.yaml
+```

--- a/plugins/sdlc-workflow/sandboxes/setup/policy.yaml
+++ b/plugins/sdlc-workflow/sandboxes/setup/policy.yaml
@@ -1,0 +1,40 @@
+version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /lib64
+    - /proc
+    - /dev/urandom
+    - /etc
+    - /opt
+  read_write:
+    - /tmp
+    - /dev/null
+    - /home/sandbox
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  llm_api:
+    endpoints:
+      - host: api.anthropic.com
+        port: 443
+      - host: "*-aiplatform.googleapis.com"
+        port: 443
+      - host: "bedrock-runtime.*.amazonaws.com"
+        port: 443
+    binaries:
+      - { path: /usr/local/bin/* }
+      - { path: /usr/bin/* }
+  jira:
+    endpoints:
+      - host: "*.atlassian.net"
+        port: 443
+    binaries:
+      - { path: /usr/local/bin/* }
+      - { path: /usr/bin/* }

--- a/plugins/sdlc-workflow/sandboxes/setup/policy.yaml
+++ b/plugins/sdlc-workflow/sandboxes/setup/policy.yaml
@@ -3,6 +3,7 @@ version: 1
 filesystem_policy:
   include_workdir: true
   read_only:
+    - /var/log
     - /usr
     - /lib
     - /lib64
@@ -13,7 +14,10 @@ filesystem_policy:
   read_write:
     - /tmp
     - /dev/null
-    - /home/sandbox
+    - /sandbox
+
+landlock:
+  compatibility: best_effort
 
 process:
   run_as_user: sandbox

--- a/plugins/sdlc-workflow/sandboxes/verify-pr/Dockerfile
+++ b/plugins/sdlc-workflow/sandboxes/verify-pr/Dockerfile
@@ -1,0 +1,2 @@
+FROM ghcr.io/mrizzi/sdlc-plugins/sdlc-base:latest
+COPY policy.yaml /etc/openshell/policy.yaml

--- a/plugins/sdlc-workflow/sandboxes/verify-pr/README.md
+++ b/plugins/sdlc-workflow/sandboxes/verify-pr/README.md
@@ -1,0 +1,34 @@
+# verify-pr Sandbox
+
+Sandbox for the verify-pr skill. Verifies PRs against Jira task acceptance criteria and creates sub-tasks for review feedback. Read-only filesystem, read-only GitHub access.
+
+## Allowed Endpoints
+
+| Endpoint | Access |
+|---|---|
+| LLM API (Anthropic, Vertex AI, Bedrock) | full |
+| Jira (`*.atlassian.net`) | full |
+| GitHub API (`api.github.com`) | read-only |
+| Filesystem workspace | read-only |
+
+## Usage
+
+```bash
+openshell sandbox create \
+  --from ghcr.io/mrizzi/sdlc-plugins/verify-pr:latest
+```
+
+## Extending
+
+```dockerfile
+FROM ghcr.io/mrizzi/sdlc-plugins/verify-pr:latest
+# Add tools needed for code analysis
+```
+
+## Custom Policy
+
+```bash
+openshell sandbox create \
+  --from ghcr.io/mrizzi/sdlc-plugins/sdlc-base:latest \
+  --policy plugins/sdlc-workflow/sandboxes/verify-pr/policy.yaml
+```

--- a/plugins/sdlc-workflow/sandboxes/verify-pr/policy.yaml
+++ b/plugins/sdlc-workflow/sandboxes/verify-pr/policy.yaml
@@ -3,6 +3,7 @@ version: 1
 filesystem_policy:
   include_workdir: false
   read_only:
+    - /var/log
     - /usr
     - /lib
     - /lib64
@@ -10,10 +11,13 @@ filesystem_policy:
     - /dev/urandom
     - /etc
     - /opt
-    - /home/sandbox
+    - /sandbox
   read_write:
     - /tmp
     - /dev/null
+
+landlock:
+  compatibility: best_effort
 
 process:
   run_as_user: sandbox

--- a/plugins/sdlc-workflow/sandboxes/verify-pr/policy.yaml
+++ b/plugins/sdlc-workflow/sandboxes/verify-pr/policy.yaml
@@ -1,0 +1,47 @@
+version: 1
+
+filesystem_policy:
+  include_workdir: false
+  read_only:
+    - /usr
+    - /lib
+    - /lib64
+    - /proc
+    - /dev/urandom
+    - /etc
+    - /opt
+    - /home/sandbox
+  read_write:
+    - /tmp
+    - /dev/null
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  llm_api:
+    endpoints:
+      - host: api.anthropic.com
+        port: 443
+      - host: "*-aiplatform.googleapis.com"
+        port: 443
+      - host: "bedrock-runtime.*.amazonaws.com"
+        port: 443
+    binaries:
+      - { path: /usr/local/bin/* }
+      - { path: /usr/bin/* }
+  jira:
+    endpoints:
+      - host: "*.atlassian.net"
+        port: 443
+    binaries:
+      - { path: /usr/local/bin/* }
+      - { path: /usr/bin/* }
+  github_api:
+    endpoints:
+      - host: api.github.com
+        port: 443
+    binaries:
+      - { path: /usr/local/bin/* }
+      - { path: /usr/bin/* }


### PR DESCRIPTION
## Summary

- 6 sandbox directories with least-privilege OpenShell policies, Dockerfiles, and READMEs
- Top-level sandboxes README with access matrix, quickstart, and extension guide
- Per-skill policies enforce network/filesystem boundaries per the design spec access matrix
- All Dockerfiles are two lines: `FROM base` + `COPY policy.yaml`

Implements [TC-4715](https://redhat.atlassian.net/browse/TC-4715)

## Test plan

- [ ] Verify all 19 files are present (6 dirs × 3 files + top-level README)
- [ ] Verify each policy.yaml has unique network_policies entries
- [ ] Verify read-only skills use `include_workdir: false`
- [ ] Verify read-write skills use `include_workdir: true`
- [ ] Build a per-skill image: `podman build -t implement-task plugins/sdlc-workflow/sandboxes/implement-task/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add per-skill OpenShell sandbox images and policies for sdlc-workflow plugins with least-privilege network and filesystem access.

New Features:
- Introduce dedicated OpenShell sandbox configurations for each sdlc-workflow skill and a shared general-purpose sandbox image.
- Document available sandboxes, their access levels, and usage patterns for sdlc-workflow skills.
- Provide minimal Dockerfiles for building sandbox images from a shared sdlc-base image with embedded policies.

Enhancements:
- Define least-privilege network and filesystem policies per skill to constrain Jira, GitHub, Figma, package registries, and workspace access.