### PR TITLE
feat(triage-security): add proactive cross-stream remediation with security-preemptive label

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -70,6 +70,7 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 1.58 | `triage-security` MUST check existing issuelinks before creating sibling "Related" links — MUST NOT create a link if one already exists between the two issues. | `triage-security/jira-triage-operations.md` — Step 4.2 |
 | 1.59 | `triage-security` MUST search for related CVE Jiras by Upstream Affected Component (`customfield_10632`) in Step 4.3 and check existing remediation tasks before creating new ones. | `triage-security/jira-triage-operations.md` — Step 4.3 |
 | 1.60 | `verify-pr` MUST compare eval assertion failures against base branch eval baselines before creating subtasks — only regressions (assertions that pass at baseline but fail on the PR) trigger subtask creation. | `verify-pr/SKILL.md` — Step 6d (Eval failure sub-tasks), `verify-pr/style-conventions.md` — Check 5 |
+| 1.61 | `triage-security` MUST create proactive remediation tasks with `security-preemptive` label for affected streams without CVE Jiras (Step 7 Case B) and MUST reconcile when stream-specific CVE Jiras arrive by linking the CVE and removing the label (Step 4.4). | `triage-security/SKILL.md` — Step 7 Case B, `triage-security/jira-triage-operations.md` — Step 4.4 |
 
 ### Prior Art — Cross-phase integrity (§1.33–1.35)
 
@@ -163,6 +164,6 @@ Each constraint above references its source. The full source files are:
 - `plugins/sdlc-workflow/skills/define-feature/SKILL.md` — Guardrails (§1.7–1.8), Important Rules (§1.9)
 - `plugins/sdlc-workflow/skills/report-bug/SKILL.md` — Guardrails (§1.50–1.51), Step 4 Preview and Confirm (§1.52)
 - `plugins/sdlc-workflow/skills/triage-bug/SKILL.md` — Guardrails (§1.53–1.54), Step 5 Front-load reproducer test (§1.55), Step 4 Post root cause comment (§1.56), Step 6 Decomposition Guard (§1.57)
-- `plugins/sdlc-workflow/skills/triage-security/SKILL.md` — Guardrails (§1.37, §1.38, §1.47), Step 0 (§1.49), Step 1 Ecosystem detection (§1.48), Step 1 Data Extraction (§1.49), Step 2.1 (§1.47), Step 2.2 (§1.42), Step 2.3 (§1.48), Step 2.4 (§1.44), Step 7 (§1.43), Important Rules (§1.38–§1.43, §1.45, §1.46), Remediation Task Creation (§1.46)
-- `plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md` — Step 4.2 Idempotent sibling linking (§1.58), Step 4.3 Cross-CVE overlap detection (§1.59)
+- `plugins/sdlc-workflow/skills/triage-security/SKILL.md` — Guardrails (§1.37, §1.38, §1.47), Step 0 (§1.49), Step 1 Ecosystem detection (§1.48), Step 1 Data Extraction (§1.49), Step 2.1 (§1.47), Step 2.2 (§1.42), Step 2.3 (§1.48), Step 2.4 (§1.44), Step 7 (§1.43), Step 7 Case B (§1.61), Important Rules (§1.38–§1.43, §1.45, §1.46), Remediation Task Creation (§1.46)
+- `plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md` — Step 4.2 Idempotent sibling linking (§1.58), Step 4.3 Cross-CVE overlap detection (§1.59), Step 4.4 Proactive reconciliation (§1.61)
 - `docs/methodology.md` — Core Principles (§2.1, §3.2, §5.5)

--- a/evals/triage-security/evals.json
+++ b/evals/triage-security/evals.json
@@ -122,6 +122,32 @@
         "Step 4.3 compares the remediation task's bump version (5.96.1) against the current CVE's fix threshold (5.98.0) and determines the fix does NOT cover this CVE",
         "The overlap table is presented to the engineer showing TC-8012 and TC-8013 with 'Covers This CVE? = No' — the triage proceeds to create new remediation tasks rather than recommending closure"
       ]
+    },
+    {
+      "id": 10,
+      "prompt": "Triage Vulnerability issue TC-8020. The issue details are in vuln-issue-cross-stream-preemptive.md, the security matrix is in security-matrix-mock.md, and the project CLAUDE.md is in claude-md-security-config.md. The issue has stream suffix [rhtpa-2.2] and the cross-stream version impact analysis shows stream rhtpa-2.1 is also affected (tokio 1.40.0, threshold 1.42.0). A JQL search for sibling CVE Jiras with label CVE-2026-55123 returns no results for stream rhtpa-2.1 — no CVE Jira exists for that stream. Do NOT actually call Jira MCP, git show, or any external tools. Instead, write your triage analysis to the workspace outputs/ directory: write outputs/data-extraction.md with the parsed CVE data, write outputs/version-impact.md with the version impact table showing cross-stream impact, write outputs/remediation.md with the remediation tasks for the current stream (Case A) and the preemptive tasks for the other stream (Case B), and write outputs/cross-stream.md with the cross-stream impact comment and preemptive task details.",
+      "expected_output": "A triage analysis where Step 7 Case A creates standard remediation tasks for the current stream (rhtpa-2.2), and Step 7 Case B creates proactive preemptive remediation tasks for stream rhtpa-2.1 (which has no CVE Jira). The preemptive tasks include the security-preemptive label and use a 'Related' link to the originating CVE Jira TC-8020.",
+      "files": ["files/vuln-issue-cross-stream-preemptive.md", "files/security-matrix-mock.md", "files/claude-md-security-config.md"],
+      "assertions": [
+        "Step 7 Case A creates standard remediation tasks for the current stream (rhtpa-2.2) with standard labels ['ai-generated-jira', 'Security', 'CVE-2026-55123'] and 'Depend' link to TC-8020",
+        "Step 7 Case B detects that stream rhtpa-2.1 is also affected but has no CVE Jira — creates proactive preemptive remediation tasks (§1.60)",
+        "Preemptive tasks for stream rhtpa-2.1 include the 'security-preemptive' label alongside standard labels: ['ai-generated-jira', 'Security', 'CVE-2026-55123', 'security-preemptive']",
+        "Preemptive tasks are linked to the originating CVE Jira TC-8020 with 'Related' link type (not 'Depend') because the originating CVE belongs to a different stream",
+        "Preemptive task descriptions include a preemptive remediation prefix noting TC-8020 (stream rhtpa-2.2) as the originating CVE"
+      ]
+    },
+    {
+      "id": 11,
+      "prompt": "Triage Vulnerability issue TC-8021. The issue details are in vuln-issue-preemptive-reconciliation.md, the security matrix is in security-matrix-mock.md, and the project CLAUDE.md is in claude-md-security-config.md. The issue has stream suffix [rhtpa-2.1]. A JQL search for tasks with labels 'security-preemptive' and 'CVE-2026-55123' returns TC-8022 (a preemptive remediation task for rhtpa-2.1 created from prior triage of TC-8020). Do NOT actually call Jira MCP, git show, or any external tools. Instead, write your triage analysis to the workspace outputs/ directory: write outputs/data-extraction.md with the parsed CVE data, write outputs/reconciliation.md with the Step 4.4 preemptive task reconciliation analysis, and write outputs/triage-outcome.md explaining how the existing preemptive task was reconciled.",
+      "expected_output": "A triage analysis where Step 4.4 detects existing preemptive task TC-8022 for CVE-2026-55123 in stream rhtpa-2.1. The reconciliation links the new CVE Jira TC-8021 to TC-8022 with 'Depend', removes the 'security-preemptive' label from TC-8022, and skips new remediation task creation in Step 7.",
+      "files": ["files/vuln-issue-preemptive-reconciliation.md", "files/security-matrix-mock.md", "files/claude-md-security-config.md"],
+      "assertions": [
+        "Step 4.4 searches for preemptive tasks using JQL with labels 'security-preemptive' and 'CVE-2026-55123' (§1.60)",
+        "Step 4.4 filters results to match the current stream (rhtpa-2.1) by checking the task summary for the stream name",
+        "Step 4.4 links the new CVE Jira TC-8021 to the preemptive task TC-8022 with 'Depend' link type (standard remediation linkage)",
+        "Step 4.4 removes the 'security-preemptive' label from TC-8022 — the task is now a standard remediation task linked to a proper CVE Jira",
+        "Step 7 skips remediation task creation for this stream because Step 4.4 reconciliation already linked an existing task"
+      ]
     }
   ]
 }

--- a/evals/triage-security/files/vuln-issue-cross-stream-preemptive.md
+++ b/evals/triage-security/files/vuln-issue-cross-stream-preemptive.md
@@ -1,0 +1,63 @@
+<!-- SYNTHETIC TEST DATA — scoped Vulnerability issue where cross-stream analysis reveals another stream is affected but has no CVE Jira -->
+
+# Mock Jira Vulnerability Issue
+
+**Key**: TC-8020
+**Summary**: CVE-2026-55123 tokio - Use-after-free in task abort [rhtpa-2.2]
+**Issue Type**: Vulnerability
+**Status**: New
+**Labels**: CVE-2026-55123, pscomponent:org/rhtpa-server
+**Affects Versions**: RHTPA 2.2.0, RHTPA 2.2.1
+**Due Date**: 2026-08-15
+**Assignee**: Unassigned
+
+## Custom Fields
+
+- **customfield_10632** (Upstream Affected Component): tokio
+- **customfield_10669** (PS Component): pscomponent:org/rhtpa-server
+- **customfield_10832** (Stream): rhtpa-2.2
+
+## Issue Links
+
+_(no existing links)_
+
+## Remote Links
+
+- [GHSA-2026-tk91-v5pp](https://github.com/advisories/GHSA-2026-tk91-v5pp) — GitHub Advisory
+- [CVE-2026-55123](https://www.cve.org/CVERecord?id=CVE-2026-55123) — CVE Record
+- [tokio-rs/tokio#7001](https://github.com/tokio-rs/tokio/pull/7001) — Upstream fix PR
+
+## Comments
+
+_(no comments)_
+
+---
+
+## Description
+
+A vulnerability was found in the tokio crate. Versions of tokio before 1.42.0 are vulnerable to a use-after-free when a spawned task is aborted while holding a borrowed reference. This can lead to memory corruption and potential code execution.
+
+**Affected package**: tokio
+**Affected versions**: versions before 1.42.0
+**Fixed version**: 1.42.0
+**CVSS**: 8.1 (High)
+
+The issue is scoped to stream [rhtpa-2.2]. However, cross-stream version impact analysis reveals that stream rhtpa-2.1 also ships tokio < 1.42.0. No sibling CVE Jira exists for the rhtpa-2.1 stream.
+
+### Cross-stream version impact (provided by Step 2 analysis)
+
+| Version     | Stream    | tokio version | Affected? |
+|-------------|-----------|---------------|-----------|
+| RHTPA 2.1.0 | rhtpa-2.1 | 1.40.0        | YES       |
+| RHTPA 2.1.1 | rhtpa-2.1 | 1.40.0        | YES       |
+| RHTPA 2.2.0 | rhtpa-2.2 | 1.41.1        | YES       |
+| RHTPA 2.2.1 | rhtpa-2.2 | 1.41.1        | YES       |
+
+### Sibling CVE Jiras (provided by Step 4 JQL search)
+
+No sibling Vulnerability issues found for CVE-2026-55123 in stream rhtpa-2.1.
+
+### References
+
+- https://github.com/advisories/GHSA-2026-tk91-v5pp
+- https://rustsec.org/advisories/RUSTSEC-2026-0088.html

--- a/evals/triage-security/files/vuln-issue-preemptive-reconciliation.md
+++ b/evals/triage-security/files/vuln-issue-preemptive-reconciliation.md
@@ -1,0 +1,60 @@
+<!-- SYNTHETIC TEST DATA — CVE Jira arrives for a stream that already has a preemptive remediation task -->
+
+# Mock Jira Vulnerability Issue
+
+**Key**: TC-8021
+**Summary**: CVE-2026-55123 tokio - Use-after-free in task abort [rhtpa-2.1]
+**Issue Type**: Vulnerability
+**Status**: New
+**Labels**: CVE-2026-55123, pscomponent:org/rhtpa-server
+**Affects Versions**: RHTPA 2.1.0, RHTPA 2.1.1
+**Due Date**: 2026-08-15
+**Assignee**: Unassigned
+
+## Custom Fields
+
+- **customfield_10632** (Upstream Affected Component): tokio
+- **customfield_10669** (PS Component): pscomponent:org/rhtpa-server
+- **customfield_10832** (Stream): rhtpa-2.1
+
+## Issue Links
+
+_(no existing links)_
+
+## Remote Links
+
+- [GHSA-2026-tk91-v5pp](https://github.com/advisories/GHSA-2026-tk91-v5pp) — GitHub Advisory
+- [CVE-2026-55123](https://www.cve.org/CVERecord?id=CVE-2026-55123) — CVE Record
+- [tokio-rs/tokio#7001](https://github.com/tokio-rs/tokio/pull/7001) — Upstream fix PR
+
+## Comments
+
+_(no comments)_
+
+---
+
+## Description
+
+A vulnerability was found in the tokio crate. Versions of tokio before 1.42.0 are vulnerable to a use-after-free when a spawned task is aborted while holding a borrowed reference. This can lead to memory corruption and potential code execution.
+
+**Affected package**: tokio
+**Affected versions**: versions before 1.42.0
+**Fixed version**: 1.42.0
+**CVSS**: 8.1 (High)
+
+This issue is scoped to stream [rhtpa-2.1]. A proactive remediation task (TC-8022) already exists for this stream, created by a prior cross-stream triage of TC-8020 (stream [rhtpa-2.2]).
+
+### Existing preemptive task (provided by Step 4.4 JQL search)
+
+A JQL search for `labels = 'security-preemptive' AND labels = 'CVE-2026-55123'` returns:
+
+- **TC-8022** — Remediate CVE-2026-55123: bump tokio to 1.42.0 (rhtpa-2.1)
+  - **Status**: Open
+  - **Labels**: ai-generated-jira, Security, CVE-2026-55123, security-preemptive
+  - **Issue Links**:
+    - **Related**: TC-8020 (originating CVE Jira, stream [rhtpa-2.2])
+
+### References
+
+- https://github.com/advisories/GHSA-2026-tk91-v5pp
+- https://rustsec.org/advisories/RUSTSEC-2026-0088.html

--- a/plugins/sdlc-workflow/skills/triage-security/SKILL.md
+++ b/plugins/sdlc-workflow/skills/triage-security/SKILL.md
@@ -39,7 +39,7 @@ Do **not** use for:
 | 1 | Data Extraction | Vulnerability issue key | CVE ID, library, affected range, remote links |
 | 2 | Version Impact Analysis | security-matrix.md, lock files | Version impact table |
 | 3 | Affects Versions Correction | Version impact table, Jira versions | Corrected Affects Versions |
-| 4 | Duplicate, Sibling, and Overlap Check | JQL search (sibling issues), component field search | Duplicate detection, issue links, cross-CVE overlap |
+| 4 | Duplicate, Sibling, Overlap, and Reconciliation Check | JQL search (sibling issues), component field search, preemptive task search | Duplicate detection, issue links, cross-CVE overlap, preemptive task reconciliation |
 | 5 | Version Lifecycle Check | Product pages URL | EOL status per version |
 | 6 | Already Fixed Check | Resolved sibling issues | Already-fixed detection |
 | 7 | Remediation | Impact analysis results | Remediation tasks or close recommendation |
@@ -336,11 +336,11 @@ Read `jira-triage-operations.md` for the detailed procedures.
 - **Step 3** – Affects Versions Correction: discover available Jira versions
   dynamically, compare against the version impact table, and correct with
   engineer confirmation
-- **Step 4** – Duplicate, Sibling, and Overlap Check: search for sibling
-  Vulnerability issues with the same CVE, classify as same-stream duplicates
-  or cross-stream companions, link related issues, and detect cross-CVE overlap
-  where a different CVE's remediation already covers the current CVE's fix
-  threshold
+- **Step 4** – Duplicate, Sibling, Overlap, and Reconciliation Check: search for
+  sibling Vulnerability issues with the same CVE, classify as same-stream
+  duplicates or cross-stream companions, link related issues, detect cross-CVE
+  overlap where a different CVE's remediation already covers the current CVE's
+  fix threshold, and reconcile with existing preemptive remediation tasks
 - **Step 5** – Version Lifecycle Check: verify affected versions are still
   within support lifecycle via the Product pages URL
 - **Step 6** – Already Fixed Check: cross-reference resolved sibling issues
@@ -380,24 +380,48 @@ are affected:
   (see Remediation Task Creation below).
 - Link each Task to the Vulnerability issue.
 
-### Case B: Cross-stream impact notice
+### Case B: Cross-stream impact — proactive remediation
 
 If the version impact analysis reveals that **other streams** (outside this
-issue's scope) are also affected, add a comment to the current issue noting
-the cross-stream impact. Do **not** create new Vulnerability issues or
-remediation tasks for those other streams — PSIRT manages per-stream
-Vulnerability tracking.
+issue's scope) are also affected:
 
-Example comment:
-```
-Cross-stream impact: [library] [affected-range] also affects stream(s)
-[other-stream-1], [other-stream-2] based on lock file analysis.
-These streams are tracked by companion issues (see Related links)
-or may require separate PSIRT triage.
-```
+1. **Post the cross-stream impact comment** (existing behavior):
+   ```
+   Cross-stream impact: [library] [affected-range] also affects stream(s)
+   [other-stream-1], [other-stream-2] based on lock file analysis.
+   These streams are tracked by companion issues (see Related links)
+   or may require separate PSIRT triage.
+   ```
 
-This is informational only — the engineer and PSIRT decide next steps for
-other streams.
+2. **Check for existing CVE Jiras** for each affected stream. Search for
+   sibling Vulnerability issues with the same CVE label and a matching stream
+   suffix (reuse the JQL from Step 4).
+
+3. **For each affected stream without its own CVE Jira**, create proactive
+   remediation tasks using the same templates as Case A, but with the
+   preemptive variant (see `remediation-templates.md` — Preemptive Task
+   Variant):
+   - Labels include `security-preemptive` alongside standard labels
+   - Link type is "Related" (not "Depend") to the originating CVE Jira
+   - Description includes a preemptive remediation prefix noting the
+     originating CVE and stream
+
+4. **For streams that already have a CVE Jira**, skip task creation — those
+   streams will be triaged through their own CVE issue.
+
+5. **Add comment** to the originating CVE Jira listing the preemptive tasks:
+   ```
+   Preemptive remediation tasks created for streams without CVE Jiras:
+   - [stream-1]: [task-key-1] (security-preemptive)
+   - [stream-2]: [task-key-2] (security-preemptive)
+
+   These tasks use the "Related" link type and carry the security-preemptive
+   label. When PSIRT creates stream-specific CVE Jiras, Step 4.4
+   reconciliation will link them and remove the label.
+   ```
+
+Do **not** create new Vulnerability issues — PSIRT manages per-stream
+Vulnerability tracking. Only create remediation **Tasks**.
 
 ### Case C: No supported versions affected
 

--- a/plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md
+++ b/plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md
@@ -2,8 +2,8 @@
 
 This companion file contains the detailed procedures for Steps 3–6 of the
 triage-security skill. These steps handle Affects Versions correction,
-duplicate and sibling detection, version lifecycle checks, and already-fixed
-detection.
+duplicate and sibling detection, cross-CVE overlap detection, preemptive task
+reconciliation, version lifecycle checks, and already-fixed detection.
 
 ## Step 3 – Affects Versions Correction
 
@@ -228,7 +228,64 @@ entirely.
      No existing remediation covers this CVE's fix threshold. Proceeding with
      new remediation task creation.
      ```
-   - **If no related CVEs found for this component:** proceed silently to Step 5.
+   - **If no related CVEs found for this component:** proceed silently to Step 4.4.
+
+### 4.4 – Preemptive task reconciliation
+
+When triaging a new CVE Jira for a specific stream, check whether a proactive
+remediation task already exists for this CVE and stream (created by a prior
+Step 7 Case B run on a different stream's CVE Jira).
+
+1. **Search for preemptive tasks** matching the current CVE:
+
+   ```
+   jira.search_jql(
+     "project = <project-key> AND issuetype = Task AND labels = 'security-preemptive' AND labels = '<CVE-ID>' ORDER BY created DESC",
+     fields: ["summary", "status", "labels", "issuelinks"]
+   )
+   ```
+
+2. **Filter results** to tasks whose summary contains the current issue's stream
+   name (e.g., the stream suffix from the issue summary). A preemptive task
+   created for stream `rhtpa-2.1` will have `(rhtpa-2.1)` in its summary.
+
+3. **If a matching preemptive task is found:**
+
+   a. **Link** the new CVE Jira to the preemptive task with "Depend" (standard
+      remediation linkage):
+      ```
+      jira.create_link(
+        inwardIssue: <current-cve-jira-key>,
+        outwardIssue: <preemptive-task-key>,
+        type: "Depend"
+      )
+      ```
+   b. **Remove the `security-preemptive` label** from the task — it is now
+      linked to a proper CVE Jira:
+      ```
+      current_labels = <preemptive-task-labels>
+      updated_labels = current_labels.filter(l => l != "security-preemptive")
+      jira.edit_issue(<preemptive-task-key>, fields={
+        "labels": updated_labels
+      })
+      ```
+   c. **Inform the engineer:**
+      ```
+      Existing preemptive remediation task [task-key] found for this CVE and
+      stream. Created from cross-stream analysis of [originating-CVE-Jira]
+      (linked via "Related").
+
+      Actions taken:
+      - Linked [current-cve-key] → [task-key] with "Depend"
+      - Removed "security-preemptive" label from [task-key]
+
+      The preemptive task is now a standard remediation task for this CVE Jira.
+      Skipping new remediation task creation in Step 7.
+      ```
+   d. **Record the reconciliation** — mark that remediation already exists for
+      this stream so Step 7 skips task creation for it.
+
+4. **If no matching preemptive task found:** proceed silently to Step 5.
 
 ## Step 5 – Version Lifecycle Check
 

--- a/plugins/sdlc-workflow/skills/triage-security/remediation-templates.md
+++ b/plugins/sdlc-workflow/skills/triage-security/remediation-templates.md
@@ -223,6 +223,71 @@ task = jira.create_issue(
 )
 ```
 
+## Preemptive Task Variant
+
+When Step 7 Case B identifies affected streams that lack their own CVE Jira,
+create proactive remediation tasks using the same templates as Case A but with
+these differences:
+
+### Labels
+
+Add `security-preemptive` to the labels array to distinguish proactive tasks
+from standard remediation:
+
+```
+labels: ["ai-generated-jira", "Security", "<CVE-ID>", "security-preemptive"]
+```
+
+### Description prefix
+
+Prepend a note to the Description section of the task template:
+
+```
+> **Preemptive remediation**: This task was created proactively from cross-stream
+> impact analysis of [originating-CVE-Jira-key] (stream [originating-stream]).
+> No stream-specific CVE Jira exists yet for this stream. When PSIRT creates one,
+> this task will be linked and the `security-preemptive` label removed.
+```
+
+### Link type
+
+Link preemptive tasks to the originating CVE Jira with "Related" (not "Depend"),
+because the originating CVE belongs to a different stream:
+
+```
+jira.create_link(
+  inwardIssue: <originating-cve-jira-key>,
+  outwardIssue: <preemptive-task-key>,
+  type: "Related"
+)
+```
+
+### Creation pseudocode
+
+```
+# Source dependency ecosystems — preemptive variant
+upstream_task = jira.create_issue(
+  projectKey: "<project-key>",
+  issueTypeName: "Task",
+  summary: "Remediate CVE-YYYY-XXXXX: bump [library] to [fixed-version] ([stream])",
+  description: <upstream-task-description-with-preemptive-prefix>,
+  labels: ["ai-generated-jira", "Security", "<CVE-ID>", "security-preemptive"]
+)
+
+# System package ecosystems — preemptive variant
+task = jira.create_issue(
+  projectKey: "<project-key>",
+  issueTypeName: "Task",
+  summary: "Remediate CVE-YYYY-XXXXX: update [package-name] to [fixed-version] ([stream])",
+  description: <system-package-task-description-with-preemptive-prefix>,
+  labels: ["ai-generated-jira", "Security", "<CVE-ID>", "security-preemptive"]
+)
+```
+
+Downstream propagation subtasks (for source dependency ecosystems) also receive
+the `security-preemptive` label and use the same "Related" link to the
+originating CVE Jira.
+
 ## Jira Linkage
 
 After creating remediation tasks:


### PR DESCRIPTION
## Summary

- Step 7 Case B now creates preemptive remediation tasks (labeled `security-preemptive`) for affected streams that lack their own CVE Jira, linked to the originating CVE with "Related" link type
- Step 4.4 reconciliation detects existing preemptive tasks when a stream-specific CVE Jira arrives, links them with "Depend", and removes the `security-preemptive` label
- New constraint §1.60 and two eval cases (10, 11) with fixture files for preemptive task creation and reconciliation

## Test plan

- [ ] Existing eval cases 1–9 pass without modification
- [ ] New eval case 10 validates preemptive task creation for affected streams without CVE Jiras
- [ ] New eval case 11 validates reconciliation when a CVE Jira arrives for a stream with an existing preemptive task
- [ ] Constraint §1.60 correctly references Step 7 Case B and Step 4.4

Closes: [TC-4853](https://redhat.atlassian.net/browse/TC-4853)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add proactive cross-stream remediation task creation and reconciliation for triage-security CVE workflows.

New Features:
- Introduce proactive remediation tasks for affected streams without their own CVE Jiras, labeled with security-preemptive and linked as Related to the originating CVE Jira.
- Document a preemptive task variant in remediation templates, including labels, descriptions, and linkage rules for proactive tasks.

Enhancements:
- Extend triage-security Step 4 to perform preemptive task reconciliation by linking new stream-specific CVE Jiras to existing preemptive tasks and normalizing their labels.
- Update triage-security documentation to describe the expanded reconciliation flow in Steps 4 and 7, including engineer-facing comments and guidance.
- Add a new constraint ensuring proactive preemptive task creation and reconciliation behavior is enforced.

Tests:
- Add new triage-security evaluation cases and fixtures to cover cross-stream preemptive task creation and subsequent reconciliation when stream-specific CVE Jiras arrive.