### PR TITLE
fix(fullsend): remove concurrency group from verify-pr shim

### DIFF
--- a/.github/workflows/fullsend-verify-pr.yml
+++ b/.github/workflows/fullsend-verify-pr.yml
@@ -7,10 +7,6 @@ on:
         description: 'Jira issue ID (e.g., TC-4792)'
         required: true
 
-concurrency:
-  group: fullsend-verify-pr
-  cancel-in-progress: false
-
 jobs:
   verify-pr:
     uses: mrizzi/sdlc-plugins/.github/workflows/reusable-verify-pr.yml@run-in-fullsend


### PR DESCRIPTION
## Summary

Remove the concurrency group that serialized parallel verify-pr runs. Fullsend doesn't use concurrency groups. Workflows are designed for parallel execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Remove the concurrency group from the fullsend-verify-pr workflow to allow parallel verify-pr runs without enforced serialization.