### PR TITLE
fix(jira-client): sanitize ADF taskList/taskItem nodes to prevent INVALID_INPUT errors

### DIFF
--- a/plugins/sdlc-workflow/scripts/jira-client.py
+++ b/plugins/sdlc-workflow/scripts/jira-client.py
@@ -394,6 +394,35 @@ def parse_inline_formatting(text: str) -> List[Dict[str, Any]]:
     return nodes if nodes else [{"type": "text", "text": text}]
 
 
+def sanitize_adf(doc: Dict[str, Any]) -> Dict[str, Any]:
+    """Sanitize ADF by converting taskList/taskItem nodes to bulletList/listItem.
+
+    The Jira ADF spec requires a localId attribute on taskList and taskItem nodes,
+    but LLMs frequently omit it. Converting to bulletList/listItem avoids the
+    requirement entirely and prevents 400 INVALID_INPUT errors.
+
+    Args:
+        doc: ADF document to sanitize
+
+    Returns:
+        Sanitized ADF document (modified in place and returned)
+    """
+    def walk(node: Dict[str, Any]) -> None:
+        if node.get("type") == "taskList":
+            node["type"] = "bulletList"
+            node.pop("attrs", None)
+        elif node.get("type") == "taskItem":
+            node["type"] = "listItem"
+            node.pop("attrs", None)
+
+        for child in node.get("content", []):
+            if isinstance(child, dict):
+                walk(child)
+
+    walk(doc)
+    return doc
+
+
 # =============================================================================
 # JIRA API Operations
 # =============================================================================
@@ -438,7 +467,7 @@ def create_issue(
         "fields": {
             "project": {"key": project_key},
             "summary": summary,
-            "description": markdown_to_adf(description_md),
+            "description": sanitize_adf(markdown_to_adf(description_md)),
             "issuetype": {"id": issue_type} if issue_type.isdigit() else {"name": issue_type},
         }
     }
@@ -479,7 +508,7 @@ def add_comment(issue_key: str, comment_md: str) -> Dict[str, Any]:
     Returns:
         Created comment object
     """
-    data = {"body": markdown_to_adf(comment_md)}
+    data = {"body": sanitize_adf(markdown_to_adf(comment_md))}
     return make_request('POST', f"issue/{issue_key}/comment", data)
 
 

--- a/plugins/sdlc-workflow/scripts/test_jira_client.py
+++ b/plugins/sdlc-workflow/scripts/test_jira_client.py
@@ -19,6 +19,7 @@ spec = importlib.util.spec_from_file_location("jira_client", jira_client_path)
 jira_client = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(jira_client)
 markdown_to_adf = jira_client.markdown_to_adf
+sanitize_adf = jira_client.sanitize_adf
 
 
 def test_code_block_with_blank_lines():
@@ -195,6 +196,189 @@ After"""
     print("✓ Horizontal rule test passed")
 
 
+def test_sanitize_adf_converts_tasklist_to_bulletlist():
+    """Verifies that taskList/taskItem nodes without localId are converted to bulletList/listItem."""
+    # Given an ADF document with taskList/taskItem nodes missing localId
+    doc = {
+        "type": "doc",
+        "version": 1,
+        "content": [
+            {
+                "type": "taskList",
+                "content": [
+                    {
+                        "type": "taskItem",
+                        "attrs": {"state": "TODO"},
+                        "content": [{"type": "text", "text": "First criterion"}]
+                    },
+                    {
+                        "type": "taskItem",
+                        "attrs": {"state": "TODO"},
+                        "content": [{"type": "text", "text": "Second criterion"}]
+                    }
+                ]
+            }
+        ]
+    }
+
+    # When sanitizing the ADF
+    result = sanitize_adf(doc)
+
+    # Then taskList becomes bulletList and taskItems become listItems
+    list_node = result["content"][0]
+    assert list_node["type"] == "bulletList", f"Expected bulletList, got {list_node['type']}"
+    assert "attrs" not in list_node, "bulletList should not have attrs"
+
+    for item in list_node["content"]:
+        assert item["type"] == "listItem", f"Expected listItem, got {item['type']}"
+        assert "attrs" not in item, "listItem should not have attrs"
+
+    assert list_node["content"][0]["content"][0]["text"] == "First criterion"
+    assert list_node["content"][1]["content"][0]["text"] == "Second criterion"
+
+    print("✓ sanitize_adf converts taskList to bulletList test passed")
+
+
+def test_sanitize_adf_preserves_content():
+    """Verifies that taskItem inner content (paragraph and text nodes) is preserved."""
+    # Given a taskItem with nested paragraph content
+    doc = {
+        "type": "doc",
+        "version": 1,
+        "content": [
+            {
+                "type": "taskList",
+                "content": [
+                    {
+                        "type": "taskItem",
+                        "attrs": {"state": "TODO"},
+                        "content": [
+                            {
+                                "type": "paragraph",
+                                "content": [
+                                    {"type": "text", "text": "Bold text", "marks": [{"type": "strong"}]},
+                                    {"type": "text", "text": " and normal text"}
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+    # When sanitizing
+    result = sanitize_adf(doc)
+
+    # Then inner content is preserved
+    item = result["content"][0]["content"][0]
+    para = item["content"][0]
+    assert para["type"] == "paragraph"
+    assert para["content"][0]["text"] == "Bold text"
+    assert para["content"][0]["marks"] == [{"type": "strong"}]
+    assert para["content"][1]["text"] == " and normal text"
+
+    print("✓ sanitize_adf preserves content test passed")
+
+
+def test_sanitize_adf_handles_nested_tasklist():
+    """Verifies that nested taskList inside other ADF containers is recursively sanitized."""
+    # Given a taskList nested inside a panel
+    doc = {
+        "type": "doc",
+        "version": 1,
+        "content": [
+            {
+                "type": "panel",
+                "attrs": {"panelType": "info"},
+                "content": [
+                    {
+                        "type": "taskList",
+                        "content": [
+                            {
+                                "type": "taskItem",
+                                "attrs": {"state": "TODO"},
+                                "content": [{"type": "text", "text": "Nested item"}]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+    # When sanitizing
+    result = sanitize_adf(doc)
+
+    # Then the nested taskList is also converted
+    panel = result["content"][0]
+    assert panel["type"] == "panel", "Panel should remain unchanged"
+    nested_list = panel["content"][0]
+    assert nested_list["type"] == "bulletList", f"Expected bulletList, got {nested_list['type']}"
+    assert nested_list["content"][0]["type"] == "listItem"
+
+    print("✓ sanitize_adf handles nested taskList test passed")
+
+
+def test_sanitize_adf_noop_for_bulletlist():
+    """Verifies that ADF with only bulletList/listItem passes through unchanged."""
+    # Given an ADF document with standard bulletList
+    doc = {
+        "type": "doc",
+        "version": 1,
+        "content": [
+            {
+                "type": "bulletList",
+                "content": [
+                    {
+                        "type": "listItem",
+                        "content": [
+                            {
+                                "type": "paragraph",
+                                "content": [{"type": "text", "text": "Already a bullet"}]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+    import copy
+    original = copy.deepcopy(doc)
+
+    # When sanitizing
+    result = sanitize_adf(doc)
+
+    # Then the document is unchanged
+    assert result == original, "bulletList document should pass through unchanged"
+
+    print("✓ sanitize_adf no-op for bulletList test passed")
+
+
+def test_create_issue_adf_has_no_tasklist():
+    """Verifies that create_issue() output ADF contains no taskList/taskItem nodes."""
+    # Given markdown with checkbox-style items (the format that triggers the bug)
+    md = "## Acceptance Criteria\n\n- [ ] First criterion\n- [ ] Second criterion"
+
+    # When converting to ADF (same path as create_issue)
+    adf = sanitize_adf(markdown_to_adf(md))
+
+    # Then no taskList or taskItem nodes should exist anywhere in the tree
+    def find_node_types(node):
+        types = {node.get("type")}
+        for child in node.get("content", []):
+            if isinstance(child, dict):
+                types.update(find_node_types(child))
+        return types
+
+    all_types = find_node_types(adf)
+    assert "taskList" not in all_types, "ADF should not contain taskList nodes"
+    assert "taskItem" not in all_types, "ADF should not contain taskItem nodes"
+
+    print("✓ create_issue ADF has no taskList test passed")
+
+
 def run_all_tests():
     """Run all tests and report results."""
     tests = [
@@ -205,6 +389,11 @@ def run_all_tests():
         test_multiple_code_blocks,
         test_nested_structures,
         test_horizontal_rule,
+        test_sanitize_adf_converts_tasklist_to_bulletlist,
+        test_sanitize_adf_preserves_content,
+        test_sanitize_adf_handles_nested_tasklist,
+        test_sanitize_adf_noop_for_bulletlist,
+        test_create_issue_adf_has_no_tasklist,
     ]
 
     failed = []


### PR DESCRIPTION
## Summary

- Add `sanitize_adf()` function in `jira-client.py` that converts `taskList`/`taskItem` ADF nodes to `bulletList`/`listItem` nodes, preventing 400 INVALID_INPUT errors from Jira when the LLM generates checkbox-style lists without the required `localId` attribute
- Integrate `sanitize_adf()` into both `create_issue()` and `add_comment()` code paths
- Add 5 new unit tests covering the reproducer case, content preservation, nested containers, no-op for valid ADF, and integration-level assertion

Implements [TC-4930](https://redhat.atlassian.net/browse/TC-4930)

## Test plan

- [x] Reproducer test: ADF with `taskList`/`taskItem` nodes without `localId` → converted to `bulletList`/`listItem`
- [x] Content preservation: paragraph/text/marks inside `taskItem` are retained after conversion
- [x] Nested containers: `taskList` inside a `panel` is recursively sanitized
- [x] No-op: ADF with only `bulletList`/`listItem` passes through unchanged
- [x] Integration: `create_issue()` output ADF contains no `taskList`/`taskItem` nodes
- [x] All 7 existing tests pass (no regressions)

## Summary by Sourcery

Sanitize Jira ADF payloads to avoid INVALID_INPUT errors when checkbox-style lists are generated and ensure coverage with new tests.

Bug Fixes:
- Convert taskList/taskItem ADF nodes to bulletList/listItem to avoid Jira 400 INVALID_INPUT errors due to missing localId attributes in LLM-generated content.
- Apply ADF sanitization to issue descriptions and comments produced by markdown_to_adf before sending them to Jira.

Tests:
- Add unit tests validating taskList/taskItem conversion, content preservation, nested container handling, no-op behavior for already valid bullet lists, and absence of taskList/taskItem nodes in create_issue() ADF output.