### PR TITLE
fix(fullsend): use correct Jira link type "Related" in sandbox mode

### DIFF
--- a/plugins/sdlc-workflow/schemas/verify-pr-result.schema.json
+++ b/plugins/sdlc-workflow/schemas/verify-pr-result.schema.json
@@ -58,7 +58,7 @@
             "required": ["type", "link_type", "inward", "outward"],
             "properties": {
               "type": {},
-              "link_type": { "type": "string", "enum": ["Blocks", "Relates"] },
+              "link_type": { "type": "string", "enum": ["Blocks", "Related"] },
               "inward": { "type": "string", "minLength": 1 },
               "outward": { "type": "string", "minLength": 1 }
             },

--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -862,7 +862,7 @@ jira.create_issue_link(type="Relates", inwardIssue=<root-cause-task-id>, outward
 ```json
 {
   "type": "create_link",
-  "link_type": "Relates",
+  "link_type": "Related",
   "inward": "{{rc-N.key}}",
   "outward": "<parent-task-id>"
 }


### PR DESCRIPTION
## Summary

The Jira REST API link type name is `Related`, not `Relates`. The MCP path maps `Relates` internally, but the sandbox mode JSON output passes the value directly to the REST API via `execute-actions.py`, causing a 404 on `create_link` for root-cause tasks.

## Root cause

The schema enum and SKILL.md sandbox mode template used `"Relates"` (the MCP convention) instead of `"Related"` (the Jira REST API `issueLinkType.name` field).

## Fix

- `schemas/verify-pr-result.schema.json`: change enum from `["Blocks", "Relates"]` to `["Blocks", "Related"]`
- `skills/verify-pr/SKILL.md`: change sandbox mode template from `"link_type": "Relates"` to `"link_type": "Related"`

## Evidence

```
$ python3 -c "..." # list issue link types
10077 | Related | inward: is related to | outward: relates to
```

The failing run log showed:
```
[4/6] create_link
❌ Resource not found (404 Not Found)
Failed to create link: TC-4799 Relates TC-4789
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update Jira link type naming in verify-pr workflow to match the Jira REST API and prevent sandbox-mode link creation failures.

Bug Fixes:
- Correct the Jira link type value from "Relates" to "Related" in sandbox-mode JSON to avoid 404 errors when creating issue links.

Documentation:
- Update the verify-pr skill sandbox template in SKILL.md to use the correct Jira link type name "Related".