### PR TITLE
feat(triage-security): add ProdSec contact config and vulnerability creator @mention

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -76,6 +76,8 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 1.64 | `plan-feature` MUST fall back to Feature → Task hierarchy when no level-1 type exists, without error. | `plan-feature/SKILL.md` — Step 2.5 |
 | 1.65 | `triage-security` MUST query MITRE CVE API and OSV.dev for structured version ranges in Step 1.5 and use them as the primary fix threshold source when available, falling back to Jira description data only when external APIs are unavailable. | `triage-security/SKILL.md` — Step 1.5, `triage-security/version-impact-analysis.md` — Step 2.3 |
 | 1.66 | `triage-security` MUST post a description digest comment on each remediation task immediately after creation per `shared/description-digest-protocol.md`, before creating issue links or other comments. | `triage-security/SKILL.md` — Remediation Task Creation, `triage-security/remediation-templates.md` — Jira Issue Creation |
+| 1.67 | `triage-security` MUST @mention the vulnerability issue's reporter in the Step 7 summary comment by default (no configuration required — uses the reporter field from the Jira issue). | `triage-security/SKILL.md` — Post-Triage Summary |
+| 1.68 | `triage-security` MUST @mention the configured ProdSec Jira account in Affects Versions correction (Step 3) and cross-CVE overlap (Step 4.3) comments when a ProdSec Jira account ID is present in Security Configuration, and MUST skip the mention silently when not configured. | `triage-security/SKILL.md` — Step 0, `triage-security/jira-triage-operations.md` — Steps 3, 4.3 |
 
 ### Prior Art — Cross-phase integrity (§1.33–1.35)
 
@@ -169,8 +171,8 @@ Each constraint above references its source. The full source files are:
 - `plugins/sdlc-workflow/skills/define-feature/SKILL.md` — Guardrails (§1.7–1.8), Important Rules (§1.9)
 - `plugins/sdlc-workflow/skills/report-bug/SKILL.md` — Guardrails (§1.50–1.51), Step 4 Preview and Confirm (§1.52)
 - `plugins/sdlc-workflow/skills/triage-bug/SKILL.md` — Guardrails (§1.53–1.54), Step 5 Front-load reproducer test (§1.55), Step 4 Post root cause comment (§1.56), Step 6 Decomposition Guard (§1.57)
-- `plugins/sdlc-workflow/skills/triage-security/SKILL.md` — Guardrails (§1.37, §1.38, §1.47), Step 0 (§1.49), Step 1 Ecosystem detection (§1.48), Step 1 Data Extraction (§1.49), Step 1.5 External CVE Data Enrichment (§1.62), Step 2.1 (§1.47), Step 2.2 (§1.42), Step 2.3 (§1.48), Step 2.4 (§1.44), Step 7 (§1.43), Step 7 Case B (§1.61), Important Rules (§1.38–§1.43, §1.45, §1.46), Remediation Task Creation (§1.46, §1.66)
+- `plugins/sdlc-workflow/skills/triage-security/SKILL.md` — Guardrails (§1.37, §1.38, §1.47), Step 0 (§1.49, §1.68), Step 1 Ecosystem detection (§1.48), Step 1 Data Extraction (§1.49), Step 1.5 External CVE Data Enrichment (§1.62), Step 2.1 (§1.47), Step 2.2 (§1.42), Step 2.3 (§1.48), Step 2.4 (§1.44), Step 7 (§1.43), Step 7 Case B (§1.61), Post-Triage Summary (§1.67), Important Rules (§1.38–§1.43, §1.45, §1.46), Remediation Task Creation (§1.46, §1.66)
 - `plugins/sdlc-workflow/skills/triage-security/version-impact-analysis.md` — Step 2.3 enriched fix threshold (§1.62)
 - `plugins/sdlc-workflow/skills/triage-security/remediation-templates.md` — Jira Issue Creation digest comment (§1.66)
-- `plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md` — Step 4.2 Idempotent sibling linking (§1.58), Step 4.3 Cross-CVE overlap detection (§1.59), Step 4.4 Proactive reconciliation (§1.61)
+- `plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md` — Step 3 ProdSec @mention (§1.68), Step 4.2 Idempotent sibling linking (§1.58), Step 4.3 Cross-CVE overlap detection (§1.59), Step 4.3 ProdSec @mention (§1.68), Step 4.4 Proactive reconciliation (§1.61)
 - `docs/methodology.md` — Core Principles (§2.1, §3.2, §5.5)

--- a/evals/triage-security/evals.json
+++ b/evals/triage-security/evals.json
@@ -174,6 +174,19 @@
         "Digest comments are posted BEFORE creating issue links (Depend, Blocks) or other comments on the tasks (§1.66, shared/description-digest-protocol.md Rules)",
         "The digest is computed using scripts/sha256-digest.py with the re-fetched description, not the description string passed to create_issue (shared/description-digest-protocol.md Hashing)"
       ]
+    },
+    {
+      "id": 15,
+      "prompt": "Triage Vulnerability issue TC-8001. The issue details are in vuln-issue-standard.md, the security matrix is in security-matrix-mock.md, and the project CLAUDE.md is in claude-md-security-config-prodsec.md. Note that the CLAUDE.md includes ProdSec contact configuration (ProdSec contact email: prodsec-team@example.com, ProdSec Jira account ID: 557058:prodsec-mock-account-id). The Vulnerability issue was reported by user 'psirt-analyst' with Jira account ID '557058:psirt-analyst-mock-id'. Do NOT actually call Jira MCP, git show, or any external tools. Instead, write your triage analysis to the workspace outputs/ directory: write outputs/data-extraction.md with the parsed CVE data table from Step 1, write outputs/version-impact.md with the version impact table from Step 2, write outputs/affects-versions.md with the Affects Versions correction comment from Step 3 including any @mentions, and write outputs/remediation.md with the post-triage summary comment from Step 7 including the reporter @mention.",
+      "expected_output": "A triage analysis demonstrating both @mention behaviors: (1) the post-triage summary comment in Step 7 includes an @mention of the vulnerability reporter (psirt-analyst, account ID 557058:psirt-analyst-mock-id) using an ADF mention node, and (2) the Affects Versions correction comment in Step 3 includes an @mention of the configured ProdSec contact (account ID 557058:prodsec-mock-account-id) using an ADF mention node.",
+      "files": ["files/vuln-issue-standard.md", "files/security-matrix-mock.md", "files/claude-md-security-config-prodsec.md"],
+      "assertions": [
+        "The post-triage summary comment (Step 7) includes an @mention of the vulnerability issue's reporter using an ADF mention node with account ID '557058:psirt-analyst-mock-id' (§1.67)",
+        "The reporter @mention in Step 7 is present by default without any ProdSec configuration — it uses the reporter field from the Jira issue (§1.67)",
+        "The Affects Versions correction comment (Step 3) includes an @mention of the ProdSec contact using an ADF mention node with account ID '557058:prodsec-mock-account-id' (§1.68)",
+        "The ProdSec @mention appears before the Comment Footnote in the Affects Versions correction comment (§1.68)",
+        "Step 0 extracts the ProdSec Jira account ID from the Security Configuration as an optional field without raising an error (Step 0 config validation)"
+      ]
     }
   ]
 }

--- a/evals/triage-security/files/claude-md-security-config-prodsec.md
+++ b/evals/triage-security/files/claude-md-security-config-prodsec.md
@@ -1,0 +1,66 @@
+<!-- SYNTHETIC TEST DATA — mock CLAUDE.md with Security Configuration including ProdSec contact for triage-security eval testing -->
+
+# rhtpa
+
+## Documentation
+
+- [docs/architecture.md](docs/architecture.md) — System architecture overview
+
+# Project Configuration
+
+## Repository Registry
+
+| Repository | Role | Serena Instance | Path |
+|---|---|---|---|
+| rhtpa-backend | Rust backend service | serena_backend | /home/dev/repos/rhtpa-backend |
+
+## Jira Configuration
+
+- Project key: TC
+- Cloud ID: 2b9e35e3-6bd3-4cec-b838-f4249ee02432
+- Feature issue type ID: 10142
+- Git Pull Request custom field: customfield_10875
+- GitHub Issue custom field: customfield_10747
+
+## Code Intelligence
+
+Serena MCP servers provide code intelligence for repository analysis.
+
+### Tool naming convention
+
+Tools are called as `mcp__<serena-instance>__<tool>`.
+
+### Configured instances
+
+| Serena Instance | Repository | Language Server |
+|---|---|---|
+| serena_backend | rhtpa-backend | rust-analyzer |
+
+### Limitations
+
+- rust-analyzer may take 30-60 seconds to index on first use
+
+## Security Configuration
+
+### Product Lifecycle
+
+- Product pages URL: https://access.example.com/product-life-cycle/rhtpa
+- Jira version prefix: RHTPA
+- Vulnerability issue type ID: 10024
+- Component label pattern: pscomponent:
+- VEX Justification custom field: customfield_12345
+- ProdSec contact email: prodsec-team@example.com
+- ProdSec Jira account ID: 557058:prodsec-mock-account-id
+
+### Version Streams
+
+| Stream | Konflux Release Repo | Local Path |
+|--------|----------------------|------------|
+| 2.1.x | git.example.com/rhtpa/rhtpa-release.0.3.z | /home/dev/repos/rhtpa-release.0.3.z |
+| 2.2.x | git.example.com/rhtpa/rhtpa-release.0.4.z | /home/dev/repos/rhtpa-release.0.4.z |
+
+### Source Repositories
+
+| Repository | URL | Local Path |
+|------------|-----|------------|
+| rhtpa-backend | https://github.com/rhtpa/rhtpa-backend | /home/dev/repos/rhtpa-backend |

--- a/plugins/sdlc-workflow/skills/setup/SKILL.md
+++ b/plugins/sdlc-workflow/skills/setup/SKILL.md
@@ -500,6 +500,22 @@ Ask the user for the following fields:
 
    If the user skips, leave the placeholder empty in the template.
 
+9. **ProdSec contact email** _(optional)_ — the email address of the Product Security
+   contact for this project. Used for informational reference in CVE triage
+   notifications. Ask the user:
+
+   > "ProdSec contact email (optional, for CVE triage notifications)?"
+
+   If the user skips, leave the placeholder empty in the template.
+
+10. **ProdSec Jira account ID** _(optional)_ — the Jira account ID of the ProdSec
+    contact. Used for @mentions in triage comments (Affects Versions corrections,
+    cross-CVE overlap notifications). Ask the user:
+
+    > "ProdSec Jira account ID (optional, for @mentions in triage comments)?"
+
+    If the user skips, leave the placeholder empty in the template.
+
 ### Step 10.2 – Collect Version Streams
 
 Ask the user for one or more version streams. For each stream, collect:

--- a/plugins/sdlc-workflow/skills/setup/security-config.template.md
+++ b/plugins/sdlc-workflow/skills/setup/security-config.template.md
@@ -33,6 +33,15 @@
        on Vulnerability issues (e.g., "customfield_10832"). Used together with the
        Upstream Affected Component field for cross-CVE overlap filtering.
 
+     Optional fields for security team notification:
+     - ProdSec contact email: the email address of the Product Security contact for
+       this project (e.g., "prodsec@example.com"). Used for informational reference
+       in CVE triage notifications. Leave blank if your project does not have a
+       dedicated security team.
+     - ProdSec Jira account ID: the Jira account ID of the ProdSec contact (e.g.,
+       "557058:abc123"). Used for @mentions in triage comments (Affects Versions
+       corrections, cross-CVE overlap notifications). Leave blank to skip @mentions.
+
      Example:
        Product pages URL: https://lifecycle.example.com/products/myproduct
        Jira version prefix: MYPRODUCT
@@ -51,6 +60,8 @@
 - Upstream Affected Component custom field: {{upstream-affected-component-field-id}}
 - PS Component custom field: {{ps-component-field-id}}
 - Stream custom field: {{stream-field-id}}
+- ProdSec contact email: {{prodsec-email}}
+- ProdSec Jira account ID: {{prodsec-jira-account-id}}
 
 ### Version Streams
 

--- a/plugins/sdlc-workflow/skills/triage-security/SKILL.md
+++ b/plugins/sdlc-workflow/skills/triage-security/SKILL.md
@@ -127,6 +127,11 @@ Extract the following from the configuration for use in later steps:
 - **Stream custom field** _(optional)_ — from Security Configuration (e.g.,
   `customfield_10832`). Used with the Upstream Affected Component field for cross-CVE
   overlap filtering in Step 4.3.
+- **ProdSec contact email** _(optional)_ — from Security Configuration. If configured,
+  used for informational reference in triage notifications. If not configured, skip silently.
+- **ProdSec Jira account ID** _(optional)_ — from Security Configuration. If configured,
+  used for @mentions in Affects Versions correction (Step 3) and cross-CVE overlap (Step 4.3)
+  comments. If not configured, skip @mentions silently.
 - **Version Streams** — Konflux release repo URLs and local paths from Security Configuration
 - **Source Repositories** — source repo names and URLs from Security Configuration
 
@@ -567,6 +572,14 @@ Add a summary comment to the original Vulnerability issue documenting:
 3. The triage outcome (closed or remediation created)
 4. Links to all remediation tasks created (upstream + downstream for source
    dependency ecosystems, or single task for system packages)
+5. An @mention of the vulnerability issue's reporter (the PSIRT analyst who
+   created it). Use the reporter's account ID from the Jira issue data extracted
+   in Step 1. Include an ADF mention node:
+   ```json
+   { "type": "mention", "attrs": { "id": "<reporter-account-id>", "text": "@<reporter-name>" } }
+   ```
+   This @mention is mandatory and requires no configuration — the reporter field
+   is always available on the Jira issue.
 
 This comment provides a complete audit trail for future reference. The comment
 MUST include the Comment Footnote (see above).

--- a/plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md
+++ b/plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md
@@ -85,12 +85,21 @@ Jira version in the Affects Versions correction. Unreleased versions are valid
 Affects Versions values — they track that the CVE must be fixed before the next
 release ships.
 
-Add a comment documenting the correction:
+Add a comment documenting the correction. If a ProdSec Jira account ID is
+configured in Security Configuration, append an @mention before the Comment
+Footnote using an ADF mention node:
+
+```json
+{ "type": "mention", "attrs": { "id": "<prodsec-jira-account-id>", "text": "@<prodsec-name>" } }
+```
+
+If no ProdSec Jira account ID is configured, omit the @mention silently.
 
 ```
 jira.add_comment(<jira-issue-id>, "Corrected Affects Versions: [old] → [new].
 Based on lock file analysis at pinned commits from security-matrix.md.
-Scoped to stream <stream> per issue suffix.")
+Scoped to stream <stream> per issue suffix.
+[ProdSec @mention if configured]")
 ```
 
 ## Step 4 – Duplicate, Sibling, and Overlap Check
@@ -207,7 +216,15 @@ entirely.
    - If the bump version is **below** the fix threshold: the existing
      remediation does not cover this CVE.
 
-6. **Present findings** to the engineer:
+6. **Present findings** to the engineer. If a ProdSec Jira account ID is
+   configured in Security Configuration, append an @mention before the Comment
+   Footnote in any comments posted during this step, using an ADF mention node:
+
+   ```json
+   { "type": "mention", "attrs": { "id": "<prodsec-jira-account-id>", "text": "@<prodsec-name>" } }
+   ```
+
+   If no ProdSec Jira account ID is configured, omit the @mention silently.
 
    - **If a covering remediation exists:**
      ```
@@ -216,6 +233,7 @@ entirely.
      ([fix-version]). No new remediation task needed.
 
      Recommendation: Close this issue — the fix is already covered by [task-key].
+     [ProdSec @mention if configured]
      ```
    - **If related CVEs exist but no covering remediation:**
      ```
@@ -227,6 +245,7 @@ entirely.
 
      No existing remediation covers this CVE's fix threshold. Proceeding with
      new remediation task creation.
+     [ProdSec @mention if configured]
      ```
    - **If no related CVEs found for this component:** proceed silently to Step 4.4.
 


### PR DESCRIPTION
## Summary

- Add optional ProdSec contact fields (email, Jira account ID) to the setup skill's security config template and collection prompts
- triage-security now @mentions the vulnerability reporter in the Step 7 summary comment by default (§1.67)
- triage-security @mentions the configured ProdSec contact in Affects Versions correction (Step 3) and cross-CVE overlap (Step 4.3) comments when configured (§1.68)
- Add constraints §1.67–§1.68 to `docs/constraints.md`
- Add eval case 15 with ProdSec fixture to verify both mention behaviors

## Test plan

- [ ] Eval case 15 passes — reporter @mention in summary comment, ProdSec @mention in triage comments
- [ ] Existing eval cases 1–14 pass with unchanged `claude-md-security-config.md` (no ProdSec fields — backward compatible)

Implements [TC-4947](https://redhat.atlassian.net/browse/TC-4947)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add configurable Product Security contact metadata and ensure triage-security comments @mention the appropriate security contacts and vulnerability reporters.

New Features:
- Introduce optional ProdSec contact email and Jira account ID fields in security configuration and setup prompts for CVE triage workflows.
- Add automatic @mentions for vulnerability reporters and optional ProdSec contacts in triage-security Jira comments, including summary and overlap/correction steps.

Enhancements:
- Extend triage-security documentation to describe new @mention behaviors and ProdSec contact usage in relevant triage steps.
- Update constraints to codify required @mention behaviors and reference the new documentation locations.

Documentation:
- Update security configuration templates and skill docs to document ProdSec contact fields and their role in triage notifications.

Tests:
- Add a new triage-security eval case with a ProdSec-enabled security configuration fixture to validate reporter and ProdSec @mention behavior.