### PR TITLE
docs: add bug lifecycle pipeline documentation and constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ implementing tasks, and verifying pull requests:
 - **verify-pr** — Verify a PR against its Jira task's acceptance criteria and
   deterministic guardrails.
 
+- **report-bug** — Interactively define a Jira Bug by walking through
+  project-configured template sections, or accept structured input
+  programmatically from other skills.
+
+- **triage-bug** — Triage a Jira Bug issue by investigating root cause through
+  codebase analysis, posting a root cause comment, and producing a linked fix
+  Task with a reproducer test front-loaded for `/implement-task` consumption.
+
 - **triage-security** — Triage PSIRT-created Vulnerability issues (CVEs) with
   version-aware impact analysis across supported product versions. Includes a
   discovery mode for listing untriaged vulnerabilities.
@@ -87,6 +95,8 @@ catching regressions. See the eval directories for each skill:
 - [evals/define-feature/](evals/define-feature/) — Define-feature eval cases
 - [evals/implement-task/](evals/implement-task/) — Implement-task eval cases
 - [evals/verify-pr/](evals/verify-pr/) — Verify-pr eval cases
+- [evals/report-bug/](evals/report-bug/) — Report-bug eval cases
+- [evals/triage-bug/](evals/triage-bug/) — Triage-bug eval cases
 - [evals/triage-security/](evals/triage-security/) — Triage-security eval cases
 - [evals/setup/](evals/setup/) — Setup eval cases
 

--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -61,7 +61,7 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 1.49 | `triage-security` MUST read the Component label pattern from Security Configuration — MUST NOT hardcode label prefixes. | `triage-security/SKILL.md` — Step 0, Step 1 (Data Extraction) |
 | 1.50 | `report-bug` MUST NOT modify, create, or delete any files in any repository. Only Jira MCP tools are permitted for output. | `report-bug/SKILL.md` — Guardrails |
 | 1.51 | `report-bug` MUST NOT fabricate content. All Bug description content must come from user input or structured input from calling skills. | `report-bug/SKILL.md` — Guardrails |
-| 1.52 | `report-bug` MUST NOT create a Jira issue without showing a full preview and receiving explicit user approval. | `report-bug/SKILL.md` — Step 6 (Preview and Approval) |
+| 1.52 | `report-bug` MUST NOT create a Jira issue without showing a full preview and receiving explicit user approval. | `report-bug/SKILL.md` — Step 4 (Preview and Confirm) |
 | 1.53 | `triage-bug` MUST NOT modify, create, or delete any source code files in any repository. Only read-only tools (Read, Glob, Grep, Serena search) are permitted for codebase investigation. | `triage-bug/SKILL.md` — Guardrails |
 | 1.54 | `triage-bug` output goes to Jira (tasks, comments, links) — never to the filesystem. | `triage-bug/SKILL.md` — Guardrails |
 | 1.55 | `triage-bug` MUST front-load the reproducer test as the first acceptance criterion and first test requirement in generated Tasks. | `triage-bug/SKILL.md` — Step 5 (Front-load the reproducer test) |
@@ -158,7 +158,7 @@ Each constraint above references its source. The full source files are:
 - `plugins/sdlc-workflow/skills/verify-pr/correctness.md` — Constraints (§1.11, §1.22, §1.23), Output Format (§1.24)
 - `plugins/sdlc-workflow/skills/verify-pr/style-conventions.md` — Check 1 Convention applicability (§1.36), Check 2 (§1.16), Check 3 (§1.17), Check 4 (§1.18, §1.19, §1.20, §1.21), Check 5 (§1.30), Constraints (§1.11, §1.22, §1.23), Output Format (§1.24)
 - `plugins/sdlc-workflow/skills/define-feature/SKILL.md` — Guardrails (§1.7–1.8), Important Rules (§1.9)
-- `plugins/sdlc-workflow/skills/report-bug/SKILL.md` — Guardrails (§1.50–1.51), Step 6 Preview and Approval (§1.52)
+- `plugins/sdlc-workflow/skills/report-bug/SKILL.md` — Guardrails (§1.50–1.51), Step 4 Preview and Confirm (§1.52)
 - `plugins/sdlc-workflow/skills/triage-bug/SKILL.md` — Guardrails (§1.53–1.54), Step 5 Front-load reproducer test (§1.55), Step 4 Post root cause comment (§1.56), Step 6 Decomposition Guard (§1.57)
 - `plugins/sdlc-workflow/skills/triage-security/SKILL.md` — Guardrails (§1.37, §1.38, §1.47), Step 0 (§1.49), Step 1 Ecosystem detection (§1.48), Step 1 Data Extraction (§1.49), Step 2.1 (§1.47), Step 2.2 (§1.42), Step 2.3 (§1.48), Step 2.4 (§1.44), Step 7 (§1.43), Important Rules (§1.38–§1.43, §1.45, §1.46), Remediation Task Creation (§1.46)
 - `docs/methodology.md` — Core Principles (§2.1, §3.2, §5.5)

--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -59,6 +59,14 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 1.47 | `triage-security` output goes to Jira only, with one exception: it may write to local `security-matrix.md` files in the project working directory for supportability matrix population. | `triage-security/SKILL.md` — Guardrails, Step 2.1 |
 | 1.48 | `triage-security` MUST read ecosystems, lock file paths, and check commands from security-matrix.md Ecosystem Mappings — MUST NOT hardcode language-specific logic. | `triage-security/SKILL.md` — Step 1 (Ecosystem detection), Step 2.3 |
 | 1.49 | `triage-security` MUST read the Component label pattern from Security Configuration — MUST NOT hardcode label prefixes. | `triage-security/SKILL.md` — Step 0, Step 1 (Data Extraction) |
+| 1.50 | `report-bug` MUST NOT modify, create, or delete any files in any repository. Only Jira MCP tools are permitted for output. | `report-bug/SKILL.md` — Guardrails |
+| 1.51 | `report-bug` MUST NOT fabricate content. All Bug description content must come from user input or structured input from calling skills. | `report-bug/SKILL.md` — Guardrails |
+| 1.52 | `report-bug` MUST NOT create a Jira issue without showing a full preview and receiving explicit user approval. | `report-bug/SKILL.md` — Step 6 (Preview and Approval) |
+| 1.53 | `triage-bug` MUST NOT modify, create, or delete any source code files in any repository. Only read-only tools (Read, Glob, Grep, Serena search) are permitted for codebase investigation. | `triage-bug/SKILL.md` — Guardrails |
+| 1.54 | `triage-bug` output goes to Jira (tasks, comments, links) — never to the filesystem. | `triage-bug/SKILL.md` — Guardrails |
+| 1.55 | `triage-bug` MUST front-load the reproducer test as the first acceptance criterion and first test requirement in generated Tasks. | `triage-bug/SKILL.md` — Step 5 (Front-load the reproducer test) |
+| 1.56 | `triage-bug` MUST post a root cause analysis comment on the Bug issue before creating the fix Task. | `triage-bug/SKILL.md` — Step 4 (Post root cause comment) |
+| 1.57 | `triage-bug` MUST flag multi-root-cause bugs for decomposition rather than silently creating a single Task that bundles unrelated fixes. | `triage-bug/SKILL.md` — Step 6 (Decomposition Guard) |
 
 ### Prior Art — Cross-phase integrity (§1.33–1.35)
 
@@ -150,5 +158,7 @@ Each constraint above references its source. The full source files are:
 - `plugins/sdlc-workflow/skills/verify-pr/correctness.md` — Constraints (§1.11, §1.22, §1.23), Output Format (§1.24)
 - `plugins/sdlc-workflow/skills/verify-pr/style-conventions.md` — Check 1 Convention applicability (§1.36), Check 2 (§1.16), Check 3 (§1.17), Check 4 (§1.18, §1.19, §1.20, §1.21), Check 5 (§1.30), Constraints (§1.11, §1.22, §1.23), Output Format (§1.24)
 - `plugins/sdlc-workflow/skills/define-feature/SKILL.md` — Guardrails (§1.7–1.8), Important Rules (§1.9)
+- `plugins/sdlc-workflow/skills/report-bug/SKILL.md` — Guardrails (§1.50–1.51), Step 6 Preview and Approval (§1.52)
+- `plugins/sdlc-workflow/skills/triage-bug/SKILL.md` — Guardrails (§1.53–1.54), Step 5 Front-load reproducer test (§1.55), Step 4 Post root cause comment (§1.56), Step 6 Decomposition Guard (§1.57)
 - `plugins/sdlc-workflow/skills/triage-security/SKILL.md` — Guardrails (§1.37, §1.38, §1.47), Step 0 (§1.49), Step 1 Ecosystem detection (§1.48), Step 1 Data Extraction (§1.49), Step 2.1 (§1.47), Step 2.2 (§1.42), Step 2.3 (§1.48), Step 2.4 (§1.44), Step 7 (§1.43), Important Rules (§1.38–§1.43, §1.45, §1.46), Remediation Task Creation (§1.46)
 - `docs/methodology.md` — Core Principles (§2.1, §3.2, §5.5)

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -101,6 +101,35 @@ decline in the `review-feedback` metric over time = system improving.
 
 ---
 
+## SDLC Pipelines
+
+The workflow supports two parallel pipelines that share downstream execution phases:
+
+```
+Feature:  define-feature → plan-feature  → implement-task → verify-pr
+Bug:      report-bug     → triage-bug    → implement-task → verify-pr
+```
+
+### Feature Pipeline
+
+The feature pipeline starts with an interactive Feature definition (`define-feature`),
+followed by automated planning that decomposes the Feature into implementation Tasks
+(`plan-feature`). Each Task is then implemented (`implement-task`) and verified
+(`verify-pr`).
+
+### Bug Pipeline
+
+The bug pipeline starts with a structured Bug report (`report-bug`), followed by
+automated triage that investigates the root cause and produces a single fix Task
+(`triage-bug`). The generated Task front-loads a reproducer test as its first
+acceptance criterion, ensuring the bug is verified fixed before the PR merges.
+
+The bug pipeline reuses downstream skills unchanged — the key difference is the
+entry point (Bug issue type vs Feature issue type) and the intermediate phase
+(triage with codebase investigation vs planning with task decomposition).
+
+---
+
 ## SDLC Workflow Phases
 
 The platform evolves incrementally. The AI assistant should always

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -4,6 +4,8 @@ This document describes the execution workflow for the sdlc-workflow plugin skil
 
 ## Workflow Overview
 
+### Feature Lifecycle Overview
+
 ```mermaid
 flowchart TD
     subgraph Prerequisites

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -284,6 +284,119 @@ Triages a Jira Vulnerability issue (CVE-based, auto-created by PSIRT) with full 
 
 ---
 
+### Bug Lifecycle
+
+The bug lifecycle uses two entry-point skills (`report-bug` and `triage-bug`) that
+feed into the existing `implement-task` and `verify-pr` phases.
+
+```mermaid
+flowchart TD
+    subgraph Report Phase
+        report["/report-bug"]
+    end
+
+    subgraph Triage Phase
+        triage["/triage-bug PROJ-456"]
+    end
+
+    subgraph Implement Phase
+        implement_fix["/implement-task PROJ-457"]
+    end
+
+    subgraph Verify Phase
+        verify_fix["/verify-pr PROJ-457"]
+        merge_decision{"Human decides\nto merge"}
+    end
+
+    report -->|"Bug created in Jira"| triage
+    triage -->|"Fix Task created in Jira\n(linked to Bug)"| implement_fix
+    implement_fix -->|"Branch + PR created\n(status: In Review)"| verify_fix
+    verify_fix --> merge_decision
+    merge_decision -->|Merged| done["Done"]
+
+    classDef skill fill:#4a90d9,stroke:#2c5f8a,color:#fff
+    classDef human fill:#f5a623,stroke:#c47d10,color:#fff
+    classDef state fill:#7ed321,stroke:#5a9e18,color:#fff
+
+    class report,triage,implement_fix,verify_fix skill
+    class merge_decision human
+    class done state
+```
+
+**Jira state transitions:** New → In Progress (implement-task) → In Review (implement-task) → Done (human merge)
+
+#### Report Phase
+
+**Skill:** `/sdlc-workflow:report-bug`
+
+Interactively walks the user through the project's bug description template sections
+and creates a fully-described Bug issue in Jira. Also accepts structured input
+programmatically from other skills.
+
+**Invocation:**
+
+```
+/sdlc-workflow:report-bug
+/sdlc-workflow:report-bug My Bug Summary
+/sdlc-workflow:report-bug <structured-input>
+```
+
+**Workflow:**
+1. Validate Project Configuration and Bug Configuration in CLAUDE.md
+2. Load the bug description template
+3. Walk through required sections interactively (or accept structured input)
+4. Walk through optional sections
+5. Offer self-assignment
+6. Preview the full description and collect approval
+7. Create the Bug issue in Jira (labeled `ai-generated-jira`)
+8. Post a summary comment and suggest `/triage-bug` as the next step
+
+**Output:**
+- Bug issue created in Jira with a structured description
+- Summary comment on the created issue
+
+**Guardrails:**
+- Jira-only — no filesystem modifications permitted
+- All description content must come from user input — no fabrication
+- Issue is never created without user preview and approval
+
+#### Triage Phase (Bug)
+
+**Skill:** `/sdlc-workflow:triage-bug`
+
+Investigates a Jira Bug issue's root cause through codebase analysis and produces
+a single linked Task that `/implement-task` can consume. The generated Task
+front-loads a reproducer test as the first acceptance criterion.
+
+**Invocation:**
+
+```
+/sdlc-workflow:triage-bug PROJ-456
+```
+
+**Workflow:**
+1. Validate Project Configuration and Bug Configuration in CLAUDE.md
+2. Fetch and parse the Bug issue description
+3. Reproduce or trace the bug behavior
+4. Investigate the codebase using Serena or fallback tools
+5. Post root cause analysis comment on the Bug issue
+6. Generate a fix Task with reproducer test front-loaded
+7. Link Task to Bug (Task blocks Bug)
+8. Flag multi-root-cause bugs for decomposition
+
+**Output:**
+- Root cause analysis comment on the Bug issue
+- Fix Task created in Jira (labeled `ai-generated-jira`, linked to Bug)
+- Description digest comment on the created Task
+
+**Guardrails:**
+- Read-only + Jira — no source code modifications permitted
+- Only read-only tools for codebase investigation
+- All output goes to Jira, never to the filesystem
+- Multi-root-cause bugs flagged for decomposition rather than silently bundled
+
+---
+
 ## Feature Branch Workflow Variant
 
 When `plan-feature` selects **feature-branch mode**, the workflow wraps the normal implementation tasks with two bookend tasks that manage the feature branch lifecycle:

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -55,6 +55,47 @@ flowchart TD
 
 **Jira state transitions:** New → In Progress (implement-task) → In Review (implement-task) → Done (human merge)
 
+### Bug Lifecycle Overview
+
+The bug lifecycle uses two entry-point skills (`report-bug` and `triage-bug`) that
+feed into the existing `implement-task` and `verify-pr` phases.
+
+```mermaid
+flowchart TD
+    subgraph Report Phase
+        report["/report-bug"]
+    end
+
+    subgraph Triage Phase
+        triage["/triage-bug PROJ-456"]
+    end
+
+    subgraph Implement Phase
+        implement_fix["/implement-task PROJ-457"]
+    end
+
+    subgraph Verify Phase
+        verify_fix["/verify-pr PROJ-457"]
+        merge_decision{"Human decides\nto merge"}
+    end
+
+    report -->|"Bug created in Jira"| triage
+    triage -->|"Fix Task created in Jira\n(linked to Bug)"| implement_fix
+    implement_fix -->|"Branch + PR created\n(status: In Review)"| verify_fix
+    verify_fix --> merge_decision
+    merge_decision -->|Merged| done["Done"]
+
+    classDef skill fill:#4a90d9,stroke:#2c5f8a,color:#fff
+    classDef human fill:#f5a623,stroke:#c47d10,color:#fff
+    classDef state fill:#7ed321,stroke:#5a9e18,color:#fff
+
+    class report,triage,implement_fix,verify_fix skill
+    class merge_decision human
+    class done state
+```
+
+**Jira state transitions:** New → In Progress (implement-task) → In Review (implement-task) → Done (human merge)
+
 ---
 
 ## Prerequisite: Setup
@@ -284,48 +325,7 @@ Triages a Jira Vulnerability issue (CVE-based, auto-created by PSIRT) with full 
 
 ---
 
-### Bug Lifecycle
-
-The bug lifecycle uses two entry-point skills (`report-bug` and `triage-bug`) that
-feed into the existing `implement-task` and `verify-pr` phases.
-
-```mermaid
-flowchart TD
-    subgraph Report Phase
-        report["/report-bug"]
-    end
-
-    subgraph Triage Phase
-        triage["/triage-bug PROJ-456"]
-    end
-
-    subgraph Implement Phase
-        implement_fix["/implement-task PROJ-457"]
-    end
-
-    subgraph Verify Phase
-        verify_fix["/verify-pr PROJ-457"]
-        merge_decision{"Human decides\nto merge"}
-    end
-
-    report -->|"Bug created in Jira"| triage
-    triage -->|"Fix Task created in Jira\n(linked to Bug)"| implement_fix
-    implement_fix -->|"Branch + PR created\n(status: In Review)"| verify_fix
-    verify_fix --> merge_decision
-    merge_decision -->|Merged| done["Done"]
-
-    classDef skill fill:#4a90d9,stroke:#2c5f8a,color:#fff
-    classDef human fill:#f5a623,stroke:#c47d10,color:#fff
-    classDef state fill:#7ed321,stroke:#5a9e18,color:#fff
-
-    class report,triage,implement_fix,verify_fix skill
-    class merge_decision human
-    class done state
-```
-
-**Jira state transitions:** New → In Progress (implement-task) → In Review (implement-task) → Done (human merge)
-
-#### Report Phase
+### Report Phase
 
 **Skill:** `/sdlc-workflow:report-bug`
 
@@ -360,7 +360,7 @@ programmatically from other skills.
 - All description content must come from user input — no fabrication
 - Issue is never created without user preview and approval
 
-#### Triage Phase (Bug)
+### Triage Phase (Bug)
 
 **Skill:** `/sdlc-workflow:triage-bug`
 


### PR DESCRIPTION
## Summary

- Add report-bug and triage-bug skills to project documentation across four files
- Document the dual-pipeline architecture (Feature pipeline and Bug pipeline) in methodology.md
- Add bug lifecycle workflow phases with mermaid diagram, invocation patterns, and guardrails in workflow.md
- Add skill catalog entries and eval directory links in README.md
- Add constraint rules 1.50–1.57 for both new skills in constraints.md

Implements [TC-4805](https://redhat.atlassian.net/browse/TC-4805)

## Test plan

- [x] Verify all Markdown files render correctly
- [x] Verify constraint rule numbering is sequential (1.50–1.57) with no gaps or conflicts
- [x] Verify README skill catalog entries match actual skill names and directories
- [x] Verify documentation references are consistent with actual skill implementations
- [x] CI plugin validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Document the new bug-focused SDLC pipeline and integrate the report-bug and triage-bug skills into the workflow and constraints docs.

Enhancements:
- Define SDLC pipeline architecture with explicit Feature and Bug pipelines that share implementation and verification phases.
- Add formal constraint rules 1.50–1.57 for report-bug and triage-bug, including non-fabrication, Jira-only IO, reproducer-first tasks, root cause comments, and multi-root-cause decomposition safeguards.

Documentation:
- Add a Bug Lifecycle workflow section detailing report-bug and triage-bug phases, outputs, guardrails, and their relationship to implement-task and verify-pr.
- Describe parallel Feature and Bug pipelines in the methodology, highlighting shared downstream phases and differences in entry points and intermediate steps.
- Extend the README skill catalog and evals list with entries and links for the report-bug and triage-bug skills.