### PR TITLE
ci: register fullsend-verify-pr workflow on default branch

### DIFF
--- a/.github/workflows/fullsend-verify-pr.yml
+++ b/.github/workflows/fullsend-verify-pr.yml
@@ -1,0 +1,14 @@
+name: fullsend verify-pr
+
+on:
+  workflow_dispatch:
+    inputs:
+      jira_issue_id:
+        description: 'Jira issue ID (e.g., TC-4792)'
+        required: true
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Use --ref run-in-fullsend to run the real workflow"


### PR DESCRIPTION
## Summary

- GitHub requires `workflow_dispatch` workflows to exist on the default branch for API/UI discovery
- The actual workflow content runs from `--ref run-in-fullsend`, so this file only needs to exist on `main` for registration
- Once merged, the workflow can be triggered with: `gh workflow run fullsend-verify-pr.yml --ref run-in-fullsend --field jira_issue_id=TC-4792`

## Test plan

- [ ] Verify workflow appears in `gh api repos/mrizzi/sdlc-plugins/actions/workflows`
- [ ] Trigger with `--ref run-in-fullsend` and confirm it uses the branch version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Introduce a workflow_dispatch-based fullsend-verify-pr workflow registered on the default branch for manual runs tied to a Jira issue ID.