### PR TITLE
fix(ci): use tag-names output for bare tags in Red Hat actions

### DIFF
--- a/.github/workflows/build-sandbox-image.yml
+++ b/.github/workflows/build-sandbox-image.yml
@@ -60,7 +60,7 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         with:
           image: ${{ env.IMAGE_NAME }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tag-names }}
           containerfiles: plugins/sdlc-workflow/sandboxes/base/Dockerfile
           context: .
           platforms: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
@@ -70,5 +70,5 @@ jobs:
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ env.IMAGE_NAME }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tag-names }}
           registry: ${{ env.REGISTRY }}


### PR DESCRIPTION
## Summary

Fix tag format mismatch between `docker/metadata-action` and Red Hat build/push actions.

`docker/metadata-action` `tags` output provides full image refs (`ghcr.io/.../sdlc-base:sha-abc`). Red Hat actions (`buildah-build`, `push-to-registry`) expect bare tag names (`sha-abc`) because they combine `image` + `tags` + `registry` themselves.

## Fix

Use the `tag-names` output (added in [v5.9.0](https://github.com/docker/metadata-action/issues/212)) which provides bare tag names without the image prefix.

## Change

```diff
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tag-names }}
```

Applied to both `buildah-build` and `push-to-registry` steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update build-sandbox-image workflow to use docker/metadata-action tag-names output for Red Hat buildah-build and push-to-registry steps.