### PR TITLE
fix(fullsend): use branch ref instead of pinned SHA for skill files

### DIFF
--- a/.github/workflows/fullsend-verify-pr.yml
+++ b/.github/workflows/fullsend-verify-pr.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  SDLC_PLUGINS_REF: e56cbe13f93c1dc0a3fe6f9600cbc4fa6ad04be0
+  SDLC_PLUGINS_REF: run-in-fullsend
 
 jobs:
   verify-pr:


### PR DESCRIPTION
## Summary

- Change `SDLC_PLUGINS_REF` from pinned commit SHA to branch name `run-in-fullsend`
- Fixes the chicken-and-egg problem where the workflow fetched stale skill files that didn't include the GCP path fix or image tag fix from PR #175

## Root cause

The workflow checked out sdlc-plugins at SHA `e56cbe1` (set before PR #175). That commit had:
- `image: ...sdlc-base:latest` (wrong, `:latest` is only on main)
- `dest: /tmp/.gcp-credentials.json` (collides with `google-github-actions/auth` directory)

Both issues were fixed in PR #175, but the fix never reached the runtime because the workflow kept using the old SHA.

## Verification

All 7 checks pass:
1. `SDLC_PLUGINS_REF` = `run-in-fullsend` (always latest)
2. Harness image = `:latest-run-in-fullsend` (matches build output)
3. GCP dest = `/tmp/gcp-credentials.json` (no collision)
4. Env file `GOOGLE_APPLICATION_CREDENTIALS` matches dest
5. No stale `.gcp-credentials.json` references remain
6. Image with `latest-run-in-fullsend` tag exists
7. Target repos will still pin to SHA for reproducibility

## Test plan

- [ ] Merge and trigger: `gh workflow run fullsend-verify-pr.yml --ref run-in-fullsend --field jira_issue_id=TC-4792`
- [ ] Verify image pulled is `sdlc-base:latest-run-in-fullsend`
- [ ] Verify GCP credentials mount succeeds (no "same file" error)
- [ ] Verify sandbox starts and agent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Use a moving branch reference for SDLC_PLUGINS_REF so the workflow always consumes the latest skill files for fullsend verification.