### PR TITLE
feat(triage-security): add cross-CVE overlap detection via Upstream Affected Component

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -68,6 +68,7 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 1.56 | `triage-bug` MUST post a root cause analysis comment on the Bug issue before creating the fix Task. | `triage-bug/SKILL.md` — Step 4 (Post root cause comment) |
 | 1.57 | `triage-bug` MUST flag multi-root-cause bugs for decomposition rather than silently creating a single Task that bundles unrelated fixes. | `triage-bug/SKILL.md` — Step 6 (Decomposition Guard) |
 | 1.58 | `triage-security` MUST check existing issuelinks before creating sibling "Related" links — MUST NOT create a link if one already exists between the two issues. | `triage-security/jira-triage-operations.md` — Step 4.2 |
+| 1.59 | `triage-security` MUST search for related CVE Jiras by Upstream Affected Component (`customfield_10632`) in Step 4.3 and check existing remediation tasks before creating new ones. | `triage-security/jira-triage-operations.md` — Step 4.3 |
 
 ### Prior Art — Cross-phase integrity (§1.33–1.35)
 
@@ -162,5 +163,5 @@ Each constraint above references its source. The full source files are:
 - `plugins/sdlc-workflow/skills/report-bug/SKILL.md` — Guardrails (§1.50–1.51), Step 4 Preview and Confirm (§1.52)
 - `plugins/sdlc-workflow/skills/triage-bug/SKILL.md` — Guardrails (§1.53–1.54), Step 5 Front-load reproducer test (§1.55), Step 4 Post root cause comment (§1.56), Step 6 Decomposition Guard (§1.57)
 - `plugins/sdlc-workflow/skills/triage-security/SKILL.md` — Guardrails (§1.37, §1.38, §1.47), Step 0 (§1.49), Step 1 Ecosystem detection (§1.48), Step 1 Data Extraction (§1.49), Step 2.1 (§1.47), Step 2.2 (§1.42), Step 2.3 (§1.48), Step 2.4 (§1.44), Step 7 (§1.43), Important Rules (§1.38–§1.43, §1.45, §1.46), Remediation Task Creation (§1.46)
-- `plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md` — Step 4.2 Idempotent sibling linking (§1.58)
+- `plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md` — Step 4.2 Idempotent sibling linking (§1.58), Step 4.3 Cross-CVE overlap detection (§1.59)
 - `docs/methodology.md` — Core Principles (§2.1, §3.2, §5.5)

--- a/evals/triage-security/evals.json
+++ b/evals/triage-security/evals.json
@@ -91,10 +91,36 @@
       "files": ["files/vuln-issue-sibling-prelinked.md", "files/security-matrix-mock.md", "files/claude-md-security-config.md"],
       "assertions": [
         "Sibling check correctly classifies TC-8001 as a different-stream companion (stream [rhtpa-2.2] vs current issue's [rhtpa-2.1]), not a same-stream duplicate (Step 4)",
-        "Step 4.2 checks the current issue's existing issuelinks before attempting to create a 'Related' link to TC-8001 (§1.50)",
-        "Step 4.2 detects the pre-existing 'Related' link to TC-8001 and skips link creation — does NOT call jira.create_link (§1.50)",
+        "Step 4.2 checks the current issue's existing issuelinks before attempting to create a 'Related' link to TC-8001 (§1.58)",
+        "Step 4.2 detects the pre-existing 'Related' link to TC-8001 and skips link creation — does NOT call jira.create_link (§1.58)",
         "The output includes a log message indicating the link was skipped because it already exists (e.g., 'Related link to TC-8001 already exists — skipping')",
         "The sibling landscape table is still presented to the engineer despite the link already existing — the idempotent check only affects link creation, not the sibling summary"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "Triage Vulnerability issue TC-8010. The issue details are in vuln-issue-overlap-covered.md, the security matrix is in security-matrix-mock.md, and the project CLAUDE.md is in claude-md-security-config.md. The issue has stream suffix [rhtpa-2.2] and customfield_10632 (Upstream Affected Component) set to 'axios'. A JQL search for related CVE Jiras with cf[10632] ~ 'axios' returns TC-8008 (CVE-2026-42035), which has a linked remediation task TC-8009 that bumps axios to 1.9.0. The current CVE's fix threshold is 1.8.2. Do NOT actually call Jira MCP, git show, or any external tools. Instead, write your triage analysis to the workspace outputs/ directory: write outputs/data-extraction.md with the parsed CVE data, write outputs/overlap-check.md with the Step 4.3 cross-CVE overlap analysis, and write outputs/triage-outcome.md explaining the triage decision.",
+      "expected_output": "A triage analysis where Step 4.3 detects that the related CVE TC-8008 has a remediation task TC-8009 that bumps axios to 1.9.0, which exceeds the current CVE's fix threshold of 1.8.2. The triage outcome recommends closing the issue because the existing remediation already covers this CVE.",
+      "files": ["files/vuln-issue-overlap-covered.md", "files/security-matrix-mock.md", "files/claude-md-security-config.md"],
+      "assertions": [
+        "Step 4.3 extracts the Upstream Affected Component (axios) from customfield_10632 and uses it to search for related CVE Jiras (§1.59)",
+        "Step 4.3 filters search results by matching PS Component (customfield_10669 = pscomponent:org/rhtpa-ui) and Stream (customfield_10832 = rhtpa-2.2)",
+        "Step 4.3 traverses issuelinks on TC-8008 to find remediation task TC-8009 via the 'Depend' link type",
+        "Step 4.3 compares the remediation task's bump version (1.9.0) against the current CVE's fix threshold (1.8.2) and determines the fix is already covered",
+        "Triage outcome recommends closing the issue because existing remediation task TC-8009 already bumps axios past the fix threshold — no new remediation task is created"
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "Triage Vulnerability issue TC-8011. The issue details are in vuln-issue-overlap-not-covered.md, the security matrix is in security-matrix-mock.md, and the project CLAUDE.md is in claude-md-security-config.md. The issue has stream suffix [rhtpa-2.2] and customfield_10632 (Upstream Affected Component) set to 'webpack'. A JQL search for related CVE Jiras with cf[10632] ~ 'webpack' returns TC-8012 (CVE-2026-43210), which has a linked remediation task TC-8013 that bumps webpack to 5.96.1. The current CVE's fix threshold is 5.98.0. Do NOT actually call Jira MCP, git show, or any external tools. Instead, write your triage analysis to the workspace outputs/ directory: write outputs/data-extraction.md with the parsed CVE data, write outputs/overlap-check.md with the Step 4.3 cross-CVE overlap analysis, and write outputs/triage-outcome.md explaining the triage decision.",
+      "expected_output": "A triage analysis where Step 4.3 detects related CVE TC-8012 with remediation task TC-8013 that bumps webpack to 5.96.1, but this does NOT meet the current CVE's fix threshold of 5.98.0. The overlap table shows the related CVE and its remediation, but the triage proceeds with new remediation task creation because the existing fix is insufficient.",
+      "files": ["files/vuln-issue-overlap-not-covered.md", "files/security-matrix-mock.md", "files/claude-md-security-config.md"],
+      "assertions": [
+        "Step 4.3 extracts the Upstream Affected Component (webpack) from customfield_10632 and uses it to search for related CVE Jiras (§1.59)",
+        "Step 4.3 filters search results by matching PS Component (customfield_10669 = pscomponent:org/rhtpa-ui) and Stream (customfield_10832 = rhtpa-2.2)",
+        "Step 4.3 traverses issuelinks on TC-8012 to find remediation task TC-8013 via the 'Depend' link type",
+        "Step 4.3 compares the remediation task's bump version (5.96.1) against the current CVE's fix threshold (5.98.0) and determines the fix does NOT cover this CVE",
+        "The overlap table is presented to the engineer showing TC-8012 and TC-8013 with 'Covers This CVE? = No' — the triage proceeds to create new remediation tasks rather than recommending closure"
       ]
     }
   ]

--- a/evals/triage-security/files/vuln-issue-overlap-covered.md
+++ b/evals/triage-security/files/vuln-issue-overlap-covered.md
@@ -1,0 +1,64 @@
+<!-- SYNTHETIC TEST DATA — cross-CVE overlap where existing remediation already covers this CVE's fix threshold -->
+
+# Mock Jira Vulnerability Issue
+
+**Key**: TC-8010
+**Summary**: CVE-2026-44492 axios - Server-Side Request Forgery via crafted URL [rhtpa-2.2]
+**Issue Type**: Vulnerability
+**Status**: New
+**Labels**: CVE-2026-44492, pscomponent:org/rhtpa-ui
+**Affects Versions**: RHTPA 2.2.0
+**Due Date**: 2026-08-01
+**Assignee**: Unassigned
+
+## Custom Fields
+
+- **customfield_10632** (Upstream Affected Component): axios
+- **customfield_10669** (PS Component): pscomponent:org/rhtpa-ui
+- **customfield_10832** (Stream): rhtpa-2.2
+
+## Issue Links
+
+_(no existing links)_
+
+## Remote Links
+
+- [GHSA-2026-ax91-r7pp](https://github.com/advisories/GHSA-2026-ax91-r7pp) — GitHub Advisory
+- [CVE-2026-44492](https://www.cve.org/CVERecord?id=CVE-2026-44492) — CVE Record
+
+## Comments
+
+_(no comments)_
+
+---
+
+## Description
+
+A vulnerability was found in axios. The axios package before version 1.8.2 is vulnerable to Server-Side Request Forgery (SSRF) via a crafted URL that bypasses hostname validation. An attacker can exploit this to make requests to internal services.
+
+**Affected package**: axios
+**Affected versions**: versions before 1.8.2
+**Fixed version**: 1.8.2
+**CVSS**: 8.1 (High)
+
+The vulnerability exists because axios does not properly validate the hostname in URLs when following redirects. An attacker can craft a URL that initially resolves to an external host but redirects to an internal service.
+
+### References
+
+- https://github.com/advisories/GHSA-2026-ax91-r7pp
+
+### Related CVE Jiras (provided by JQL search on customfield_10632 = "axios")
+
+The following related CVE Jira was found affecting the same upstream component:
+
+- **TC-8008** — CVE-2026-42035 axios - Prototype Pollution via header parsing [rhtpa-2.2]
+  - **Status**: In Progress
+  - **Labels**: CVE-2026-42035, pscomponent:org/rhtpa-ui
+  - **customfield_10632**: axios
+  - **customfield_10669**: pscomponent:org/rhtpa-ui
+  - **customfield_10832**: rhtpa-2.2
+  - **Issue Links**:
+    - **Depend**: TC-8009 (remediation Task)
+      - **Summary**: Bump axios to 1.9.0 in rhtpa-ui [rhtpa-2.2]
+      - **Status**: In Progress
+      - **Description excerpt**: "Bump axios from 1.7.4 to 1.9.0 to resolve CVE-2026-42035. The fix requires axios >= 1.8.0."

--- a/evals/triage-security/files/vuln-issue-overlap-not-covered.md
+++ b/evals/triage-security/files/vuln-issue-overlap-not-covered.md
@@ -1,0 +1,64 @@
+<!-- SYNTHETIC TEST DATA — cross-CVE overlap where existing remediation does NOT cover this CVE's fix threshold -->
+
+# Mock Jira Vulnerability Issue
+
+**Key**: TC-8011
+**Summary**: CVE-2026-45678 webpack - Arbitrary Code Execution via loader chain [rhtpa-2.2]
+**Issue Type**: Vulnerability
+**Status**: New
+**Labels**: CVE-2026-45678, pscomponent:org/rhtpa-ui
+**Affects Versions**: RHTPA 2.2.0
+**Due Date**: 2026-08-15
+**Assignee**: Unassigned
+
+## Custom Fields
+
+- **customfield_10632** (Upstream Affected Component): webpack
+- **customfield_10669** (PS Component): pscomponent:org/rhtpa-ui
+- **customfield_10832** (Stream): rhtpa-2.2
+
+## Issue Links
+
+_(no existing links)_
+
+## Remote Links
+
+- [GHSA-2026-wk55-m3rr](https://github.com/advisories/GHSA-2026-wk55-m3rr) — GitHub Advisory
+- [CVE-2026-45678](https://www.cve.org/CVERecord?id=CVE-2026-45678) — CVE Record
+
+## Comments
+
+_(no comments)_
+
+---
+
+## Description
+
+A vulnerability was found in webpack. The webpack package before version 5.98.0 allows arbitrary code execution through a specially crafted loader chain configuration. An attacker with control over a project's webpack configuration can execute arbitrary code during the build process.
+
+**Affected package**: webpack
+**Affected versions**: versions before 5.98.0
+**Fixed version**: 5.98.0
+**CVSS**: 7.8 (High)
+
+The vulnerability exists because webpack does not properly sanitize loader paths when resolving the loader chain, allowing path traversal to execute arbitrary modules.
+
+### References
+
+- https://github.com/advisories/GHSA-2026-wk55-m3rr
+
+### Related CVE Jiras (provided by JQL search on customfield_10632 = "webpack")
+
+The following related CVE Jira was found affecting the same upstream component:
+
+- **TC-8012** — CVE-2026-43210 webpack - ReDoS in chunk name validation [rhtpa-2.2]
+  - **Status**: Closed (Done)
+  - **Labels**: CVE-2026-43210, pscomponent:org/rhtpa-ui
+  - **customfield_10632**: webpack
+  - **customfield_10669**: pscomponent:org/rhtpa-ui
+  - **customfield_10832**: rhtpa-2.2
+  - **Issue Links**:
+    - **Depend**: TC-8013 (remediation Task)
+      - **Summary**: Bump webpack to 5.96.1 in rhtpa-ui [rhtpa-2.2]
+      - **Status**: Closed (Done)
+      - **Description excerpt**: "Bump webpack from 5.95.0 to 5.96.1 to resolve CVE-2026-43210. The fix requires webpack >= 5.96.0."

--- a/plugins/sdlc-workflow/skills/setup/SKILL.md
+++ b/plugins/sdlc-workflow/skills/setup/SKILL.md
@@ -333,6 +333,39 @@ Ask the user for the following fields:
 
    If the user skips, leave the placeholder empty in the template.
 
+6. **Upstream Affected Component custom field** _(optional)_ — the custom field ID that
+   stores the upstream library name on Vulnerability issues (e.g., `customfield_10632`).
+   Used by Step 4.3 for cross-CVE overlap detection. Ask the user:
+
+   > "Do you have an Upstream Affected Component custom field on Vulnerability issues?
+   > This field stores the upstream library name (e.g., 'axios', 'webpack') and enables
+   > cross-CVE overlap detection. Provide the custom field ID, or leave blank to skip
+   > overlap detection."
+
+   If the user skips, leave the placeholder empty in the template.
+
+7. **PS Component custom field** _(optional)_ — the custom field ID that stores the
+   PS Component identifier on Vulnerability issues (e.g., `customfield_10669`).
+   Used together with the Upstream Affected Component field for cross-CVE overlap
+   filtering. Ask the user:
+
+   > "Do you have a PS Component custom field on Vulnerability issues? This field
+   > stores the product component identifier (e.g., 'pscomponent:org/image-name')
+   > and is used to filter cross-CVE overlap results. Provide the custom field ID,
+   > or leave blank."
+
+   If the user skips, leave the placeholder empty in the template.
+
+8. **Stream custom field** _(optional)_ — the custom field ID that stores the stream
+   identifier on Vulnerability issues (e.g., `customfield_10832`). Used together with
+   the Upstream Affected Component field for cross-CVE overlap filtering. Ask the user:
+
+   > "Do you have a Stream custom field on Vulnerability issues? This field stores
+   > the stream identifier (e.g., 'rhtpa-2.2') and is used to filter cross-CVE
+   > overlap results. Provide the custom field ID, or leave blank."
+
+   If the user skips, leave the placeholder empty in the template.
+
 ### Step 9.2 – Collect Version Streams
 
 Ask the user for one or more version streams. For each stream, collect:

--- a/plugins/sdlc-workflow/skills/setup/security-config.template.md
+++ b/plugins/sdlc-workflow/skills/setup/security-config.template.md
@@ -22,19 +22,35 @@
        cannot be auto-discovered via Jira metadata. To find it, inspect a closed
        Vulnerability issue that has it set and look for the custom field. Leave blank
        if your project does not use VEX Justification.
+     - Upstream Affected Component custom field: the Jira custom field ID that stores
+       the upstream library name on Vulnerability issues (e.g., "customfield_10632").
+       Used by Step 4.3 for cross-CVE overlap detection. Leave blank to skip overlap
+       detection.
+     - PS Component custom field: the Jira custom field ID that stores the PS Component
+       identifier on Vulnerability issues (e.g., "customfield_10669"). Used together
+       with the Upstream Affected Component field for cross-CVE overlap filtering.
+     - Stream custom field: the Jira custom field ID that stores the stream identifier
+       on Vulnerability issues (e.g., "customfield_10832"). Used together with the
+       Upstream Affected Component field for cross-CVE overlap filtering.
 
      Example:
        Product pages URL: https://lifecycle.example.com/products/myproduct
        Jira version prefix: MYPRODUCT
        Vulnerability issue type ID: 10001
        Component label pattern: pscomponent:
-       VEX Justification custom field: customfield_00000 -->
+       VEX Justification custom field: customfield_00000
+       Upstream Affected Component custom field: customfield_10632
+       PS Component custom field: customfield_10669
+       Stream custom field: customfield_10832 -->
 
 - Product pages URL: {{product-pages-url}}
 - Jira version prefix: {{jira-version-prefix}}
 - Vulnerability issue type ID: {{vulnerability-issue-type-id}}
 - Component label pattern: {{component-label-pattern}}
 - VEX Justification custom field: {{vex-justification-field-id}}
+- Upstream Affected Component custom field: {{upstream-affected-component-field-id}}
+- PS Component custom field: {{ps-component-field-id}}
+- Stream custom field: {{stream-field-id}}
 
 ### Version Streams
 

--- a/plugins/sdlc-workflow/skills/triage-security/SKILL.md
+++ b/plugins/sdlc-workflow/skills/triage-security/SKILL.md
@@ -117,6 +117,15 @@ Extract the following from the configuration for use in later steps:
 - **VEX Justification custom field** _(optional)_ — from Security Configuration (e.g.,
   `customfield_00000`). If configured, used in Steps 6 and 7 when closing issues as
   "Not a Bug". If not configured, close with resolution only, without the VEX field.
+- **Upstream Affected Component custom field** _(optional)_ — from Security Configuration
+  (e.g., `customfield_10632`). If configured, used in Step 4.3 for cross-CVE overlap
+  detection. If not configured, Step 4.3 is skipped entirely.
+- **PS Component custom field** _(optional)_ — from Security Configuration (e.g.,
+  `customfield_10669`). Used with the Upstream Affected Component field for cross-CVE
+  overlap filtering in Step 4.3.
+- **Stream custom field** _(optional)_ — from Security Configuration (e.g.,
+  `customfield_10832`). Used with the Upstream Affected Component field for cross-CVE
+  overlap filtering in Step 4.3.
 - **Version Streams** — Konflux release repo URLs and local paths from Security Configuration
 - **Source Repositories** — source repo names and URLs from Security Configuration
 

--- a/plugins/sdlc-workflow/skills/triage-security/SKILL.md
+++ b/plugins/sdlc-workflow/skills/triage-security/SKILL.md
@@ -39,7 +39,7 @@ Do **not** use for:
 | 1 | Data Extraction | Vulnerability issue key | CVE ID, library, affected range, remote links |
 | 2 | Version Impact Analysis | security-matrix.md, lock files | Version impact table |
 | 3 | Affects Versions Correction | Version impact table, Jira versions | Corrected Affects Versions |
-| 4 | Duplicate/Sibling Check | JQL search (sibling issues) | Duplicate detection, issue links |
+| 4 | Duplicate, Sibling, and Overlap Check | JQL search (sibling issues), component field search | Duplicate detection, issue links, cross-CVE overlap |
 | 5 | Version Lifecycle Check | Product pages URL | EOL status per version |
 | 6 | Already Fixed Check | Resolved sibling issues | Already-fixed detection |
 | 7 | Remediation | Impact analysis results | Remediation tasks or close recommendation |
@@ -327,9 +327,11 @@ Read `jira-triage-operations.md` for the detailed procedures.
 - **Step 3** – Affects Versions Correction: discover available Jira versions
   dynamically, compare against the version impact table, and correct with
   engineer confirmation
-- **Step 4** – Duplicate and Sibling Check: search for sibling Vulnerability
-  issues with the same CVE, classify as same-stream duplicates or cross-stream
-  companions, link related issues
+- **Step 4** – Duplicate, Sibling, and Overlap Check: search for sibling
+  Vulnerability issues with the same CVE, classify as same-stream duplicates
+  or cross-stream companions, link related issues, and detect cross-CVE overlap
+  where a different CVE's remediation already covers the current CVE's fix
+  threshold
 - **Step 5** – Version Lifecycle Check: verify affected versions are still
   within support lifecycle via the Product pages URL
 - **Step 6** – Already Fixed Check: cross-reference resolved sibling issues

--- a/plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md
+++ b/plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md
@@ -165,24 +165,32 @@ Search for Vulnerability issues that affect the **same upstream component** as t
 current issue, regardless of CVE ID. This detects cases where a different CVE's
 remediation already bumped the library past the current CVE's fix threshold.
 
+**Prerequisite:** This step requires the Upstream Affected Component custom field,
+PS Component custom field, and Stream custom field to be configured in Security
+Configuration (Step 0). If any of these fields are not configured, skip this step
+entirely.
+
 1. **Extract the Upstream Affected Component** from the current issue's
-   `customfield_10632` field (already fetched in Step 1 with `fields=["*all"]`).
-   If the field is empty or not present, skip this step — cross-CVE overlap
-   detection requires the component field to be populated.
+   `<upstream-affected-component-field>` (already fetched in Step 1 with
+   `fields=["*all"]`). If the field is empty or not present, skip this step —
+   cross-CVE overlap detection requires the component field to be populated.
 
 2. **Search for related CVE Jiras** with the same component value:
 
    ```
    jira.search_jql(
-     "project = <project-key> AND issuetype = <vulnerability-issue-type-id> AND cf[10632] ~ '<component-value>' AND key != <current-issue-key>",
-     fields: ["summary", "status", "labels", "issuelinks", "customfield_10632", "customfield_10669", "customfield_10832"]
+     "project = <project-key> AND issuetype = <vulnerability-issue-type-id> AND cf[<upstream-affected-component-field-number>] ~ '<component-value>' AND key != <current-issue-key>",
+     fields: ["summary", "status", "labels", "issuelinks", "<upstream-affected-component-field>", "<ps-component-field>", "<stream-field>"]
    )
    ```
 
-3. **Filter results** to matching PS Component (`customfield_10669`) and Stream
-   (`customfield_10832`) values. Only issues that share the same PS Component
-   and Stream as the current issue are relevant — different components or
-   streams are tracked separately.
+   Where `<upstream-affected-component-field-number>` is the numeric portion of the
+   configured field ID (e.g., `10632` from `customfield_10632`).
+
+3. **Filter results** to matching PS Component (`<ps-component-field>`) and Stream
+   (`<stream-field>`) values. Only issues that share the same PS Component and
+   Stream as the current issue are relevant — different components or streams are
+   tracked separately.
 
 4. **Traverse issue links** on each matching CVE Jira. For each match, inspect
    its `issuelinks` array for linked remediation Tasks (link type `"Depend"` —

--- a/plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md
+++ b/plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md
@@ -93,7 +93,7 @@ Based on lock file analysis at pinned commits from security-matrix.md.
 Scoped to stream <stream> per issue suffix.")
 ```
 
-## Step 4 – Duplicate and Sibling Check
+## Step 4 – Duplicate, Sibling, and Overlap Check
 
 Search for sibling Vulnerability issues with the same CVE label:
 
@@ -157,7 +157,70 @@ one issue per stream intentionally. For each different-stream sibling:
    | TC-5678 ← | 2.2.x  | New         | MYPRODUCT 2.2.0, MYPRODUCT 2.2.1 |
    ```
 
-**If no siblings found**, proceed to Step 5.
+**If no siblings found**, proceed to Step 4.3.
+
+### 4.3 – Cross-CVE overlap detection
+
+Search for Vulnerability issues that affect the **same upstream component** as the
+current issue, regardless of CVE ID. This detects cases where a different CVE's
+remediation already bumped the library past the current CVE's fix threshold.
+
+1. **Extract the Upstream Affected Component** from the current issue's
+   `customfield_10632` field (already fetched in Step 1 with `fields=["*all"]`).
+   If the field is empty or not present, skip this step — cross-CVE overlap
+   detection requires the component field to be populated.
+
+2. **Search for related CVE Jiras** with the same component value:
+
+   ```
+   jira.search_jql(
+     "project = <project-key> AND issuetype = <vulnerability-issue-type-id> AND cf[10632] ~ '<component-value>' AND key != <current-issue-key>",
+     fields: ["summary", "status", "labels", "issuelinks", "customfield_10632", "customfield_10669", "customfield_10832"]
+   )
+   ```
+
+3. **Filter results** to matching PS Component (`customfield_10669`) and Stream
+   (`customfield_10832`) values. Only issues that share the same PS Component
+   and Stream as the current issue are relevant — different components or
+   streams are tracked separately.
+
+4. **Traverse issue links** on each matching CVE Jira. For each match, inspect
+   its `issuelinks` array for linked remediation Tasks (link type `"Depend"` —
+   the same link type used when `triage-security` creates remediation tasks).
+   Fetch each linked remediation Task to inspect its description.
+
+5. **Compare remediation coverage.** For each remediation Task found, extract
+   the dependency version bump from its description (the target version the
+   library is bumped to). Compare this version against the current CVE's fix
+   threshold (from Step 1's Data Extraction — the "fixed version" field):
+
+   - If the remediation task's bump version **meets or exceeds** the current
+     CVE's fix threshold: the existing remediation already covers this CVE.
+   - If the bump version is **below** the fix threshold: the existing
+     remediation does not cover this CVE.
+
+6. **Present findings** to the engineer:
+
+   - **If a covering remediation exists:**
+     ```
+     Existing remediation task [task-key] (from [related-CVE-ID]) already bumps
+     [library] to [version], which meets or exceeds this CVE's fix threshold
+     ([fix-version]). No new remediation task needed.
+
+     Recommendation: Close this issue — the fix is already covered by [task-key].
+     ```
+   - **If related CVEs exist but no covering remediation:**
+     ```
+     Related CVE Jiras found for [component] in the same stream:
+
+     | Related CVE | Issue | Remediation Task | Bump Version | Covers This CVE? |
+     |-------------|-------|------------------|--------------|------------------|
+     | CVE-YYYY-XXXXX | TC-1234 | TC-1235 | 1.2.3 | No (threshold: 1.3.0) |
+
+     No existing remediation covers this CVE's fix threshold. Proceeding with
+     new remediation task creation.
+     ```
+   - **If no related CVEs found for this component:** proceed silently to Step 5.
 
 ## Step 5 – Version Lifecycle Check
 


### PR DESCRIPTION
## Summary

- Adds Step 4.3 to `triage-security` that searches for related CVE Jiras by Upstream Affected Component (`customfield_10632`), PS Component (`customfield_10669`), and Stream (`customfield_10832`), then traverses issue links to find existing remediation tasks and compares their bump versions against the current CVE's fix threshold
- Updates SKILL.md Quick Reference table and Step 4 heading from "Duplicate/Sibling Check" to "Duplicate, Sibling, and Overlap Check"
- Adds constraint §1.59 to `docs/constraints.md` with traceability index update
- Adds eval cases 8 (overlap covered — recommends closing) and 9 (overlap not covered — proceeds with remediation) with fixture files
- Fixes stale §1.50 → §1.58 reference in eval 7 assertions

Implements [TC-4850](https://redhat.atlassian.net/browse/TC-4850)

## Test plan

- [ ] Verify eval cases 1–7 continue to pass without modification
- [ ] Verify eval case 8: cross-CVE overlap where existing remediation (axios 1.9.0) exceeds fix threshold (1.8.2) — skill detects and recommends closing
- [ ] Verify eval case 9: cross-CVE overlap where existing remediation (webpack 5.96.1) does NOT meet fix threshold (5.98.0) — skill reports overlap but proceeds with new remediation
- [ ] Verify Step 4.3 gracefully skips when `customfield_10632` is empty
- [ ] Verify constraint §1.59 traceability index references Step 4.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extend triage-security’s Step 4 to detect cross-CVE overlaps based on upstream component and existing remediation tasks, and update documentation and constraints to reflect the new behavior.

New Features:
- Add Step 4.3 cross-CVE overlap detection that searches related CVE issues by upstream affected component, PS Component, and stream, and checks existing remediation tasks before creating new ones.

Enhancements:
- Update triage-security SKILL documentation to describe the expanded Step 4 Duplicate, Sibling, and Overlap Check behavior.

Documentation:
- Add constraint §1.59 documenting the new cross-CVE overlap detection requirement and reference it from the traceability index.

Tests:
- Add new triage-security eval fixtures for overlap-covered and overlap-not-covered scenarios.