### PR TITLE
feat(fullsend): split post_pr_reply into reply and comment actions

### DIFF
--- a/plugins/sdlc-workflow/schemas/verify-pr-result.schema.json
+++ b/plugins/sdlc-workflow/schemas/verify-pr-result.schema.json
@@ -34,7 +34,7 @@
       "type": "object",
       "required": ["type"],
       "properties": {
-        "type": { "type": "string", "enum": ["create_subtask", "create_link", "post_pr_reply", "create_root_cause_task", "post_comment", "post_report"] }
+        "type": { "type": "string", "enum": ["create_subtask", "create_link", "post_pr_reply", "post_pr_comment", "create_root_cause_task", "post_comment", "post_report"] }
       },
       "allOf": [
         {
@@ -74,6 +74,19 @@
               "repo": { "type": "string" },
               "pr_number": { "type": "integer", "minimum": 1 },
               "comment_id": { "type": "integer", "minimum": 1 },
+              "body": { "type": "string", "minLength": 1 }
+            },
+            "additionalProperties": false
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "post_pr_comment" } } },
+          "then": {
+            "required": ["type", "repo", "pr_number", "body"],
+            "properties": {
+              "type": {},
+              "repo": { "type": "string" },
+              "pr_number": { "type": "integer", "minimum": 1 },
               "body": { "type": "string", "minLength": 1 }
             },
             "additionalProperties": false

--- a/plugins/sdlc-workflow/scripts/execute-actions.py
+++ b/plugins/sdlc-workflow/scripts/execute-actions.py
@@ -143,6 +143,23 @@ def execute_post_pr_reply(action: dict, registry: dict) -> None:
     print(f"  Posted PR reply on comment {comment_id}")
 
 
+def execute_post_pr_comment(action: dict, registry: dict) -> None:
+    repo = action["repo"]
+    pr_number = action["pr_number"]
+    body = resolve_refs(action["body"], registry)
+
+    result = subprocess.run(
+        ["gh", "api",
+         f"repos/{repo}/issues/{pr_number}/comments",
+         "-f", f"body={body}"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"gh api failed: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    print(f"  Posted PR comment on #{pr_number}")
+
+
 def execute_create_root_cause_task(action: dict, registry: dict) -> None:
     project_key = os.environ.get("JIRA_PROJECT_KEY", "")
     if not project_key:
@@ -199,6 +216,7 @@ EXECUTORS = {
     "create_subtask": execute_create_subtask,
     "create_link": execute_create_link,
     "post_pr_reply": execute_post_pr_reply,
+    "post_pr_comment": execute_post_pr_comment,
     "create_root_cause_task": execute_create_root_cause_task,
     "post_comment": execute_post_comment,
 }

--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -716,7 +716,9 @@ When a review body contains multiple classified suggestions (sub-identifiers), p
 a single standalone comment that lists all classifications together rather than one
 comment per sub-identifier.
 
-**Sandbox mode:** Instead of calling `gh api`, add an action for each reply:
+**Sandbox mode:** Instead of calling `gh api`, add an action for each reply.
+
+For **inline comment threads** (have a `comment_id`), use `post_pr_reply`:
 
 ```json
 {
@@ -725,6 +727,17 @@ comment per sub-identifier.
   "pr_number": <pr-number>,
   "comment_id": <comment-id>,
   "body": "<reply body with {{subtask-N.key}} and {{subtask-N.url}} placeholders if referencing a sub-task>"
+}
+```
+
+For **review body items** (no `comment_id`), use `post_pr_comment`:
+
+```json
+{
+  "type": "post_pr_comment",
+  "repo": "<owner/repo>",
+  "pr_number": <pr-number>,
+  "body": "<comment body>"
 }
 ```
 ### Step 6f – Idempotency Guarantees


### PR DESCRIPTION
## Summary

- Add `post_pr_comment` action type for review body items (issue-level PR comments, no comment_id)
- `post_pr_reply` remains for inline comment threads (requires comment_id)
- Schema, executor, and SKILL.md updated

## Root cause

Review body feedback has no `comment_id` (it's not an inline comment). The agent was forced to use `post_pr_reply` and produced `"comment_id": null`, failing schema validation with `None is not of type 'integer'`.

## Changes

| File | Change |
|---|---|
| `verify-pr-result.schema.json` | Add `post_pr_comment` to enum, add `allOf/if/then` with `repo`, `pr_number`, `body` (no `comment_id`) |
| `execute-actions.py` | Add `execute_post_pr_comment` using `gh api repos/.../issues/.../comments` |
| `SKILL.md` | Document both action types in sandbox mode section |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a dedicated action for posting top-level PR review comments separate from inline comment replies.

New Features:
- Add a post_pr_comment action type and executor for creating top-level PR comments on pull requests.

Bug Fixes:
- Adjust the verify-pr result schema to support review body feedback without requiring a comment_id by introducing the post_pr_comment action type.

Enhancements:
- Wire the new post_pr_comment action into the action dispatcher alongside existing post_pr_reply handling.
- Document the distinction and usage between post_pr_reply (inline threads) and post_pr_comment (review body items) in the verify-pr skill.

Documentation:
- Update SKILL documentation to describe how to use post_pr_comment versus post_pr_reply in sandbox mode.