### PR TITLE
fix(verify-pr): add baseline comparison gate to eval failure subtask creation

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -69,6 +69,7 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 1.57 | `triage-bug` MUST flag multi-root-cause bugs for decomposition rather than silently creating a single Task that bundles unrelated fixes. | `triage-bug/SKILL.md` — Step 6 (Decomposition Guard) |
 | 1.58 | `triage-security` MUST check existing issuelinks before creating sibling "Related" links — MUST NOT create a link if one already exists between the two issues. | `triage-security/jira-triage-operations.md` — Step 4.2 |
 | 1.59 | `triage-security` MUST search for related CVE Jiras by Upstream Affected Component (`customfield_10632`) in Step 4.3 and check existing remediation tasks before creating new ones. | `triage-security/jira-triage-operations.md` — Step 4.3 |
+| 1.60 | `verify-pr` MUST compare eval assertion failures against base branch eval baselines before creating subtasks — only regressions (assertions that pass at baseline but fail on the PR) trigger subtask creation. | `verify-pr/SKILL.md` — Step 6d (Eval failure sub-tasks), `verify-pr/style-conventions.md` — Check 5 |
 
 ### Prior Art — Cross-phase integrity (§1.33–1.35)
 
@@ -154,11 +155,11 @@ Each constraint above references its source. The full source files are:
 - `plugins/sdlc-workflow/shared/task-description-template.md` — Rules (§4.12)
 - `plugins/sdlc-workflow/shared/description-digest-protocol.md` — Digest format and verification procedure (§1.33, §1.34, §1.35)
 - `plugins/sdlc-workflow/shared/convention-applicability-rules.md` — File-type applicability matching logic (§1.36, §4.13)
-- `plugins/sdlc-workflow/skills/verify-pr/SKILL.md` — Step 4a (§1.10), Step 4a.1 (§1.28, §1.29), Step 4d (§1.12, §1.25), Important Rules (§1.11, §1.13, §1.22, §1.23, §1.25, §1.26), Step 5b (§1.14), Step 5 (§1.26), Step 6a (§1.30), Step 6d (§1.31), Step 7 (§1.32), Step 14 (§1.19)
+- `plugins/sdlc-workflow/skills/verify-pr/SKILL.md` — Step 4a (§1.10), Step 4a.1 (§1.28, §1.29), Step 4d (§1.12, §1.25), Important Rules (§1.11, §1.13, §1.22, §1.23, §1.25, §1.26), Step 5b (§1.14), Step 5 (§1.26), Step 6a (§1.30), Step 6d (§1.31, §1.60), Step 7 (§1.32), Step 14 (§1.19)
 - `plugins/sdlc-workflow/skills/verify-pr/intent-alignment.md` — Constraints (§1.11, §1.22, §1.23), Output Format (§1.24)
 - `plugins/sdlc-workflow/skills/verify-pr/security.md` — Constraints (§1.11, §1.22, §1.23), Output Format (§1.24)
 - `plugins/sdlc-workflow/skills/verify-pr/correctness.md` — Constraints (§1.11, §1.22, §1.23), Output Format (§1.24)
-- `plugins/sdlc-workflow/skills/verify-pr/style-conventions.md` — Check 1 Convention applicability (§1.36), Check 2 (§1.16), Check 3 (§1.17), Check 4 (§1.18, §1.19, §1.20, §1.21), Check 5 (§1.30), Constraints (§1.11, §1.22, §1.23), Output Format (§1.24)
+- `plugins/sdlc-workflow/skills/verify-pr/style-conventions.md` — Check 1 Convention applicability (§1.36), Check 2 (§1.16), Check 3 (§1.17), Check 4 (§1.18, §1.19, §1.20, §1.21), Check 5 (§1.30, §1.60), Constraints (§1.11, §1.22, §1.23), Output Format (§1.24)
 - `plugins/sdlc-workflow/skills/define-feature/SKILL.md` — Guardrails (§1.7–1.8), Important Rules (§1.9)
 - `plugins/sdlc-workflow/skills/report-bug/SKILL.md` — Guardrails (§1.50–1.51), Step 4 Preview and Confirm (§1.52)
 - `plugins/sdlc-workflow/skills/triage-bug/SKILL.md` — Guardrails (§1.53–1.54), Step 5 Front-load reproducer test (§1.55), Step 4 Post root cause comment (§1.56), Step 6 Decomposition Guard (§1.57)

--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -534,9 +534,17 @@ Process eval assertion failures from the Style/Conventions sub-agent's Check 5
 proceed if Eval Quality is WARN (i.e., at least one assertion failed). If Eval
 Quality is PASS or N/A, skip this section entirely.
 
-1. **Group by eval ID:** Group failing assertions by eval ID (e.g., all failures
-   from eval-3 become one sub-task). Each eval with at least one failing assertion
-   gets one sub-task. The sub-task summary should include the eval ID and a brief
+Additionally, only create sub-tasks for assertions classified as **regression** by
+the Style/Conventions sub-agent's Check 5 baseline comparison (step 5c.1). If all
+failing assertions are classified as **pre-existing**, skip sub-task creation
+entirely and note the pre-existing failures in the verification report summary as
+informational (e.g., "WARN (N pre-existing, no regressions)" in the Test Quality
+details column). Only assertions classified as **regression** proceed to grouping
+and sub-task creation below.
+
+1. **Group by eval ID:** Group regression-classified failing assertions by eval ID
+   (e.g., all regression failures from eval-3 become one sub-task). Each eval with
+   at least one regression failure gets one sub-task. The sub-task summary should include the eval ID and a brief
    description of the failure category, e.g., "Fix eval-3 assertion failures:
    convention upgrade eligibility, sub-task creation".
 

--- a/plugins/sdlc-workflow/skills/verify-pr/style-conventions.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/style-conventions.md
@@ -346,6 +346,34 @@ run-evals skill's summary script and follows this format:
 If no "Failed Assertions" section exists (pre-enhancement format or all
 assertions pass), extract only the pass/fail counts from the summary table.
 
+#### 5c.1 — Baseline Comparison
+
+For each skill with eval results, compare the PR's failing assertions against the
+base branch eval baselines to classify each failure as a regression or pre-existing.
+
+1. **Discover baselines**: check if a baseline exists at
+   `evals/<skill>/baselines/latest/`. Follow the same glob pattern used by the
+   correctness sub-agent (Check 3b) for baseline discovery.
+
+2. **Read baseline per-eval results**: if the `baselines/latest/` directory exists,
+   read the per-eval summary table from `baselines/latest/summary.md` to get
+   per-eval pass/fail counts at baseline. Alternatively, read
+   `baselines/latest/<eval-id>/grading.json` for each eval with failures to check
+   whether specific assertions also failed at baseline.
+
+3. **Classify each failing assertion**:
+   - **regression** — the assertion passes at baseline but fails on the PR branch,
+     or no baseline exists for the skill (conservative default — treat unknown as new)
+   - **pre-existing** — the assertion also fails at baseline
+
+4. **Include classification in evidence**: alongside each failing assertion detail
+   (assertion text and evidence), add a `classification` field with the value
+   `regression` or `pre-existing`. This classification is consumed by the
+   orchestrator's Step 6d to gate subtask creation.
+
+The verdict logic in 5d is unchanged — PASS/WARN/N/A semantics are not affected.
+The classification enriches the evidence without changing the verdict.
+
 #### 5d — Produce Verdict
 
 - **PASS** — eval results exist and all assertions pass (0 failures across all evals)
@@ -353,7 +381,7 @@ assertions pass), extract only the pass/fail counts from the summary table.
 - **N/A** — no eval result reviews found in the PR
 
 Evidence: per-eval pass rates, overall pass rate, and any failing assertion
-details (assertion text and evidence for each failure).
+details (assertion text, evidence, and baseline classification for each failure).
 
 ## Output Format
 


### PR DESCRIPTION
## Summary

- Add baseline comparison step (5c.1) to style-conventions Check 5 that classifies each failing eval assertion as "regression" or "pre-existing"
- Gate Step 6d subtask creation on regression classification — pre-existing failures noted as informational only
- Add constraint 1.60 requiring baseline comparison before eval subtask creation

Implements [TC-4892](https://redhat.atlassian.net/browse/TC-4892)

## Test plan

- [ ] Verify style-conventions.md Check 5 includes sub-step 5c.1 with baseline comparison logic
- [ ] Verify SKILL.md Step 6d includes the regression-only gate before subtask creation
- [ ] Verify constraint 1.60 follows existing table format in docs/constraints.md
- [ ] Verify source index references §1.60 for both SKILL.md Step 6d and style-conventions.md Check 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add baseline comparison of eval assertion failures against base branch baselines and gate eval failure subtask creation on regression-only failures in verify-pr.

Enhancements:
- Classify style-conventions eval assertion failures as regressions or pre-existing and include this classification in verification evidence.
- Restrict verify-pr eval failure subtasks to regression-classified failures and treat pre-existing failures as informational.
- Document new baseline comparison constraint 1.60 and link it to the relevant verify-pr steps in the constraints index.