### PR TITLE
feat(evals): add discovery mode eval case for triage-security

### DIFF
--- a/evals/triage-security/evals.json
+++ b/evals/triage-security/evals.json
@@ -70,6 +70,19 @@
         "Remediation creates a single task for the Konflux release repo — not the two-task upstream backport + downstream propagation flow used for source dependency ecosystems (Step 7 Remediation Task Creation — system package path)",
         "Remediation task description follows task-description-template.md format with Repository, Target Branch, Description, Implementation Notes, and Acceptance Criteria sections — Files to Modify is intentionally omitted per remediation-templates.md (Step 7 Remediation Task Creation)"
       ]
+    },
+    {
+      "id": 6,
+      "prompt": "You are invoked without an issue key — run discovery mode. The project CLAUDE.md is in claude-md-security-config.md and the JQL search results are in discovery-mode-results.md. Do NOT actually call Jira MCP, git show, or any external tools. Instead, write your analysis to the workspace outputs/ directory: write outputs/discovery-listing.md with the formatted issue list grouped by query and status, and write outputs/status-handling.md with the status-aware handling decisions for each listed issue.",
+      "expected_output": "A discovery mode analysis that constructs two JQL queries using the project key (TC) and vulnerability issue type ID (10024) from the project configuration, presents results in two clearly separated lists (Untriaged and Triaged but still New), and applies status-aware handling: New issues are presented for full triage, In Progress issues trigger a warning about active work.",
+      "files": ["files/claude-md-security-config.md", "files/discovery-mode-results.md"],
+      "assertions": [
+        "JQL queries use the project key (TC) and vulnerability issue type ID (10024) from the Security Configuration in claude-md-security-config.md — not hardcoded values (§1.49)",
+        "Two separate queries are constructed: one for untriaged issues (labels NOT IN ai-cve-triaged) and one for triaged-but-new issues (labels IN ai-cve-triaged AND status = New) (§1.48)",
+        "Results are grouped into two clearly separated lists: Untriaged issues and Triaged but still New issues",
+        "Each listed issue shows: issue key, status, CVE ID (from labels), summary, and created date",
+        "Status-aware handling: New issues (TC-9001, TC-9002, TC-9004) are presented for full triage, while the In Progress issue (TC-9003) triggers a warning about active work"
+      ]
     }
   ]
 }

--- a/evals/triage-security/files/discovery-mode-results.md
+++ b/evals/triage-security/files/discovery-mode-results.md
@@ -1,0 +1,26 @@
+<!-- SYNTHETIC TEST DATA — mock JQL search results for discovery mode eval testing. Keys, CVE IDs, summaries, and dates are fictional. JQL query structure mirrors SKILL.md §Discovery Mode (Steps 1-2); update both when query patterns change. -->
+
+# Mock JQL Search Results for Discovery Mode
+
+## Query 1: Untriaged Issues
+
+**JQL**: `project = TC AND issuetype = 10024 AND labels NOT IN (ai-cve-triaged) ORDER BY status ASC, created DESC`
+
+**Results** (4 issues):
+
+| Key | Summary | Status | Labels | Created |
+|-----|---------|--------|--------|---------|
+| TC-9001 | CVE-2026-40112 h2 - HTTP/2 rapid reset vulnerability [rhtpa-2.2] | New | CVE-2026-40112, pscomponent:org/rhtpa-server | 2026-06-08T14:30:00.000+0000 |
+| TC-9002 | CVE-2026-40297 serde_json - Stack overflow on deeply nested input [rhtpa-2.1] | New | CVE-2026-40297, pscomponent:org/rhtpa-server | 2026-06-07T09:15:00.000+0000 |
+| TC-9003 | CVE-2026-40455 tokio - Race condition in task cancellation [rhtpa-2.2] | In Progress | CVE-2026-40455, pscomponent:org/rhtpa-server | 2026-06-05T11:00:00.000+0000 |
+| TC-9004 | CVE-2026-40518 ring - Timing side-channel in RSA verification [rhtpa-2.2] | New | CVE-2026-40518, pscomponent:org/rhtpa-server | 2026-06-04T16:45:00.000+0000 |
+
+## Query 2: Triaged but still New
+
+**JQL**: `project = TC AND issuetype = 10024 AND labels IN (ai-cve-triaged) AND status = New ORDER BY created DESC`
+
+**Results** (1 issue):
+
+| Key | Summary | Status | Labels | Created |
+|-----|---------|--------|--------|---------|
+| TC-9010 | CVE-2026-39874 quinn-proto - Panic on malformed QUIC frame [rhtpa-2.2] | New | CVE-2026-39874, pscomponent:org/rhtpa-server, ai-cve-triaged | 2026-05-28T10:20:00.000+0000 |


### PR DESCRIPTION
## Summary

- Adds eval case 6 to `evals/triage-security/evals.json` exercising the discovery mode flow (invocation without an issue key)
- Creates `evals/triage-security/files/discovery-mode-results.md` fixture with mock JQL search results for untriaged and triaged-but-new queries
- Fixture includes mixed statuses (3 New, 1 In Progress) and 1 triaged-but-new issue to test status-aware handling

## Test plan

- [ ] Verify JSON is well-formed (`python3 -c "import json; json.load(open('evals/triage-security/evals.json'))"`)
- [ ] Verify existing evals 1–5 are unchanged
- [ ] Verify eval-6 has 5 assertions covering JQL construction, two-query structure, status grouping, and status-aware handling
- [ ] Verify discovery-mode-results.md has SYNTHETIC TEST DATA annotation header

Resolves: [TC-4768](https://redhat.atlassian.net/browse/TC-4768)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a new discovery-mode evaluation scenario for triage-security using synthetic Jira search results.

New Features:
- Introduce a discovery-mode eval case for triage-security covering invocation without an issue key.

Tests:
- Add synthetic JQL search results fixture for discovery-mode evaluation, including mixed statuses and triaged-but-new issues.