### PR TITLE
feat(triage-security): add external CVE data enrichment from MITRE and OSV.dev

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -74,6 +74,7 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 1.62 | `plan-feature` MUST discover issue types dynamically from the Jira project, not hardcode type names or IDs. | `plan-feature/SKILL.md` — Step 2.5 |
 | 1.63 | `plan-feature` MUST map issue types to hierarchy roles by `hierarchyLevel` field, not by type name. | `plan-feature/SKILL.md` — Step 2.5 |
 | 1.64 | `plan-feature` MUST fall back to Feature → Task hierarchy when no level-1 type exists, without error. | `plan-feature/SKILL.md` — Step 2.5 |
+| 1.65 | `triage-security` MUST query MITRE CVE API and OSV.dev for structured version ranges in Step 1.5 and use them as the primary fix threshold source when available, falling back to Jira description data only when external APIs are unavailable. | `triage-security/SKILL.md` — Step 1.5, `triage-security/version-impact-analysis.md` — Step 2.3 |
 
 ### Prior Art — Cross-phase integrity (§1.33–1.35)
 
@@ -167,6 +168,7 @@ Each constraint above references its source. The full source files are:
 - `plugins/sdlc-workflow/skills/define-feature/SKILL.md` — Guardrails (§1.7–1.8), Important Rules (§1.9)
 - `plugins/sdlc-workflow/skills/report-bug/SKILL.md` — Guardrails (§1.50–1.51), Step 4 Preview and Confirm (§1.52)
 - `plugins/sdlc-workflow/skills/triage-bug/SKILL.md` — Guardrails (§1.53–1.54), Step 5 Front-load reproducer test (§1.55), Step 4 Post root cause comment (§1.56), Step 6 Decomposition Guard (§1.57)
-- `plugins/sdlc-workflow/skills/triage-security/SKILL.md` — Guardrails (§1.37, §1.38, §1.47), Step 0 (§1.49), Step 1 Ecosystem detection (§1.48), Step 1 Data Extraction (§1.49), Step 2.1 (§1.47), Step 2.2 (§1.42), Step 2.3 (§1.48), Step 2.4 (§1.44), Step 7 (§1.43), Step 7 Case B (§1.61), Important Rules (§1.38–§1.43, §1.45, §1.46), Remediation Task Creation (§1.46)
+- `plugins/sdlc-workflow/skills/triage-security/SKILL.md` — Guardrails (§1.37, §1.38, §1.47), Step 0 (§1.49), Step 1 Ecosystem detection (§1.48), Step 1 Data Extraction (§1.49), Step 1.5 External CVE Data Enrichment (§1.62), Step 2.1 (§1.47), Step 2.2 (§1.42), Step 2.3 (§1.48), Step 2.4 (§1.44), Step 7 (§1.43), Step 7 Case B (§1.61), Important Rules (§1.38–§1.43, §1.45, §1.46), Remediation Task Creation (§1.46)
+- `plugins/sdlc-workflow/skills/triage-security/version-impact-analysis.md` — Step 2.3 enriched fix threshold (§1.62)
 - `plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md` — Step 4.2 Idempotent sibling linking (§1.58), Step 4.3 Cross-CVE overlap detection (§1.59), Step 4.4 Proactive reconciliation (§1.61)
 - `docs/methodology.md` — Core Principles (§2.1, §3.2, §5.5)

--- a/evals/triage-security/evals.json
+++ b/evals/triage-security/evals.json
@@ -148,6 +148,19 @@
         "Step 4.4 removes the 'security-preemptive' label from TC-8022 — the task is now a standard remediation task linked to a proper CVE Jira",
         "Step 7 skips remediation task creation for this stream because Step 4.4 reconciliation already linked an existing task"
       ]
+    },
+    {
+      "id": 12,
+      "prompt": "Triage Vulnerability issue TC-8030. The issue details are in vuln-issue-enrichment.md, the security matrix is in security-matrix-mock.md, and the project CLAUDE.md is in claude-md-security-config.md. The issue has stream suffix [rhtpa-2.2]. The Jira description says affected versions are 'versions prior to the fix' with no precise threshold. The mock MITRE CVE API response (included in the fixture) shows lessThan 0.4.8 and the mock OSV.dev response shows fixed at 0.4.8. Do NOT actually call Jira MCP, git show, WebFetch, or any external tools. Instead, use the mock API responses embedded in the fixture file and write your triage analysis to the workspace outputs/ directory: write outputs/data-extraction.md with the parsed CVE data from Step 1, write outputs/enrichment.md with the Step 1.5 external CVE data enrichment analysis including the cross-validation table, write outputs/version-impact.md with the version impact table from Step 2 using the enriched fix threshold, and write outputs/remediation.md with the remediation task descriptions.",
+      "expected_output": "A triage analysis where Step 1 extracts imprecise version data from the Jira description ('versions prior to the fix'), Step 1.5 queries MITRE CVE API and OSV.dev to obtain precise fix threshold (0.4.8), the cross-validation table shows agreement between the two external sources, and Step 2.3 uses the enriched threshold (0.4.8) for version impact comparisons.",
+      "files": ["files/vuln-issue-enrichment.md", "files/security-matrix-mock.md", "files/claude-md-security-config.md"],
+      "assertions": [
+        "Step 1 extracts imprecise affected range from the Jira description — the description lacks a specific version threshold (Step 1 Data Extraction)",
+        "Step 1.5 queries MITRE CVE API and extracts lessThan 0.4.8 as the fix threshold from the affected[].versions[] field (§1.62)",
+        "Step 1.5 queries OSV.dev API and extracts fixed version 0.4.8 from the affected[].ranges[].events field (§1.62)",
+        "Step 1.5 cross-validation shows agreement between MITRE and OSV.dev — the enriched fix threshold (0.4.8) is used as the authoritative value for Step 2.3",
+        "Step 2.3 version impact comparison uses the enriched fix threshold (0.4.8) from Step 1.5, not the imprecise Jira description data"
+      ]
     }
   ]
 }

--- a/evals/triage-security/files/vuln-issue-enrichment.md
+++ b/evals/triage-security/files/vuln-issue-enrichment.md
@@ -1,0 +1,82 @@
+<!-- SYNTHETIC TEST DATA — Vulnerability issue with imprecise Jira description for external CVE enrichment eval testing -->
+
+# Mock Jira Vulnerability Issue
+
+**Key**: TC-8030
+**Summary**: CVE-2026-48901 h2 - HTTP/2 CONTINUATION flood [rhtpa-2.2]
+**Issue Type**: Vulnerability
+**Status**: New
+**Labels**: CVE-2026-48901, pscomponent:org/rhtpa-server
+**Affects Versions**: RHTPA 2.2.0
+**Due Date**: 2026-08-01
+**Assignee**: Unassigned
+
+## Remote Links
+
+- [GHSA-2026-r7f2-kk9p](https://github.com/advisories/GHSA-2026-r7f2-kk9p) — GitHub Advisory
+- [CVE-2026-48901](https://www.cve.org/CVERecord?id=CVE-2026-48901) — CVE Record
+- [hyperium/h2#800](https://github.com/hyperium/h2/pull/800) — Upstream fix PR
+
+## Comments
+
+_(no comments)_
+
+---
+
+## Description
+
+A vulnerability was found in h2. The h2 crate is affected by an HTTP/2 CONTINUATION flood vulnerability. An attacker can send a large number of CONTINUATION frames that causes excessive memory allocation and CPU usage.
+
+**Affected package**: h2
+**Affected versions**: versions prior to the fix
+**Fixed version**: see advisory
+**CVSS**: 7.5 (High)
+
+The vulnerability exists because h2 does not limit the number of CONTINUATION frames that can follow a HEADERS frame. An attacker can exploit this to cause a denial of service.
+
+### References
+
+- https://github.com/advisories/GHSA-2026-r7f2-kk9p
+- https://rustsec.org/advisories/RUSTSEC-2026-0089.html
+
+## External CVE Data (mock responses for eval)
+
+### MITRE CVE API Response (https://cveawg.mitre.org/api/cve/CVE-2026-48901)
+
+```json
+{
+  "cveMetadata": {"cveId": "CVE-2026-48901"},
+  "containers": {
+    "cna": {
+      "affected": [{
+        "product": "h2",
+        "vendor": "hyperium",
+        "versions": [{
+          "status": "affected",
+          "lessThan": "0.4.8",
+          "versionType": "semver"
+        }]
+      }]
+    }
+  }
+}
+```
+
+### OSV.dev API Response (https://api.osv.dev/v1/vulns/CVE-2026-48901)
+
+```json
+{
+  "id": "RUSTSEC-2026-0089",
+  "aliases": ["CVE-2026-48901"],
+  "affected": [{
+    "package": {"ecosystem": "crates.io", "name": "h2"},
+    "ranges": [{
+      "type": "SEMVER",
+      "events": [
+        {"introduced": "0"},
+        {"fixed": "0.4.8"}
+      ]
+    }]
+  }]
+}
+```

--- a/plugins/sdlc-workflow/skills/triage-security/SKILL.md
+++ b/plugins/sdlc-workflow/skills/triage-security/SKILL.md
@@ -37,6 +37,7 @@ Do **not** use for:
 | 0 | Validate Configuration | CLAUDE.md | Project key, Cloud ID, Security Config |
 | 0.5 | Jira Access | -- | MCP or REST API connection |
 | 1 | Data Extraction | Vulnerability issue key | CVE ID, library, affected range, remote links |
+| 1.5 | External CVE Data Enrichment | CVE ID | Structured version ranges, cross-validated fix thresholds |
 | 2 | Version Impact Analysis | security-matrix.md, lock files | Version impact table |
 | 3 | Affects Versions Correction | Version impact table, Jira versions | Corrected Affects Versions |
 | 4 | Duplicate, Sibling, Overlap, and Reconciliation Check | JQL search (sibling issues), component field search, preemptive task search | Duplicate detection, issue links, cross-CVE overlap, preemptive task reconciliation |
@@ -304,6 +305,73 @@ flowchart TD
     F --> I["Remediation: 1 task\n(Konflux repo)"]
     G --> I
 ```
+
+## Step 1.5 – External CVE Data Enrichment
+
+After extracting data from the Jira description, query external CVE databases for
+structured vulnerability data. This is not a fallback — external sources are **always**
+queried to supplement and cross-validate the Jira description data.
+
+### 1. MITRE CVE API
+
+Query the MITRE CVE API for the authoritative CVE record:
+
+```
+WebFetch(url: "https://cveawg.mitre.org/api/cve/<CVE-ID>",
+  prompt: "Extract the affected products, version ranges, and fixed versions
+  from the CVE record. Return structured data: product name, affected version
+  range (lessThan, lessThanOrEqual), and fixed version.")
+```
+
+Parse the `affected[].versions[].lessThan` or `affected[].versions[].lessThanOrEqual`
+fields for precise fix thresholds.
+
+### 2. OSV.dev API
+
+Query the OSV.dev database for ecosystem-specific version range data:
+
+```
+WebFetch(url: "https://api.osv.dev/v1/vulns/<CVE-ID>",
+  prompt: "Extract the affected packages, ecosystem, version ranges (introduced,
+  fixed, last_affected), and severity from the OSV record.")
+```
+
+Parse `affected[].ranges[].events` for `introduced` and `fixed` version markers.
+
+### 3. Cross-validation
+
+Compare external fix thresholds against the values parsed from the Jira description
+in Step 1:
+
+- **Agreement**: use the structured external data as the authoritative fix threshold
+  for Step 2.3 comparisons. The external data takes precedence because it provides
+  machine-readable version constraints rather than prose-parsed ranges.
+- **Disagreement**: present both sources to the engineer in a comparison table and
+  ask which to use before proceeding:
+
+  ```
+  Fix threshold comparison for <CVE-ID> (<library>):
+
+  | Source          | Affected range | Fixed version |
+  |-----------------|----------------|---------------|
+  | Jira description| < 0.11.14      | 0.11.14       |
+  | MITRE CVE API   | < 0.11.13      | 0.11.13       |
+  | OSV.dev         | < 0.11.14      | 0.11.14       |
+
+  The Jira description and OSV.dev agree, but MITRE reports a different threshold.
+  Which fix threshold should be used for version impact analysis?
+  ```
+
+- **Unavailable**: if an external API returns an error (HTTP 404, timeout, network
+  failure), log a warning and fall back to the Jira description data for that source.
+  If **both** external APIs are unavailable, proceed with Jira description data only
+  and note the degraded confidence:
+
+  > "⚠ External CVE databases unavailable — using Jira description data only.
+  > Fix threshold confidence is reduced."
+
+The enriched fix threshold (from this step) is passed to Step 2.3 for use in version
+impact comparisons.
 
 ## Step 2 – Version Impact Analysis
 

--- a/plugins/sdlc-workflow/skills/triage-security/version-impact-analysis.md
+++ b/plugins/sdlc-workflow/skills/triage-security/version-impact-analysis.md
@@ -152,8 +152,11 @@ For each version in the aggregated matrix (plus the development stream):
    (e.g., `2.2.2 = retag of 2.2.1`), **skip** the version check and carry forward
    the result from the retagged version. Note in the output: "same as [version]".
 
-5. **Compare** each extracted dependency version against the CVE's affected range
-   to determine whether that product version is affected.
+5. **Compare** each extracted dependency version against the enriched fix threshold
+   from Step 1.5. When Step 1.5 produced a cross-validated fix threshold (from MITRE
+   CVE API or OSV.dev), use that value instead of the Jira description's affected
+   range. If Step 1.5 was skipped or both external APIs were unavailable, fall back
+   to the Jira description's affected range.
 
 ### 2.3.5 – Dependency chain context
 


### PR DESCRIPTION
## Summary

- Add Step 1.5 (External CVE Data Enrichment) to triage-security that queries MITRE CVE API and OSV.dev for structured version ranges on every CVE triage
- Cross-validates external data against Jira description values, presenting disagreements to the engineer for resolution
- Updates version impact analysis (Step 2.3) to use enriched fix thresholds from Step 1.5 as the primary source
- Adds constraint §1.62 and eval case 12 covering the new behavior

Implements [TC-4854](https://redhat.atlassian.net/browse/TC-4854)

## Test plan

- [ ] Verify eval cases 1–6 continue to pass without modification
- [ ] Run eval case 12 to confirm external CVE enrichment behavior works with the fixture data
- [ ] Verify Step 1.5 instructions are clear and follow the established SKILL.md conventions
- [ ] Verify constraint §1.62 is correctly added with proper traceability index entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add an external CVE data enrichment step to triage-security that pulls structured version ranges from MITRE and OSV.dev and makes this data the primary source for version impact analysis when available.

New Features:
- Introduce Step 1.5 in triage-security to always query MITRE CVE API and OSV.dev for structured CVE version and fix threshold data and cross-validate it against Jira descriptions.

Enhancements:
- Update version impact analysis to prefer cross-validated external fix thresholds over Jira description ranges, with clear fallbacks when external data is unavailable.
- Document the new enrichment workflow and its cross-validation behavior in triage-security SKILL and version-impact-analysis guides.
- Add constraint §1.62 to formalize the requirement to use external CVE data as the primary fix threshold source and link it into the traceability index.

Tests:
- Add an eval fixture file modelling a vulnerability issue with imprecise Jira description and mocked MITRE/OSV.dev responses to validate external CVE enrichment behavior.