### PR TITLE
docs(triage-security): add idempotent sibling link check to Step 4.2

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -67,6 +67,7 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 1.55 | `triage-bug` MUST front-load the reproducer test as the first acceptance criterion and first test requirement in generated Tasks. | `triage-bug/SKILL.md` — Step 5 (Front-load the reproducer test) |
 | 1.56 | `triage-bug` MUST post a root cause analysis comment on the Bug issue before creating the fix Task. | `triage-bug/SKILL.md` — Step 4 (Post root cause comment) |
 | 1.57 | `triage-bug` MUST flag multi-root-cause bugs for decomposition rather than silently creating a single Task that bundles unrelated fixes. | `triage-bug/SKILL.md` — Step 6 (Decomposition Guard) |
+| 1.58 | `triage-security` MUST check existing issuelinks before creating sibling "Related" links — MUST NOT create a link if one already exists between the two issues. | `triage-security/jira-triage-operations.md` — Step 4.2 |
 
 ### Prior Art — Cross-phase integrity (§1.33–1.35)
 
@@ -161,4 +162,5 @@ Each constraint above references its source. The full source files are:
 - `plugins/sdlc-workflow/skills/report-bug/SKILL.md` — Guardrails (§1.50–1.51), Step 4 Preview and Confirm (§1.52)
 - `plugins/sdlc-workflow/skills/triage-bug/SKILL.md` — Guardrails (§1.53–1.54), Step 5 Front-load reproducer test (§1.55), Step 4 Post root cause comment (§1.56), Step 6 Decomposition Guard (§1.57)
 - `plugins/sdlc-workflow/skills/triage-security/SKILL.md` — Guardrails (§1.37, §1.38, §1.47), Step 0 (§1.49), Step 1 Ecosystem detection (§1.48), Step 1 Data Extraction (§1.49), Step 2.1 (§1.47), Step 2.2 (§1.42), Step 2.3 (§1.48), Step 2.4 (§1.44), Step 7 (§1.43), Important Rules (§1.38–§1.43, §1.45, §1.46), Remediation Task Creation (§1.46)
+- `plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md` — Step 4.2 Idempotent sibling linking (§1.58)
 - `docs/methodology.md` — Core Principles (§2.1, §3.2, §5.5)

--- a/evals/triage-security/evals.json
+++ b/evals/triage-security/evals.json
@@ -83,6 +83,19 @@
         "Each listed issue shows: issue key, status, CVE ID (from labels), summary, and created date",
         "Status-aware handling: New issues (TC-9001, TC-9002, TC-9004) are presented for full triage, while the In Progress issue (TC-9003) triggers a warning about active work"
       ]
+    },
+    {
+      "id": 7,
+      "prompt": "Triage Vulnerability issue TC-8006. The issue details are in vuln-issue-sibling-prelinked.md, the security matrix is in security-matrix-mock.md, and the project CLAUDE.md is in claude-md-security-config.md. The issue has stream suffix [rhtpa-2.1] and a pre-existing 'Related' link to sibling TC-8001 (stream [rhtpa-2.2]). Assume a JQL search for sibling issues with the same CVE label returns one result: TC-8001 with status 'In Progress', stream suffix [rhtpa-2.2], and Affects Versions [RHTPA 2.2.0, RHTPA 2.2.1]. Do NOT actually call Jira MCP, git show, or any external tools. Instead, write your triage analysis to the workspace outputs/ directory: write outputs/data-extraction.md with the parsed CVE data, write outputs/sibling-check.md with the Step 4 sibling and link analysis, and write outputs/triage-outcome.md explaining how Step 4.2 handled the pre-existing link.",
+      "expected_output": "A triage analysis where Step 4 detects sibling TC-8001 as a different-stream companion (not a duplicate). Step 4.2 checks the issue's existing issuelinks, finds a pre-existing 'Related' link to TC-8001, and skips link creation instead of creating a duplicate. The output explicitly states that the link was skipped because it already exists.",
+      "files": ["files/vuln-issue-sibling-prelinked.md", "files/security-matrix-mock.md", "files/claude-md-security-config.md"],
+      "assertions": [
+        "Sibling check correctly classifies TC-8001 as a different-stream companion (stream [rhtpa-2.2] vs current issue's [rhtpa-2.1]), not a same-stream duplicate (Step 4)",
+        "Step 4.2 checks the current issue's existing issuelinks before attempting to create a 'Related' link to TC-8001 (§1.50)",
+        "Step 4.2 detects the pre-existing 'Related' link to TC-8001 and skips link creation — does NOT call jira.create_link (§1.50)",
+        "The output includes a log message indicating the link was skipped because it already exists (e.g., 'Related link to TC-8001 already exists — skipping')",
+        "The sibling landscape table is still presented to the engineer despite the link already existing — the idempotent check only affects link creation, not the sibling summary"
+      ]
     }
   ]
 }

--- a/evals/triage-security/files/vuln-issue-sibling-prelinked.md
+++ b/evals/triage-security/files/vuln-issue-sibling-prelinked.md
@@ -1,0 +1,58 @@
+<!-- SYNTHETIC TEST DATA — cross-stream sibling with pre-existing Related link for idempotent linking eval -->
+
+# Mock Jira Vulnerability Issue
+
+**Key**: TC-8006
+**Summary**: CVE-2026-31812 quinn-proto - Panic on large stream counts [rhtpa-2.1]
+**Issue Type**: Vulnerability
+**Status**: New
+**Labels**: CVE-2026-31812, pscomponent:org/rhtpa-server
+**Affects Versions**: RHTPA 2.1.0
+**Due Date**: 2026-07-15
+**Assignee**: Unassigned
+
+## Issue Links
+
+The following links already exist on this issue:
+
+- **Related**: TC-8001 (CVE-2026-31812 quinn-proto - Panic on large stream counts [rhtpa-2.2])
+  - Link ID: 1990401
+  - Type: Related
+  - Direction: outward (this issue → TC-8001)
+
+## Remote Links
+
+- [GHSA-2026-qp73-x4mq](https://github.com/advisories/GHSA-2026-qp73-x4mq) — GitHub Advisory
+- [CVE-2026-31812](https://www.cve.org/CVERecord?id=CVE-2026-31812) — CVE Record
+
+## Comments
+
+_(no comments)_
+
+---
+
+## Description
+
+A vulnerability was found in quinn-proto. The quinn-proto crate before version 0.11.14 allows a remote attacker to cause a panic by sending a QUIC transport frame that creates an excessive number of streams. This vulnerability is classified as a denial of service (DoS).
+
+**Affected package**: quinn-proto
+**Affected versions**: versions before 0.11.14
+**Fixed version**: 0.11.14
+**CVSS**: 7.5 (High)
+
+The vulnerability exists because quinn-proto does not properly validate the number of streams requested in a STREAMS frame. An attacker can send a specially crafted frame that causes the server to allocate an unbounded number of stream state objects, leading to a panic when the allocation exceeds internal limits.
+
+### References
+
+- https://github.com/advisories/GHSA-2026-qp73-x4mq
+- https://rustsec.org/advisories/RUSTSEC-2026-0042.html
+
+### Sibling Issues (provided by JQL search)
+
+The following sibling issue exists for the same CVE:
+
+- **TC-8001** — CVE-2026-31812 quinn-proto - Panic on large stream counts [rhtpa-2.2]
+  - **Status**: In Progress
+  - **Labels**: CVE-2026-31812, pscomponent:org/rhtpa-server
+  - **Affects Versions**: RHTPA 2.2.0, RHTPA 2.2.1
+  - **Stream suffix**: [rhtpa-2.2] (different stream from TC-8006's [rhtpa-2.1])

--- a/plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md
+++ b/plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md
@@ -125,7 +125,16 @@ If a same-stream sibling exists and is open or in progress:
 Different-stream siblings are **companion trackers**, not duplicates. PSIRT creates
 one issue per stream intentionally. For each different-stream sibling:
 
-1. **Link** the current issue to the sibling with a "Related" link type:
+1. **Check for existing link** before creating one. Read the current issue's
+   `issuelinks` array from the `jira.get_issue` response (already fetched in
+   Step 1). Check if any existing link satisfies all of:
+   - `type.name` is `"Related"`
+   - `inwardIssue.key` or `outwardIssue.key` matches the sibling key
+
+   If a matching link exists, skip link creation and log:
+   > "Related link to [sibling-key] already exists — skipping"
+
+   If no matching link exists, create the link:
    ```
    jira.create_link(
      inwardIssue: <current-issue-key>,


### PR DESCRIPTION
## Summary

- Step 4.2 in `jira-triage-operations.md` now checks existing `issuelinks` before creating a "Related" link to a cross-stream sibling, preventing duplicate links when both issues in a sibling pair are triaged
- Adds constraint §1.50 to `constraints.md` enforcing the idempotent check
- Adds eval case 7 with a new fixture (`vuln-issue-sibling-prelinked.md`) that exercises the skip-when-linked path

Implements [TC-4849](https://redhat.atlassian.net/browse/TC-4849)

## Test plan

- [ ] Eval case 7 passes: agent skips link creation when a pre-existing "Related" link to the sibling is detected
- [ ] Existing eval cases 1–6 continue to pass without modification
- [ ] Constraint §1.50 is correctly referenced in the Traceability Index

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document idempotent handling of cross-stream sibling links in triage-security Jira operations and add corresponding constraints and evaluation coverage.

Documentation:
- Update triage-security Jira operations to check for existing sibling "Related" links before creating new ones, ensuring idempotent linking behavior.
- Add constraint §1.50 specifying that triage-security must not create duplicate sibling "Related" links and reference it from the traceability index.

Tests:
- Add a new eval case and fixture covering the scenario where a cross-stream sibling already has a pre-existing "Related" link, verifying that link creation is skipped.