### PR TITLE
ci: add workflow to build and push sandbox image to GHCR

### DIFF
--- a/.github/workflows/build-sandbox-image.yml
+++ b/.github/workflows/build-sandbox-image.yml
@@ -1,0 +1,45 @@
+name: Build sandbox image
+
+on:
+  push:
+    branches: [run-in-fullsend]
+    paths:
+      - 'plugins/sdlc-workflow/**'
+      - '.github/workflows/build-sandbox-image.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/sdlc-plugins/sdlc-base
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.IMAGE_NAME }}
+          tags: latest ${{ github.sha }}
+          containerfiles: plugins/sdlc-workflow/sandboxes/base/Dockerfile
+          context: .
+
+      - name: Push to GHCR
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ env.IMAGE_NAME }}
+          tags: latest ${{ github.sha }}
+          registry: ${{ env.REGISTRY }}


### PR DESCRIPTION
## Summary

Automate container image builds using Red Hat actions (Podman/Buildah).

## Trigger

- Push to `run-in-fullsend` when `plugins/sdlc-workflow/**` changes
- Manual dispatch (`workflow_dispatch`)

## Actions used

| Action | Version | Purpose |
|---|---|---|
| `actions/checkout` | v6 | Checkout source |
| `redhat-actions/podman-login` | v1 | Authenticate to GHCR |
| `redhat-actions/buildah-build` | v2 | Build image with Buildah |
| `redhat-actions/push-to-registry` | v2 | Push to GHCR |

## Tags

- `ghcr.io/mrizzi/sdlc-plugins/sdlc-base:latest`
- `ghcr.io/mrizzi/sdlc-plugins/sdlc-base:<sha>`

## Test plan

- [ ] Merge PR → workflow triggers on `run-in-fullsend` push
- [ ] Image appears on GHCR packages page
- [ ] `podman pull ghcr.io/mrizzi/sdlc-plugins/sdlc-base:latest` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Introduce a CI workflow that builds the sdlc-base sandbox image with Buildah and pushes versioned and latest tags to GHCR on branch pushes and manual runs.