### PR TITLE
fix(fullsend): set target-repo to current workspace

### DIFF
--- a/.github/workflows/fullsend-verify-pr.yml
+++ b/.github/workflows/fullsend-verify-pr.yml
@@ -90,6 +90,7 @@ jobs:
           GOOGLE_CLOUD_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
         with:
           agent: verify-pr
+          target-repo: .
 
       - name: Clean up staged credentials
         if: always()


### PR DESCRIPTION
## Summary

- Set `target-repo: .` on the fullsend composite action
- Fullsend defaults to `$GITHUB_WORKSPACE/target-repo` which doesn't exist
- For sdlc-plugins verifying itself, the target repo is the workspace root

## Test plan

- [ ] Merge and trigger: `gh workflow run fullsend-verify-pr.yml --ref run-in-fullsend --field jira_issue_id=TC-4792`
- [ ] Verify no "Cannot open: No such file or directory" error on target-repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Configure the fullsend composite action in the verify-pr workflow to use the workspace root as its target repository to avoid missing path issues.