### PR TITLE
fix(fullsend): add role field to verify-pr harness

### DIFF
--- a/plugins/sdlc-workflow/harness/verify-pr.yaml
+++ b/plugins/sdlc-workflow/harness/verify-pr.yaml
@@ -1,3 +1,4 @@
+role: verify-pr
 agent: agents/verify-pr.md
 model: opus
 image: ghcr.io/mrizzi/sdlc-plugins/sdlc-base:latest-run-in-fullsend


### PR DESCRIPTION
## Summary

Add `role: verify-pr` to the harness config. Required by fullsend Phase 4 which moved role/slug from config.yaml's agents block into each harness file.

Breaking change in latest fullsend release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Update verify-pr harness configuration to include the required role field for fullsend Phase 4.