### PR TITLE
feat(define-feature): add priority and fixVersion prompts

### DIFF
--- a/evals/define-feature/evals.json
+++ b/evals/define-feature/evals.json
@@ -3,8 +3,8 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "Define a Jira Feature using the define-feature skill. The project's CLAUDE.md is in claude-md-configured.md. The user input for all 9 template sections is in user-input-complete.md — read each section from the file as if the user provided it during the interactive walkthrough. The Feature summary is 'Add SBOM dependency graph visualization'. The user chooses self-assignment. Do NOT call any actual MCP tools or Jira APIs. Instead, write the following outputs: outputs/preview.md (the composed Feature description preview exactly as it would be shown to the user before creation), outputs/jira-create.md (the Jira create_issue call parameters: project key, summary, issue type ID, description, labels, assignee), outputs/jira-comment.md (the comment that would be posted to the created issue, including the Comment Footnote with version from plugins/sdlc-workflow/.claude-plugin/plugin.json). Do NOT modify any files outside outputs/.",
-      "expected_output": "A complete Feature description preview containing all 9 section headings with the content from user-input-complete.md. The Jira create parameters should reference project key TC, issue type ID 10142, and include the ai-generated-jira label. The comment should include the Comment Footnote with sdlc-workflow/define-feature link and version.",
+      "prompt": "Define a Jira Feature using the define-feature skill. The project's CLAUDE.md is in claude-md-configured.md. The user input for all 9 template sections is in user-input-complete.md — read each section from the file as if the user provided it during the interactive walkthrough. The Feature summary is 'Add SBOM dependency graph visualization'. The user chooses self-assignment. For Step 3.5, the user selects priority 'Major' and fixVersion '1.5.0'. Do NOT call any actual MCP tools or Jira APIs. Instead, write the following outputs: outputs/preview.md (the composed Feature description preview exactly as it would be shown to the user before creation), outputs/jira-create.md (the Jira create_issue call parameters: project key, summary, issue type ID, description, labels, assignee, priority, fixVersions), outputs/jira-comment.md (the comment that would be posted to the created issue, including the Comment Footnote with version from plugins/sdlc-workflow/.claude-plugin/plugin.json). Do NOT modify any files outside outputs/.",
+      "expected_output": "A complete Feature description preview containing all 9 section headings with the content from user-input-complete.md. The preview should show Priority: Major and Fix Version: 1.5.0. The Jira create parameters should reference project key TC, issue type ID 10142, include the ai-generated-jira label, priority Major, and fixVersions 1.5.0. The comment should include the Comment Footnote with sdlc-workflow/define-feature link and version.",
       "files": ["files/claude-md-configured.md", "files/user-input-complete.md"],
       "assertions": [
         "outputs/preview.md contains the heading '## Feature Overview'",
@@ -16,10 +16,14 @@
         "outputs/preview.md contains the heading '## Customer Considerations'",
         "outputs/preview.md contains the heading '## Customer Information/Supportability'",
         "outputs/preview.md contains the heading '## Documentation Considerations'",
+        "outputs/preview.md contains 'Major' in the priority field display",
+        "outputs/preview.md contains '1.5.0' in the fix version field display",
         "outputs/jira-create.md references project key 'TC'",
         "outputs/jira-create.md references issue type ID '10142'",
         "outputs/jira-create.md includes the label 'ai-generated-jira'",
         "outputs/jira-create.md includes an assignee (self-assignment was chosen)",
+        "outputs/jira-create.md includes priority with name 'Major' in additional_fields",
+        "outputs/jira-create.md includes fixVersions with name '1.5.0' in additional_fields",
         "outputs/jira-comment.md contains 'sdlc-workflow/define-feature'",
         "outputs/jira-comment.md contains 'https://github.com/mrizzi/sdlc-plugins'",
         "outputs/jira-comment.md contains a version string (e.g., 'v0.' or version from plugin.json)"
@@ -27,8 +31,8 @@
     },
     {
       "id": 2,
-      "prompt": "Define a Jira Feature using the define-feature skill. The project's CLAUDE.md is in claude-md-configured.md. The user input is in user-input-partial.md — it provides content for only the 2 Required sections (Feature Overview and Requirements) and explicitly marks all other sections as 'SKIP'. The Feature summary is 'Add bulk SBOM delete endpoint'. The user leaves the Feature unassigned. Do NOT call any actual MCP tools or Jira APIs. Instead, write the following outputs: outputs/preview.md (the composed Feature description preview exactly as it would be shown to the user before creation), outputs/jira-create.md (the Jira create_issue call parameters), outputs/jira-comment.md (the comment with Comment Footnote). Do NOT modify any files outside outputs/.",
-      "expected_output": "A Feature description preview containing only the 2 Required section headings (Feature Overview and Requirements). Skipped sections must NOT appear as empty headings in the preview. The Jira create parameters should not include an assignee.",
+      "prompt": "Define a Jira Feature using the define-feature skill. The project's CLAUDE.md is in claude-md-configured.md. The user input is in user-input-partial.md — it provides content for only the 2 Required sections (Feature Overview and Requirements) and explicitly marks all other sections as 'SKIP'. The Feature summary is 'Add bulk SBOM delete endpoint'. The user leaves the Feature unassigned. For Step 3.5, the user skips both priority and fixVersion. Do NOT call any actual MCP tools or Jira APIs. Instead, write the following outputs: outputs/preview.md (the composed Feature description preview exactly as it would be shown to the user before creation), outputs/jira-create.md (the Jira create_issue call parameters), outputs/jira-comment.md (the comment with Comment Footnote). Do NOT modify any files outside outputs/.",
+      "expected_output": "A Feature description preview containing only the 2 Required section headings (Feature Overview and Requirements). Skipped sections must NOT appear as empty headings in the preview. Priority and Fix Version should show 'Not set' in the preview. The Jira create parameters should not include an assignee, priority, or fixVersions.",
       "files": ["files/claude-md-configured.md", "files/user-input-partial.md"],
       "assertions": [
         "outputs/preview.md contains the heading '## Feature Overview'",
@@ -40,8 +44,12 @@
         "outputs/preview.md does NOT contain the heading '## Customer Considerations'",
         "outputs/preview.md does NOT contain the heading '## Customer Information/Supportability'",
         "outputs/preview.md does NOT contain the heading '## Documentation Considerations'",
+        "outputs/preview.md contains 'Not set' for priority (user skipped priority selection)",
+        "outputs/preview.md contains 'Not set' for fix version (user skipped fixVersion selection)",
         "outputs/jira-create.md does NOT include an assignee or indicates 'unassigned'",
-        "outputs/jira-create.md includes the label 'ai-generated-jira'"
+        "outputs/jira-create.md includes the label 'ai-generated-jira'",
+        "outputs/jira-create.md does NOT include priority in additional_fields (user skipped)",
+        "outputs/jira-create.md does NOT include fixVersions in additional_fields (user skipped)"
       ]
     },
     {
@@ -101,6 +109,22 @@
         "outputs/api-claim-verification.md indicates the claim could not be verified (e.g., 'unverified', 'unavailable', 'cannot verify', or 'web tools unavailable')",
         "outputs/api-claim-verification.md contains a prompt or indication that the user was asked to decide (e.g., 'proceed as-is', 'verify manually', or 'Would you like to')",
         "outputs/preview.md contains the heading '## Requirements'",
+        "outputs/jira-comment.md contains 'sdlc-workflow/define-feature'"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Define a Jira Feature using the define-feature skill. The project's CLAUDE.md is in claude-md-with-field-defaults.md — it has a '### Jira Field Defaults' subsection with 'Prompt for priority: false', 'Default priority: Normal', and 'Prompt for fixVersion: false'. The user input is in user-input-partial.md — it provides content for only the 2 Required sections. All other sections are marked SKIP. The Feature summary is 'Add bulk SBOM delete endpoint'. The user leaves the Feature unassigned. Do NOT call any actual MCP tools or Jira APIs. Instead, write the following outputs: outputs/preview.md (the composed Feature description preview), outputs/jira-create.md (the Jira create_issue call parameters), outputs/jira-comment.md (the comment with Comment Footnote). Do NOT modify any files outside outputs/.",
+      "expected_output": "The skill reads Jira Field Defaults from CLAUDE.md and does NOT prompt the user for priority or fixVersion (both prompts suppressed). Because Default priority is 'Normal', the preview shows Priority: Normal (applied silently). Because no default fixVersion is configured, Fix Version shows 'Not set'. The Jira create call includes priority Normal but omits fixVersions.",
+      "files": ["files/claude-md-with-field-defaults.md", "files/user-input-partial.md"],
+      "assertions": [
+        "outputs/preview.md contains the heading '## Feature Overview'",
+        "outputs/preview.md contains the heading '## Requirements'",
+        "outputs/preview.md contains 'Normal' in the priority field display (default priority applied silently)",
+        "outputs/preview.md contains 'Not set' for fix version (no default fixVersion configured, prompt suppressed)",
+        "outputs/jira-create.md includes priority with name 'Normal' in additional_fields (default applied)",
+        "outputs/jira-create.md does NOT include fixVersions in additional_fields (no default, prompt suppressed)",
+        "outputs/jira-create.md includes the label 'ai-generated-jira'",
         "outputs/jira-comment.md contains 'sdlc-workflow/define-feature'"
       ]
     }

--- a/evals/define-feature/files/claude-md-with-field-defaults.md
+++ b/evals/define-feature/files/claude-md-with-field-defaults.md
@@ -1,0 +1,47 @@
+<!-- SYNTHETIC TEST DATA — CLAUDE.md with Jira Field Defaults configured for define-feature eval testing -->
+
+# trustify-backend
+
+## Documentation
+
+- [docs/architecture.md](docs/architecture.md) — System architecture overview
+- [docs/api.md](docs/api.md) — REST API reference
+
+# Project Configuration
+
+## Repository Registry
+
+| Repository | Role | Serena Instance | Path |
+|---|---|---|---|
+| trustify-backend | Rust backend service | serena_backend | /home/user/trustify-backend |
+
+## Jira Configuration
+
+- Project key: TC
+- Cloud ID: 2b9e35e3-6bd3-4cec-b838-f4249ee02432
+- Feature issue type ID: 10142
+- Git Pull Request custom field: customfield_10875
+- GitHub Issue custom field: customfield_10747
+
+### Jira Field Defaults
+- Default priority: Normal
+- fixVersion scope: both
+- Prompt for priority: false
+- Prompt for fixVersion: false
+
+## Code Intelligence
+
+Tools are prefixed by Serena instance name: `mcp__<instance>__<tool>`.
+
+For example, to search for a symbol in a repository whose Serena instance
+is `serena_backend`:
+
+    mcp__serena_backend__find_symbol(
+      name_path_pattern="MyService",
+      substring_matching=true,
+      include_body=false
+    )
+
+### Limitations
+
+- `serena_backend`: rust-analyzer may take 30-60 seconds to index on first use

--- a/plugins/sdlc-workflow/skills/define-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/define-feature/SKILL.md
@@ -282,6 +282,101 @@ Ask about documentation impact. Prompt with the standard categories:
 
 Also ask about user purpose, reference material, and source material for tech writers. The user may skip this section.
 
+## Step 3.5 – Select Priority and Fix Version
+
+This step lets the user set optional metadata fields (priority and fixVersion) before
+the assignee step. Both fields are optional and skippable.
+
+### Step 3.5.1 – Read Jira Field Defaults
+
+Check the project's CLAUDE.md for a `### Jira Field Defaults` subsection under
+`## Jira Configuration`. If present, extract:
+
+- **Default priority** — the priority name to pre-select (or empty/none for no default)
+- **Prompt for priority** — `true` or `false` (whether to show the priority prompt)
+- **Prompt for fixVersion** — `true` or `false` (whether to show the fixVersion prompt)
+
+If the `### Jira Field Defaults` subsection is absent, treat all fields as:
+- Default priority: _(none)_
+- Prompt for priority: `true`
+- Prompt for fixVersion: `true`
+
+This ensures backward compatibility — projects without the subsection see both prompts.
+
+### Step 3.5.2 – Fetch Available Priorities and Fix Versions
+
+Call `getJiraIssueTypeMetaWithFields` once to retrieve the available field values for
+the Feature issue type:
+
+```
+getJiraIssueTypeMetaWithFields(cloudId, projectIdOrKey, issueTypeId)
+```
+
+Where:
+- `cloudId` is from the Jira Configuration
+- `projectIdOrKey` is the Project key from the Jira Configuration
+- `issueTypeId` is the Feature issue type ID from the Jira Configuration
+
+From the response, extract:
+- **Available priorities** from `priority.allowedValues` — array of `{id, name}`
+- **Available fixVersions** from `fixVersions.allowedValues` — array of `{id, name, released, archived}`
+
+For fixVersions, filter to show only **unreleased, non-archived** versions by default
+(where `released` is `false` and `archived` is `false`).
+
+If MCP fails, follow the same REST API fallback pattern from Step 0.5. If REST API
+is also unavailable, skip this step and inform the user:
+
+> "Could not fetch available priorities and fixVersions. Skipping metadata fields."
+
+### Step 3.5.3 – Priority Prompt
+
+If `Prompt for priority` is `false` (from Jira Field Defaults), skip the priority prompt
+entirely. If a Default priority is configured, record it silently. If no default is
+configured, leave priority unset.
+
+If `Prompt for priority` is `true` (or unset), present the available priorities as a
+numbered list. If a Default priority is configured, mark it with `(default)` in the list.
+Include a "Skip" option as the last entry.
+
+Example:
+
+```
+Select priority for this Feature (or skip):
+1. Blocker
+2. Critical
+3. Major
+4. Normal (default)
+5. Minor
+6. Skip — leave unset
+```
+
+Record the user's choice for use in Step 5 (preview) and Step 6.2 (issue creation).
+
+### Step 3.5.4 – Fix Version Prompt
+
+If `Prompt for fixVersion` is `false` (from Jira Field Defaults), skip the fixVersion
+prompt entirely. Leave fixVersion unset.
+
+If `Prompt for fixVersion` is `true` (or unset), present the unreleased, non-archived
+fixVersions as a numbered list. Include a "Skip" option as the last entry.
+
+Example:
+
+```
+Select target fix version for this Feature (or skip):
+1. 1.5.0
+2. 1.6.0
+3. 2.0.0
+4. Skip — leave unset
+```
+
+If no unreleased, non-archived fixVersions are available, inform the user:
+
+> "No unreleased fixVersions found for this project. Skipping fixVersion selection."
+
+Record the user's choice for use in Step 5 (preview) and Step 6.2 (issue creation).
+
 ## Step 4 – Offer Assignee
 
 Retrieve the current user's identity:
@@ -315,6 +410,8 @@ Compose the full Feature description from all collected sections. Format it usin
 Present the full preview to the user, including:
 - **Summary (title):** the collected summary
 - **Description:** the composed description
+- **Priority:** the selected priority name, or "Not set" if skipped
+- **Fix Version:** the selected fixVersion name, or "Not set" if skipped
 - **Assignee:** the chosen assignee or "Unassigned"
 - **Labels:** `ai-generated-jira`
 
@@ -372,6 +469,29 @@ If the user chose self-assignment in Step 4, include the assignee:
 additional_fields: { "labels": ["ai-generated-jira"], "assignee": { "accountId": "<user-account-id>" } }
 ```
 
+If the user selected a priority in Step 3.5, include it in `additional_fields`:
+```
+"priority": {"name": "<selected-priority>"}
+```
+
+If the user selected a fixVersion in Step 3.5, include it in `additional_fields`:
+```
+"fixVersions": [{"name": "<selected-version>"}]
+```
+
+Omit `priority` from `additional_fields` if the user skipped priority selection.
+Omit `fixVersions` from `additional_fields` if the user skipped fixVersion selection.
+
+Combined example with all optional fields selected:
+```
+additional_fields: {
+  "labels": ["ai-generated-jira"],
+  "assignee": { "accountId": "<user-account-id>" },
+  "priority": {"name": "<selected-priority>"},
+  "fixVersions": [{"name": "<selected-version>"}]
+}
+```
+
 **On MCP failure, if REST API chosen (Step 0.5):**
 
 First, if self-assignment was chosen, get the current user's account ID:
@@ -388,7 +508,10 @@ python3 scripts/jira-client.py create_issue \
   --description-md "<composed-description>" \
   --issue-type "<feature-issue-type-id>" \
   --labels ai-generated-jira \
-  --assignee-id "$ACCOUNT_ID"  # omit if no self-assignment
+  --assignee-id "$ACCOUNT_ID" \         # omit if no self-assignment
+  --fields-json '{"priority": {"name": "<selected-priority>"}, "fixVersions": [{"name": "<selected-version>"}]}'
+  # omit priority from --fields-json if skipped
+  # omit fixVersions from --fields-json if skipped
 ```
 
 The Python client automatically converts markdown to ADF.


### PR DESCRIPTION
## Summary

- Add Step 3.5 to define-feature skill for interactive priority and fixVersion selection
- Fetch available values from `getJiraIssueTypeMetaWithFields` MCP tool
- Read `### Jira Field Defaults` from CLAUDE.md to pre-select defaults and control prompt visibility
- Update Step 5 preview to display selected priority and fixVersion
- Update Step 6.2 to include priority and fixVersions in `additional_fields` when selected
- Add eval 7 for config-driven prompt suppression, update evals 1 and 2 with priority/fixVersion assertions

Implements [TC-4873](https://redhat.atlassian.net/browse/TC-4873)

## Test plan

- [ ] Run eval 1 — verify priority 'Major' and fixVersion '1.5.0' appear in preview and create call
- [ ] Run eval 2 — verify skipped priority/fixVersion show 'Not set' and are omitted from create call
- [ ] Run eval 7 — verify Jira Field Defaults suppresses prompts and applies default priority silently
- [ ] Validate plugin with `claude plugin validate plugins/sdlc-workflow`
- [ ] Manual smoke test: run `/sdlc-workflow:define-feature` and verify priority/fixVersion prompts appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add configurable priority and fixVersion metadata handling to the define-feature Jira workflow, including prompting, preview, and issue creation integration.

New Features:
- Introduce an interactive step to select Jira priority and fixVersion for new Features, driven by Jira metadata and project defaults.
- Allow projects to configure default Jira priority and prompt visibility via a Jira Field Defaults section in CLAUDE.md.

Enhancements:
- Display selected priority and fixVersion in the Feature creation preview and propagate them into Jira issue additional_fields and REST fallback calls when set.

Tests:
- Extend define-feature evals to assert priority and fixVersion behavior and add a CLAUDE.md fixture covering Jira Field Defaults-driven prompt suppression.