### PR TITLE
feat(triage-security): add description digest to remediation tasks

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -75,6 +75,7 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 1.63 | `plan-feature` MUST map issue types to hierarchy roles by `hierarchyLevel` field, not by type name. | `plan-feature/SKILL.md` — Step 2.5 |
 | 1.64 | `plan-feature` MUST fall back to Feature → Task hierarchy when no level-1 type exists, without error. | `plan-feature/SKILL.md` — Step 2.5 |
 | 1.65 | `triage-security` MUST query MITRE CVE API and OSV.dev for structured version ranges in Step 1.5 and use them as the primary fix threshold source when available, falling back to Jira description data only when external APIs are unavailable. | `triage-security/SKILL.md` — Step 1.5, `triage-security/version-impact-analysis.md` — Step 2.3 |
+| 1.66 | `triage-security` MUST post a description digest comment on each remediation task immediately after creation per `shared/description-digest-protocol.md`, before creating issue links or other comments. | `triage-security/SKILL.md` — Remediation Task Creation, `triage-security/remediation-templates.md` — Jira Issue Creation |
 
 ### Prior Art — Cross-phase integrity (§1.33–1.35)
 
@@ -168,7 +169,8 @@ Each constraint above references its source. The full source files are:
 - `plugins/sdlc-workflow/skills/define-feature/SKILL.md` — Guardrails (§1.7–1.8), Important Rules (§1.9)
 - `plugins/sdlc-workflow/skills/report-bug/SKILL.md` — Guardrails (§1.50–1.51), Step 4 Preview and Confirm (§1.52)
 - `plugins/sdlc-workflow/skills/triage-bug/SKILL.md` — Guardrails (§1.53–1.54), Step 5 Front-load reproducer test (§1.55), Step 4 Post root cause comment (§1.56), Step 6 Decomposition Guard (§1.57)
-- `plugins/sdlc-workflow/skills/triage-security/SKILL.md` — Guardrails (§1.37, §1.38, §1.47), Step 0 (§1.49), Step 1 Ecosystem detection (§1.48), Step 1 Data Extraction (§1.49), Step 1.5 External CVE Data Enrichment (§1.62), Step 2.1 (§1.47), Step 2.2 (§1.42), Step 2.3 (§1.48), Step 2.4 (§1.44), Step 7 (§1.43), Step 7 Case B (§1.61), Important Rules (§1.38–§1.43, §1.45, §1.46), Remediation Task Creation (§1.46)
+- `plugins/sdlc-workflow/skills/triage-security/SKILL.md` — Guardrails (§1.37, §1.38, §1.47), Step 0 (§1.49), Step 1 Ecosystem detection (§1.48), Step 1 Data Extraction (§1.49), Step 1.5 External CVE Data Enrichment (§1.62), Step 2.1 (§1.47), Step 2.2 (§1.42), Step 2.3 (§1.48), Step 2.4 (§1.44), Step 7 (§1.43), Step 7 Case B (§1.61), Important Rules (§1.38–§1.43, §1.45, §1.46), Remediation Task Creation (§1.46, §1.66)
 - `plugins/sdlc-workflow/skills/triage-security/version-impact-analysis.md` — Step 2.3 enriched fix threshold (§1.62)
+- `plugins/sdlc-workflow/skills/triage-security/remediation-templates.md` — Jira Issue Creation digest comment (§1.66)
 - `plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md` — Step 4.2 Idempotent sibling linking (§1.58), Step 4.3 Cross-CVE overlap detection (§1.59), Step 4.4 Proactive reconciliation (§1.61)
 - `docs/methodology.md` — Core Principles (§2.1, §3.2, §5.5)

--- a/evals/triage-security/evals.json
+++ b/evals/triage-security/evals.json
@@ -161,6 +161,19 @@
         "Step 1.5 cross-validation shows agreement between MITRE and OSV.dev — the enriched fix threshold (0.4.8) is used as the authoritative value for Step 2.3",
         "Step 2.3 version impact comparison uses the enriched fix threshold (0.4.8) from Step 1.5, not the imprecise Jira description data"
       ]
+    },
+    {
+      "id": 13,
+      "prompt": "Triage Vulnerability issue TC-8001. The issue details are in vuln-issue-standard.md, the security matrix is in security-matrix-mock.md, and the project CLAUDE.md is in claude-md-security-config.md. Do NOT actually call Jira MCP, git show, or any external tools. Instead, write your triage analysis to the workspace outputs/ directory: write outputs/data-extraction.md with the parsed CVE data table from Step 1, write outputs/version-impact.md with the version impact table from Step 2, and write outputs/remediation.md with the remediation task descriptions AND the description digest comment steps you would perform after creating each task.",
+      "expected_output": "A triage analysis demonstrating the full remediation flow including description digest comments. After each jira.create_issue call, the skill re-fetches the created task description, computes a SHA-256 digest using scripts/sha256-digest.py, and posts a digest comment with the marker '[sdlc-workflow] Description digest:' before creating issue links or other comments.",
+      "files": ["files/vuln-issue-standard.md", "files/security-matrix-mock.md", "files/claude-md-security-config.md"],
+      "assertions": [
+        "After creating the upstream backport task, the skill re-fetches the task description from Jira and computes a SHA-256 digest using scripts/sha256-digest.py (§1.66)",
+        "After creating the downstream propagation subtask, the skill re-fetches the task description and computes a SHA-256 digest using scripts/sha256-digest.py (§1.66)",
+        "A digest comment with marker '[sdlc-workflow] Description digest:' is posted on each remediation task — both upstream and downstream (§1.66)",
+        "Digest comments are posted BEFORE creating issue links (Depend, Blocks) or other comments on the tasks (§1.66, shared/description-digest-protocol.md Rules)",
+        "The digest is computed using scripts/sha256-digest.py with the re-fetched description, not the description string passed to create_issue (shared/description-digest-protocol.md Hashing)"
+      ]
     }
   ]
 }

--- a/plugins/sdlc-workflow/skills/triage-security/SKILL.md
+++ b/plugins/sdlc-workflow/skills/triage-security/SKILL.md
@@ -533,8 +533,13 @@ When triage concludes "needs fix" (Case A above), create Jira Tasks
 following `task-description-template.md` so that `/implement-task` can parse them
 directly. Only create tasks for streams within the current issue's scope.
 
+After creating each remediation task, post a description digest comment per
+`shared/description-digest-protocol.md`. This ensures `/implement-task` can
+verify description integrity in its Step 1.5.
+
 Read `remediation-templates.md` for the full task description templates, Jira
-issue creation API calls, and linkage procedures. The key distinction:
+issue creation API calls, digest comment procedures, and linkage procedures.
+The key distinction:
 
 - **Source dependency ecosystems** (Cargo, npm, Go modules): create **two** tasks —
   an upstream backport task (fix in the source repo) and a downstream propagation

--- a/plugins/sdlc-workflow/skills/triage-security/remediation-templates.md
+++ b/plugins/sdlc-workflow/skills/triage-security/remediation-templates.md
@@ -189,6 +189,10 @@ These depend on repository structure that the triage skill does not have context
 
 ## Jira Issue Creation
 
+After creating each remediation task, post a description digest comment per
+`shared/description-digest-protocol.md`. The digest comment MUST be posted
+before creating issue links or other comments on the task.
+
 ### Source dependency ecosystems — create two tasks:
 
 ```
@@ -201,6 +205,12 @@ upstream_task = jira.create_issue(
   labels: ["ai-generated-jira", "Security", "<CVE-ID>"]
 )
 
+# 1a. Post description digest comment (before links or other comments)
+upstream_desc = jira.get_issue(<upstream-task-key>, fields=["description"])
+# Write description to temp file and compute digest
+python3 scripts/sha256-digest.py /tmp/task-desc.md  # → sha256-md:<hex> or sha256-adf:<hex>
+jira.add_comment(<upstream-task-key>, "[sdlc-workflow] Description digest: <tagged-digest>")
+
 # 2. Downstream propagation subtask
 downstream_task = jira.create_issue(
   projectKey: "<project-key>",
@@ -209,6 +219,11 @@ downstream_task = jira.create_issue(
   description: <downstream-task-description>,
   labels: ["ai-generated-jira", "Security", "<CVE-ID>"]
 )
+
+# 2a. Post description digest comment (before links or other comments)
+downstream_desc = jira.get_issue(<downstream-task-key>, fields=["description"])
+python3 scripts/sha256-digest.py /tmp/task-desc.md
+jira.add_comment(<downstream-task-key>, "[sdlc-workflow] Description digest: <tagged-digest>")
 ```
 
 ### System package ecosystems — create one task:
@@ -221,6 +236,11 @@ task = jira.create_issue(
   description: <system-package-task-description>,
   labels: ["ai-generated-jira", "Security", "<CVE-ID>"]
 )
+
+# Post description digest comment (before links or other comments)
+task_desc = jira.get_issue(<task-key>, fields=["description"])
+python3 scripts/sha256-digest.py /tmp/task-desc.md
+jira.add_comment(<task-key>, "[sdlc-workflow] Description digest: <tagged-digest>")
 ```
 
 ## Preemptive Task Variant
@@ -274,6 +294,11 @@ upstream_task = jira.create_issue(
   labels: ["ai-generated-jira", "Security", "<CVE-ID>", "security-preemptive"]
 )
 
+# Post description digest comment (before links or other comments)
+upstream_desc = jira.get_issue(<upstream-task-key>, fields=["description"])
+python3 scripts/sha256-digest.py /tmp/task-desc.md
+jira.add_comment(<upstream-task-key>, "[sdlc-workflow] Description digest: <tagged-digest>")
+
 # System package ecosystems — preemptive variant
 task = jira.create_issue(
   projectKey: "<project-key>",
@@ -282,11 +307,16 @@ task = jira.create_issue(
   description: <system-package-task-description-with-preemptive-prefix>,
   labels: ["ai-generated-jira", "Security", "<CVE-ID>", "security-preemptive"]
 )
+
+# Post description digest comment (before links or other comments)
+task_desc = jira.get_issue(<task-key>, fields=["description"])
+python3 scripts/sha256-digest.py /tmp/task-desc.md
+jira.add_comment(<task-key>, "[sdlc-workflow] Description digest: <tagged-digest>")
 ```
 
 Downstream propagation subtasks (for source dependency ecosystems) also receive
-the `security-preemptive` label and use the same "Related" link to the
-originating CVE Jira.
+the `security-preemptive` label, the description digest comment, and use the
+same "Related" link to the originating CVE Jira.
 
 ## Jira Linkage
 


### PR DESCRIPTION
## Summary

- Add description digest comment step to triage-security's remediation task creation flow per `shared/description-digest-protocol.md`
- After each `jira.create_issue` call, the skill re-fetches the description, computes a SHA-256 digest using `scripts/sha256-digest.py`, and posts a digest comment before creating issue links
- Add constraint §1.66 and eval case 13 for the new behavior

Implements [TC-4857](https://redhat.atlassian.net/browse/TC-4857)

## Test plan

- [ ] Existing eval cases 1–12 pass without modification
- [ ] New eval case 13 validates digest comment step in remediation flow
- [ ] Run `/sdlc-workflow:run-evals triage-security` to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the requirement for triage-security to post a description digest comment on each remediation Jira task immediately after creation, and add the corresponding constraint reference and evaluations coverage.

Enhancements:
- Extend triage-security remediation templates and SKILL documentation to include description digest comments for all remediation and preemptive Jira tasks, ensuring they precede links and other comments.

Documentation:
- Add constraint §1.66 describing the description digest comment requirement for triage-security remediation tasks and reference it from the relevant documentation sources.

Tests:
- Update triage-security evals to add coverage for the new description digest comment behavior in the remediation flow.