### PR TITLE
feat(evals): add RPM ecosystem eval case for triage-security

### DIFF
--- a/evals/triage-security/evals.json
+++ b/evals/triage-security/evals.json
@@ -68,7 +68,7 @@
         "Version impact table includes ALL versions from the 2.2.x stream supportability matrix (2.2.0 through 2.2.4) and uses rpms.lock.yaml data for version extraction (Step 2.3)",
         "Dependency chain context classifies the package origin as explicit install because openssl-libs is present in rpms.lock.yaml, not inherited from the base image (Step 2.3.5)",
         "Remediation creates a single task for the Konflux release repo — not the two-task upstream backport + downstream propagation flow used for source dependency ecosystems (Step 7 Remediation Task Creation — system package path)",
-        "Remediation task description follows task-description-template.md format with Repository, Target Branch, Description, Files to Modify, and Acceptance Criteria sections (Step 7 Remediation Task Creation)"
+        "Remediation task description follows task-description-template.md format with Repository, Target Branch, Description, Implementation Notes, and Acceptance Criteria sections — Files to Modify is intentionally omitted per remediation-templates.md (Step 7 Remediation Task Creation)"
       ]
     }
   ]

--- a/evals/triage-security/evals.json
+++ b/evals/triage-security/evals.json
@@ -57,6 +57,19 @@
         "The analysis treats the issue as unscoped (no stream suffix) and checks ALL versions across all streams (Step 1 Stream scope resolution, unscoped path)",
         "Cross-stream impact notice is NOT generated because the issue is unscoped — it covers all streams by definition (Step 7 Case B applies only to scoped issues)"
       ]
+    },
+    {
+      "id": 5,
+      "prompt": "Triage Vulnerability issue TC-8005. The issue details are in vuln-issue-rpm.md, the security matrix is in security-matrix-mock.md, and the project CLAUDE.md is in claude-md-security-config.md. The issue has stream suffix [rhtpa-2.2] so triage is scoped to the 2.2.x stream. Do NOT actually call Jira MCP, git show, or any external tools. Instead, write your triage analysis to the workspace outputs/ directory: write outputs/data-extraction.md with the parsed CVE data table from Step 1, write outputs/version-impact.md with the version impact table from Step 2 using rpms.lock.yaml data, write outputs/affects-versions.md with the Affects Versions correction from Step 3, and write outputs/remediation.md with the remediation task description you would create in Step 7.",
+      "expected_output": "A triage analysis for an RPM system package (openssl-libs) scoped to the 2.2.x stream. The ecosystem is detected as RPM (not Cargo). The version impact table uses rpms.lock.yaml data showing mixed impact: 2.2.0 through 2.2.2 ship the vulnerable openssl-libs version while 2.2.3 and 2.2.4 ship the patched version. Remediation creates a single task (not two-task upstream+downstream) because RPM is a system package ecosystem. The dependency chain classifies openssl-libs as an explicit install (present in rpms.lock.yaml).",
+      "files": ["files/vuln-issue-rpm.md", "files/security-matrix-mock.md", "files/claude-md-security-config.md"],
+      "assertions": [
+        "Data extraction identifies the ecosystem as RPM based on the library name (openssl-libs) and component context, not Cargo (Step 1 Ecosystem detection — read ecosystems from Ecosystem Mappings config)",
+        "Version impact table includes ALL versions from the 2.2.x stream supportability matrix (2.2.0 through 2.2.4) and uses rpms.lock.yaml data for version extraction (Step 2.3)",
+        "Dependency chain context classifies the package origin as explicit install because openssl-libs is present in rpms.lock.yaml, not inherited from the base image (Step 2.3.5)",
+        "Remediation creates a single task for the Konflux release repo — not the two-task upstream backport + downstream propagation flow used for source dependency ecosystems (Step 7 Remediation Task Creation — system package path)",
+        "Remediation task description follows task-description-template.md format with Repository, Target Branch, Description, Files to Modify, and Acceptance Criteria sections (Step 7 Remediation Task Creation)"
+      ]
     }
   ]
 }

--- a/evals/triage-security/files/security-matrix-mock.md
+++ b/evals/triage-security/files/security-matrix-mock.md
@@ -105,3 +105,20 @@ eval, use this data as the simulated output.
 | `v0.4.9` | _(retag of v0.4.8)_ |
 | `v0.4.11` | 0.4.9 |
 | `v0.4.12` | 0.4.9 |
+
+## openssl-libs versions by tag (rpms.lock.yaml)
+
+The following sections provide the RPM package versions that would be extracted
+by running `git show <tag>:rpms.lock.yaml | grep 'openssl-libs'` for each
+pinned commit. In a real triage, the skill runs these commands; in this eval,
+use this data as the simulated output.
+
+| Tag | openssl-libs version |
+|-----|----------------------|
+| `v0.3.8` | 3.0.7-24.el9 |
+| `v0.3.12` | 3.0.7-24.el9 |
+| `v0.4.5` | 3.0.7-25.el9_3 |
+| `v0.4.8` | 3.0.7-27.el9_4 |
+| `v0.4.9` | _(retag of v0.4.8)_ |
+| `v0.4.11` | 3.0.7-28.el9_4 |
+| `v0.4.12` | 3.0.7-28.el9_4 |

--- a/evals/triage-security/files/vuln-issue-rpm.md
+++ b/evals/triage-security/files/vuln-issue-rpm.md
@@ -1,0 +1,39 @@
+<!-- SYNTHETIC TEST DATA — RPM system package Vulnerability issue for triage-security eval testing -->
+
+# Mock Jira Vulnerability Issue
+
+**Key**: TC-8005
+**Summary**: CVE-2026-40215 openssl-libs - Buffer over-read in X.509 certificate verification [rhtpa-2.2]
+**Issue Type**: Vulnerability
+**Status**: New
+**Labels**: CVE-2026-40215, pscomponent:org/rhtpa-server
+**Affects Versions**: RHTPA 2.0.0
+**Due Date**: 2026-08-15
+**Assignee**: Unassigned
+
+## Remote Links
+
+- [CVE-2026-40215](https://www.cve.org/CVERecord?id=CVE-2026-40215) — CVE Record
+- [RHSA-2026:4021](https://access.redhat.com/errata/RHSA-2026:4021) — Red Hat Security Advisory
+
+## Comments
+
+_(no comments)_
+
+---
+
+## Description
+
+A vulnerability was found in openssl-libs. Versions of openssl before 3.0.7-28.el9_4 are vulnerable to a buffer over-read during X.509 certificate chain verification. A remote attacker can craft a certificate with a malformed extension that triggers an out-of-bounds read, potentially leaking sensitive memory contents or causing a crash.
+
+**Affected package**: openssl-libs
+**Affected versions**: versions before 3.0.7-28.el9_4
+**Fixed version**: 3.0.7-28.el9_4
+**CVSS**: 7.1 (High)
+
+The vulnerability exists in the `X509_verify_cert()` code path where the extension parser does not properly validate the length field of a Subject Alternative Name extension. The fix adds bounds checking before reading extension data.
+
+### References
+
+- https://www.cve.org/CVERecord?id=CVE-2026-40215
+- https://access.redhat.com/errata/RHSA-2026:4021


### PR DESCRIPTION
## Summary

- Adds eval-5 to `evals/triage-security/evals.json` exercising the RPM/system-package triage path
- Creates `vuln-issue-rpm.md` fixture with an openssl-libs CVE (TC-8005) and SYNTHETIC TEST DATA annotation
- Extends `security-matrix-mock.md` with RPM lock file data (openssl-libs versions by tag via rpms.lock.yaml) without modifying existing Cargo data
- 5 assertions verify: RPM ecosystem detection, version impact table completeness, package origin classification (explicit install via rpms.lock.yaml), single-task remediation (not two-task source dependency flow), and task-description-template.md format compliance
- Fixes eval-5 assertion 5 to expect Implementation Notes instead of Files to Modify, matching the RPM remediation template's intentional omission (TC-4769)

Implements [TC-4767](https://redhat.atlassian.net/browse/TC-4767)

## Summary by Sourcery

Add a new triage-security eval case that exercises RPM/system-package vulnerability triage using synthetic openssl-libs data.

New Features:
- Introduce a synthetic Jira vulnerability issue fixture for an openssl-libs RPM CVE used by the triage-security eval.
- Add RPM lockfile-derived openssl-libs version data to the security matrix to support RPM ecosystem evaluation.

Documentation:
- Document RPM-based openssl-libs versions by tag in the triage-security security matrix to simulate rpms.lock.yaml output.