### PR TITLE
feat(triage-security): add optional SBOM-based base image verification via cosign

### DIFF
--- a/evals/triage-security/evals.json
+++ b/evals/triage-security/evals.json
@@ -68,7 +68,8 @@
         "Version impact table includes ALL versions from the 2.2.x stream supportability matrix (2.2.0 through 2.2.4) and uses rpms.lock.yaml data for version extraction (Step 2.3)",
         "Dependency chain context classifies the package origin as explicit install because openssl-libs is present in rpms.lock.yaml, not inherited from the base image (Step 2.3.5)",
         "Remediation creates a single task for the Konflux release repo — not the two-task upstream backport + downstream propagation flow used for source dependency ecosystems (Step 7 Remediation Task Creation — system package path)",
-        "Remediation task description follows task-description-template.md format with Repository, Target Branch, Description, Implementation Notes, and Acceptance Criteria sections — Files to Modify is intentionally omitted per remediation-templates.md (Step 7 Remediation Task Creation)"
+        "Remediation task description follows task-description-template.md format with Repository, Target Branch, Description, Implementation Notes, and Acceptance Criteria sections — Files to Modify is intentionally omitted per remediation-templates.md (Step 7 Remediation Task Creation)",
+        "Dependency chain context includes an SBOM verification line — either showing the cosign comparison result or noting that SBOM verification was skipped because cosign is not available (Step 2.3.5 Optional SBOM verification)"
       ]
     },
     {
@@ -174,6 +175,19 @@
         "A digest comment with marker '[sdlc-workflow] Description digest:' is posted on each remediation task — both upstream and downstream (§1.66)",
         "Digest comments are posted BEFORE creating issue links (Depend, Blocks) or other comments on the tasks (§1.66, shared/description-digest-protocol.md Rules)",
         "The digest is computed using scripts/sha256-digest.py with the re-fetched description, not the description string passed to create_issue (shared/description-digest-protocol.md Hashing)"
+      ]
+    },
+    {
+      "id": 14,
+      "prompt": "Triage Vulnerability issue TC-8005. The issue details are in vuln-issue-rpm.md, the security matrix is in security-matrix-mock.md, and the project CLAUDE.md is in claude-md-security-config.md. The issue has stream suffix [rhtpa-2.2] so triage is scoped to the 2.2.x stream. Assume cosign IS available (which cosign returns /usr/bin/cosign). Use the following mock SBOM comparison results for the affected versions: for versions 2.2.0 through 2.2.2, openssl-libs appears in BOTH the final image SBOM and the base image SBOM (confirming base image origin); the rpms.lock.yaml for these versions also lists openssl-libs (explicit install). This means the SBOM classification DISAGREES with the rpms.lock.yaml classification for these versions. Do NOT actually call Jira MCP, git show, cosign, or any external tools. Instead, write your triage analysis to the workspace outputs/ directory: write outputs/data-extraction.md with the parsed CVE data table from Step 1, write outputs/version-impact.md with the version impact table from Step 2, and write outputs/sbom-verification.md with the SBOM verification results from Step 2.3.5 showing both rpms.lock.yaml and SBOM signals side by side.",
+      "expected_output": "A triage analysis for an RPM system package (openssl-libs) where cosign SBOM verification is available. The dependency chain output presents both rpms.lock.yaml classification (explicit install) and SBOM comparison result (base image) side by side. Because the two signals disagree, the discrepancy is flagged to the engineer for manual investigation.",
+      "files": ["files/vuln-issue-rpm.md", "files/security-matrix-mock.md", "files/claude-md-security-config.md"],
+      "assertions": [
+        "Dependency chain output includes both the rpms.lock.yaml classification AND the SBOM verification result for the affected versions (Step 2.3.5 Optional SBOM verification)",
+        "SBOM verification uses cosign download sbom to compare the final container image SBOM against the base image SBOM (Step 2.3.5 sub-steps 2 and 4)",
+        "When SBOM classification (base image) disagrees with rpms.lock.yaml classification (explicit install), the discrepancy is flagged to the engineer with a warning (Step 2.3.5 sub-step 5 disagreement handling)",
+        "The rpms.lock.yaml classification remains the primary signal — the SBOM result supplements but does not override it (Step 2.3.5 non-MVP enhancement)",
+        "The SBOM verification result is presented alongside the rpms.lock.yaml result in the dependency chain output, not as a separate section (Step 2.3.5 sub-step 6)"
       ]
     },
     {

--- a/plugins/sdlc-workflow/skills/triage-security/version-impact-analysis.md
+++ b/plugins/sdlc-workflow/skills/triage-security/version-impact-analysis.md
@@ -226,7 +226,45 @@ for the stream.
    - **In a `dnf install` / `yum install` command** → **explicit install**.
    - **Not in any install command** → **base image**.
 
-3. **Base image reference** (when origin is base image) — extract the `FROM`
+3. **Optional SBOM verification** (requires cosign CLI) — when available, compare
+   the final container image SBOM against the base image SBOM to cross-check the
+   rpms.lock.yaml classification. This step supplements but does not replace the
+   lock file classification above.
+
+   1. Check if `cosign` is available:
+      ```bash
+      which cosign
+      ```
+   2. If available, download the final image SBOM using the image reference and
+      digest from the supportability matrix:
+      ```bash
+      cosign download sbom <image-reference>@<image-digest> > /tmp/final-sbom.json
+      ```
+   3. Extract the base image reference from the Dockerfile's `FROM` line (already
+      available from the classification step above).
+   4. Download the base image SBOM:
+      ```bash
+      cosign download sbom <base-image-reference> > /tmp/base-sbom.json
+      ```
+   5. Compare the package presence in both SBOMs:
+      - **In final SBOM but NOT in base SBOM** → explicit install (confirms
+        rpms.lock.yaml classification of "in lock file")
+      - **In both SBOMs** → base image package (confirms rpms.lock.yaml
+        classification of "not in lock file")
+      - **If SBOM result disagrees with rpms.lock.yaml classification**, flag the
+        discrepancy to the engineer:
+        > "⚠️ SBOM classification disagrees with rpms.lock.yaml — lock file says
+        > [explicit install / base image] but SBOM comparison says [base image /
+        > explicit install]. Investigate manually."
+   6. Present the SBOM classification result alongside the rpms.lock.yaml result
+      in the dependency chain output (see example output below).
+
+   If `cosign` is not available or any SBOM download fails, skip with a warning
+   and use the rpms.lock.yaml classification alone:
+   > "⚠️ SBOM verification skipped — cosign not available / SBOM download failed.
+   > Using rpms.lock.yaml classification only."
+
+4. **Base image reference** (when origin is base image) — extract the `FROM`
    reference from the Dockerfile to identify the update path:
    ```bash
    git show <commit>:Dockerfile | grep -i '^FROM'
@@ -250,20 +288,39 @@ for the stream.
    depends on the base image vendor's errata pipeline. Include the current reference
    in the remediation task so the engineer or `/implement-task` can research it.
 
-4. **Introduction point** — check if the package origin differs across versions
+5. **Introduction point** — check if the package origin differs across versions
    (e.g., moved from explicit install to base image inheritance between streams).
 
-Example output (RPM, base image origin):
+Example output (RPM, base image origin with SBOM verification):
 ```
 Dependency chain for openssl (RPM):
   SBOM confirms: openssl-libs-3.0.7-27.el9.x86_64
   rpms.lock.yaml: NOT present → base image
+  SBOM verification: present in both final and base image SBOMs → base image (confirms lock file)
   Dockerfile: FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4-1227
   Origin: base image (openssl-libs inherited from ubi9-minimal)
   Pinning: version tag (9.4-1227)
 
 Remediation: update base image tag to a version with patched openssl.
 Check base image errata or container catalog for available updates.
+```
+
+Example output (RPM, explicit install with SBOM verification):
+```
+Dependency chain for custom-rpm (RPM):
+  rpms.lock.yaml: present → explicit install
+  SBOM verification: present in final SBOM but NOT in base image SBOM → explicit install (confirms lock file)
+  Origin: explicit install (custom-rpm specified in rpms.in.yaml)
+
+Remediation: update the package spec in rpms.in.yaml / rpms.lock.yaml.
+```
+
+Example output (RPM, SBOM verification skipped):
+```
+Dependency chain for openssl (RPM):
+  rpms.lock.yaml: NOT present → base image
+  SBOM verification: ⚠️ skipped — cosign not available
+  Origin: base image (openssl-libs inherited from ubi9-minimal)
 ```
 
 Note that the lock file contents and base image can differ across streams — always


### PR DESCRIPTION
## Summary

- Add optional cosign SBOM comparison step to Step 2.3.5 (Container-level dependencies) in `version-impact-analysis.md` that cross-checks rpms.lock.yaml classification against base image SBOM data
- Flag discrepancies between lock file and SBOM classifications to the engineer for manual investigation
- Gracefully degrade when cosign is unavailable with a warning message
- Add eval case 14 for RPM triage with SBOM verification and extend eval case 5 with SBOM assertion

Implements [TC-4855](https://redhat.atlassian.net/browse/TC-4855)

## Test plan

- [ ] Existing eval cases 1–13 continue to pass without modification
- [ ] New eval case 14 validates SBOM verification with disagreement scenario
- [ ] Plugin validation passes (`claude plugin validate plugins/sdlc-workflow`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add optional SBOM-based verification using cosign to cross-check RPM origin classification in container dependency triage and surface its results in example outputs.

New Features:
- Introduce an optional cosign-based SBOM comparison step to validate rpms.lock.yaml classifications for container RPM dependencies.
- Display SBOM verification results alongside lock file data in dependency chain outputs, including explicit install and base image scenarios.

Enhancements:
- Gracefully skip SBOM verification with a warning when cosign is unavailable or SBOM downloads fail.

Tests:
- Add a new triage-security eval case covering RPM triage with SBOM verification and extend an existing eval case with SBOM assertions.