### PR TITLE
feat(fullsend): add optional GH_TOKEN secret for cross-repo PR comments

### DIFF
--- a/.github/workflows/reusable-verify-pr.yml
+++ b/.github/workflows/reusable-verify-pr.yml
@@ -38,6 +38,8 @@ on:
         required: true
       GCP_CLOUD_ML_REGION:
         required: true
+      GH_TOKEN:
+        required: false
 
 jobs:
   verify-pr:
@@ -118,7 +120,7 @@ jobs:
           VERIFY_PR_JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
           VERIFY_PR_JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
           VERIFY_PR_JIRA_PROJECT_KEY: ${{ secrets.JIRA_PROJECT_KEY }}
-          VERIFY_PR_GH_TOKEN: ${{ github.token }}
+          VERIFY_PR_GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
           VERIFY_PR_ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.FULLSEND_GCP_PROJECT_ID }}
           VERIFY_PR_CLOUD_ML_REGION: ${{ secrets.GCP_CLOUD_ML_REGION }}
         run: bash .github/scripts/setup-agent-env.sh


### PR DESCRIPTION
## Summary

- Add `GH_TOKEN` as an optional secret to the reusable workflow
- When provided (PAT with cross-repo access), used for post-script writes
- When not provided, falls back to `github.token` (same-repo only)
- Sandbox provider continues using `github.token` for reads (unchanged)

## Root cause

JIRAPLAY-1380 links to a PR on `mrizzi/trustify-ui`, but the workflow runs in `mrizzi/trustify-ai-workflow`. The `github.token` is scoped to the workflow's repo and can't comment on a different repo's PR.

## Usage

Callers that need cross-repo PR comments add a PAT secret:

```yaml
secrets:
  GH_TOKEN: ${{ secrets.GH_TOKEN }}  # fine-grained PAT with Pull requests: Read+Write
```

Fine-grained PAT permissions: Pull requests (Read and write) on target repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add optional GH_TOKEN support to the reusable PR verification workflow to enable cross-repo pull request comments while preserving same-repo behavior by default.

New Features:
- Allow callers of the reusable verify-pr workflow to provide an optional GH_TOKEN secret for GitHub API writes.

Enhancements:
- Fallback to the default github.token when GH_TOKEN is not provided to maintain existing same-repo workflows.