### PR TITLE
docs(triage-security): add Quick Reference table and enrich frontmatter keywords

### DIFF
--- a/plugins/sdlc-workflow/skills/triage-security/SKILL.md
+++ b/plugins/sdlc-workflow/skills/triage-security/SKILL.md
@@ -2,7 +2,9 @@
 name: triage-security
 description: >-
   Use when a PSIRT-created Vulnerability issue (CVE-based) needs version-aware triage
-  to determine which supported product versions are actually affected.
+  to determine which supported product versions are actually affected. Covers untriaged
+  CVE assessment, security triage, Affects Versions mismatch correction, version impact
+  analysis, duplicate CVE detection, and remediation task creation.
 argument-hint: "[jira-issue-id]"
 ---
 
@@ -27,6 +29,20 @@ Do **not** use for:
 - Manually reported security bugs (no CVE, no PSIRT labels)
 - Non-security Jira issues (Features, Tasks, Bugs)
 - Issues in projects without Security Configuration in CLAUDE.md
+
+## Quick Reference
+
+| Step | Name | Input | Output |
+|------|------|-------|--------|
+| 0 | Validate Configuration | CLAUDE.md | Project key, Cloud ID, Security Config |
+| 0.5 | Jira Access | -- | MCP or REST API connection |
+| 1 | Data Extraction | Vulnerability issue key | CVE ID, library, affected range, remote links |
+| 2 | Version Impact Analysis | security-matrix.md, lock files | Version impact table |
+| 3 | Affects Versions Correction | Version impact table, Jira versions | Corrected Affects Versions |
+| 4 | Duplicate/Sibling Check | JQL search (sibling issues) | Duplicate detection, issue links |
+| 5 | Version Lifecycle Check | Product pages URL | EOL status per version |
+| 6 | Already Fixed Check | Resolved sibling issues | Already-fixed detection |
+| 7 | Remediation | Impact analysis results | Remediation tasks or close recommendation |
 
 ## Guardrails
 


### PR DESCRIPTION
## Summary

- Enriched frontmatter description with symptom keywords (untriaged CVE, security triage, Affects Versions mismatch, version impact analysis, duplicate CVE detection, remediation task creation) to improve skill discoverability
- Added Quick Reference table between "When to Use" and "Guardrails" sections summarizing the 7-step triage flow with inputs and outputs per step
- No behavioral changes — only documentation/metadata additions

Implements [TC-4766](https://redhat.atlassian.net/browse/TC-4766)

## Test plan

- [x] Verify plugin validation passes (`claude plugin validate plugins/sdlc-workflow`)
- [x] Verify Quick Reference table covers all steps (0, 0.5, 1–7)
- [x] Verify Quick Reference placement between "When to Use" and "Guardrails"
- [x] Verify frontmatter includes at least 3 additional symptom keywords
- [ ] Verify existing triage-security eval assertions still pass (non-behavioral changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the triage-security skill with expanded use-case description and a quick-reference table outlining the end-to-end triage flow.

Documentation:
- Add symptom-focused keywords to the triage-security skill description to improve discoverability in documentation search.
- Introduce a Quick Reference table summarizing each triage step with its inputs and outputs between the When to Use and Guardrails sections.