### PR TITLE
docs: update project-config-contract and constraints for local matrix storage

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -56,7 +56,7 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 1.44 | `triage-security` MUST present version impact table to engineer before making triage decisions. | `triage-security/SKILL.md` — Step 2.4 |
 | 1.45 | `triage-security` MUST skip retag versions (identical digest) and note them in the impact table. | `triage-security/SKILL.md` — Important Rules §5 |
 | 1.46 | `triage-security` remediation tasks MUST follow the task-description-template.md format. | `triage-security/SKILL.md` — Important Rules §9, Remediation Task Creation |
-| 1.47 | `triage-security` output goes to Jira only, with one exception: it may write to `security-matrix.md` in Konflux release repos for supportability matrix population. | `triage-security/SKILL.md` — Guardrails, Step 2.1 |
+| 1.47 | `triage-security` output goes to Jira only, with one exception: it may write to local `security-matrix.md` files in the project working directory for supportability matrix population. | `triage-security/SKILL.md` — Guardrails, Step 2.1 |
 | 1.48 | `triage-security` MUST read ecosystems, lock file paths, and check commands from security-matrix.md Ecosystem Mappings — MUST NOT hardcode language-specific logic. | `triage-security/SKILL.md` — Step 1 (Ecosystem detection), Step 2.3 |
 | 1.49 | `triage-security` MUST read the Component label pattern from Security Configuration — MUST NOT hardcode label prefixes. | `triage-security/SKILL.md` — Step 0, Step 1 (Data Extraction) |
 

--- a/docs/project-config-contract.md
+++ b/docs/project-config-contract.md
@@ -206,9 +206,9 @@ and security matrix file path.
 | Column | Description | Example |
 |---|---|---|
 | Stream | Version stream label | `2.2.x` |
-| Konflux Release Repo | Git repository URL (used in Forward Pointers) | `git.downstream.example.com/.../product-release.0.4.z` |
+| Konflux Release Repo | Git repository URL (used for lock file inspection and fallback matrix reads via `git show`) | `git.downstream.example.com/.../product-release.0.4.z` |
 | Local Path | User's local clone path | `/path/to/product-release.0.4.z` |
-| Security Matrix Path | Path to security-matrix.md within the repo | `docs/security-matrix.md` |
+| Security Matrix Path | Path to security-matrix.md relative to the project working directory | `docs/security-matrix-2.2.x.md` |
 
 At least one row is required.
 
@@ -244,8 +244,8 @@ repository names listed here.
 
 | Stream | Konflux Release Repo | Local Path | Security Matrix Path |
 |---|---|---|---|
-| 2.1.x | git.downstream.example.com/.../product-release.0.3.z | /path/to/product-release.0.3.z | docs/security-matrix.md |
-| 2.2.x | git.downstream.example.com/.../product-release.0.4.z | /path/to/product-release.0.4.z | docs/security-matrix.md |
+| 2.1.x | git.downstream.example.com/.../product-release.0.3.z | /path/to/product-release.0.3.z | docs/security-matrix-2.1.x.md |
+| 2.2.x | git.downstream.example.com/.../product-release.0.4.z | /path/to/product-release.0.4.z | docs/security-matrix-2.2.x.md |
 
 ### Source Repositories
 
@@ -259,9 +259,10 @@ repository names listed here.
 
 - "`triage-security` reads Product Lifecycle fields to filter Jira
   versions and identify PSIRT component labels."
-- "`triage-security` follows Version Streams to load security-matrix.md
-  from each Konflux release repo and chain across streams via forward
-  pointers."
+- "`triage-security` reads security-matrix.md from local files at the
+  Security Matrix Path relative to the project working directory, falling
+  back to Konflux release repos via `git show` when local files don't
+  exist."
 - "`triage-security` uses Source Repositories to identify which repos'
   lock files to inspect for dependency versions."
 - "`setup` scaffolds this section interactively using


### PR DESCRIPTION
## Summary

- Update `docs/project-config-contract.md` Version Streams table to reflect local Security Matrix Path semantics (relative to project working directory, stream-specific naming)
- Update Konflux Release Repo column description from "Forward Pointers" to "lock file inspection and fallback matrix reads via `git show`"
- Update "How skills use it" section to describe local file reads with Konflux fallback instead of forward-pointer chaining
- Update `docs/constraints.md` constraint 1.47 to describe local write target instead of Konflux release repos

## Test plan

- [x] Cross-reference updated docs against SKILL.md guardrails (TC-4790) — constraint 1.47 text matches
- [x] Cross-reference against version-impact-analysis.md (TC-4789) — "How skills use it" reflects actual loading behavior
- [x] Verify no remaining forward-pointer references in either document
- [x] Verify example table paths use stream-specific naming consistent with column description

Implements [TC-4792](https://redhat.atlassian.net/browse/TC-4792)

## Summary by Sourcery

Update documentation to reflect local security matrix storage semantics and Konflux fallback behavior.

Documentation:
- Clarify version stream table descriptions for Konflux release repos and security matrix paths in project-config-contract.
- Update example version stream entries to use stream-specific security matrix file names.
- Revise triage-security behavior docs to describe reading local security matrix files with Konflux git fallback instead of forward-pointer chaining.
- Adjust constraint 1.47 to describe writing to local security-matrix files instead of Konflux release repositories.