### PR TITLE
ci: multi-arch builds, semver tags, PR safety, and build cache

### DIFF
--- a/.github/workflows/build-sandbox-image.yml
+++ b/.github/workflows/build-sandbox-image.yml
@@ -8,6 +8,7 @@ on:
       - 'plugins/sdlc-workflow/**'
       - '.github/workflows/build-sandbox-image.yml'
   pull_request:
+    branches: [run-in-fullsend]
     paths:
       - 'plugins/sdlc-workflow/**'
       - '.github/workflows/build-sandbox-image.yml'

--- a/.github/workflows/build-sandbox-image.yml
+++ b/.github/workflows/build-sandbox-image.yml
@@ -3,6 +3,7 @@ name: Build sandbox image
 on:
   push:
     branches: [run-in-fullsend]
+    tags: ['v*']
     paths:
       - 'plugins/sdlc-workflow/**'
       - '.github/workflows/build-sandbox-image.yml'
@@ -13,7 +14,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: build-sandbox-image-${{ github.ref }}
+  group: build-sandbox-image-${{ github.ref_name }}
   cancel-in-progress: true
 
 env:
@@ -31,6 +32,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up QEMU
+        if: github.event_name != 'pull_request'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Buildx
@@ -60,7 +62,7 @@ jobs:
         with:
           context: .
           file: plugins/sdlc-workflow/sandboxes/base/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-sandbox-image.yml
+++ b/.github/workflows/build-sandbox-image.yml
@@ -6,7 +6,15 @@ on:
     paths:
       - 'plugins/sdlc-workflow/**'
       - '.github/workflows/build-sandbox-image.yml'
+  pull_request:
+    paths:
+      - 'plugins/sdlc-workflow/**'
+      - '.github/workflows/build-sandbox-image.yml'
   workflow_dispatch:
+
+concurrency:
+  group: build-sandbox-image-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io
@@ -22,24 +30,39 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
-        uses: redhat-actions/podman-login@v1
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build image
-        uses: redhat-actions/buildah-build@v2
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
         with:
-          image: ${{ env.IMAGE_NAME }}
-          tags: latest ${{ github.sha }}
-          containerfiles: plugins/sdlc-workflow/sandboxes/base/Dockerfile
-          context: .
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
-      - name: Push to GHCR
-        uses: redhat-actions/push-to-registry@v2
+      - name: Build and push
+        uses: docker/build-push-action@v6
         with:
-          image: ${{ env.IMAGE_NAME }}
-          tags: latest ${{ github.sha }}
-          registry: ${{ env.REGISTRY }}
+          context: .
+          file: plugins/sdlc-workflow/sandboxes/base/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Upgrade the sandbox image CI pipeline based on patterns from rhdh-fullsend ([comparison](docs/specs/2026-06-15-rhdh-fullsend-comparison.md)).

## Changes

| Feature | Before | After |
|---|---|---|
| Architecture | amd64 only | amd64 + arm64 (QEMU + Buildx) |
| Tagging | `latest` + raw SHA | Semver (`X.Y.Z`, `X.Y`), `sha-<short>`, `latest` |
| PR builds | Not triggered | Build without push |
| Cache | None | GHA cache |
| Concurrency | None | Cancel-in-progress per ref |
| Build tool | Red Hat actions (Buildah) | Docker actions (Buildx) |

## Why Docker actions instead of Red Hat actions

Multi-arch builds require Buildx + QEMU. The Red Hat actions (`buildah-build`, `push-to-registry`) don't support multi-platform builds natively. The Docker actions (`setup-qemu-action`, `setup-buildx-action`, `build-push-action`) are the standard for this. Images are still OCI-compliant and work with Podman.

## Test plan

- [x] arm64 image built locally and tested with fullsend v0.17.0 — full pipeline success
- [x] amd64 image tested with fullsend v0.17.0 — full pipeline success (all previous runs)
- [ ] CI builds multi-arch after merge (verified by pulling with `--platform`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the sandbox image CI workflow to support multi-architecture builds with improved tagging, caching, and safer PR behavior.

New Features:
- Trigger sandbox image builds on pull requests without pushing images.
- Build and publish multi-architecture sandbox images for amd64 and arm64.
- Generate semantic version, SHA-based, and latest image tags via metadata extraction.

Enhancements:
- Switch the sandbox image workflow from Red Hat Buildah/Podman actions to Docker Buildx-based actions for building and pushing images.
- Add GitHub Actions concurrency control to cancel in-progress sandbox-image builds per ref.
- Enable GitHub Actions cache for Docker builds to speed up repeated sandbox image builds.

CI:
- Configure the sandbox image workflow to use QEMU and Buildx for multi-platform builds and to avoid registry login and pushes on pull_request events.