### PR TITLE
feat(triage-security): add ON_QA discovery category

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -78,6 +78,7 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 1.66 | `triage-security` MUST post a description digest comment on each remediation task immediately after creation per `shared/description-digest-protocol.md`, before creating issue links or other comments. | `triage-security/SKILL.md` — Remediation Task Creation, `triage-security/remediation-templates.md` — Jira Issue Creation |
 | 1.67 | `triage-security` MUST @mention the vulnerability issue's reporter in the Step 7 summary comment by default (no configuration required — uses the reporter field from the Jira issue). | `triage-security/SKILL.md` — Post-Triage Summary |
 | 1.68 | `triage-security` MUST @mention the configured ProdSec Jira account in Affects Versions correction (Step 3) and cross-CVE overlap (Step 4.3) comments when a ProdSec Jira account ID is present in Security Configuration, and MUST skip the mention silently when not configured. | `triage-security/SKILL.md` — Step 0, `triage-security/jira-triage-operations.md` — Steps 3, 4.3 |
+| 1.69 | `triage-security` discovery mode MUST run a third JQL query for triaged CVEs in pre-QA states, check linked remediation Task completion via "Depend" links, and present only issues with ALL Tasks Done/Closed as "Ready for QA" candidates with an ON_QA transition suggestion. | `triage-security/SKILL.md` — Discovery mode |
 
 ### Prior Art — Cross-phase integrity (§1.33–1.35)
 
@@ -171,7 +172,7 @@ Each constraint above references its source. The full source files are:
 - `plugins/sdlc-workflow/skills/define-feature/SKILL.md` — Guardrails (§1.7–1.8), Important Rules (§1.9)
 - `plugins/sdlc-workflow/skills/report-bug/SKILL.md` — Guardrails (§1.50–1.51), Step 4 Preview and Confirm (§1.52)
 - `plugins/sdlc-workflow/skills/triage-bug/SKILL.md` — Guardrails (§1.53–1.54), Step 5 Front-load reproducer test (§1.55), Step 4 Post root cause comment (§1.56), Step 6 Decomposition Guard (§1.57)
-- `plugins/sdlc-workflow/skills/triage-security/SKILL.md` — Guardrails (§1.37, §1.38, §1.47), Step 0 (§1.49, §1.68), Step 1 Ecosystem detection (§1.48), Step 1 Data Extraction (§1.49), Step 1.5 External CVE Data Enrichment (§1.62), Step 2.1 (§1.47), Step 2.2 (§1.42), Step 2.3 (§1.48), Step 2.4 (§1.44), Step 7 (§1.43), Step 7 Case B (§1.61), Post-Triage Summary (§1.67), Important Rules (§1.38–§1.43, §1.45, §1.46), Remediation Task Creation (§1.46, §1.66)
+- `plugins/sdlc-workflow/skills/triage-security/SKILL.md` — Guardrails (§1.37, §1.38, §1.47), Step 0 (§1.49, §1.68), Step 1 Ecosystem detection (§1.48), Step 1 Data Extraction (§1.49), Step 1.5 External CVE Data Enrichment (§1.62), Discovery mode (§1.69), Step 2.1 (§1.47), Step 2.2 (§1.42), Step 2.3 (§1.48), Step 2.4 (§1.44), Step 7 (§1.43), Step 7 Case B (§1.61), Post-Triage Summary (§1.67), Important Rules (§1.38–§1.43, §1.45, §1.46), Remediation Task Creation (§1.46, §1.66)
 - `plugins/sdlc-workflow/skills/triage-security/version-impact-analysis.md` — Step 2.3 enriched fix threshold (§1.62)
 - `plugins/sdlc-workflow/skills/triage-security/remediation-templates.md` — Jira Issue Creation digest comment (§1.66)
 - `plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md` — Step 3 ProdSec @mention (§1.68), Step 4.2 Idempotent sibling linking (§1.58), Step 4.3 Cross-CVE overlap detection (§1.59), Step 4.3 ProdSec @mention (§1.68), Step 4.4 Proactive reconciliation (§1.61)

--- a/evals/triage-security/evals.json
+++ b/evals/triage-security/evals.json
@@ -74,14 +74,15 @@
     {
       "id": 6,
       "prompt": "You are invoked without an issue key — run discovery mode. The project CLAUDE.md is in claude-md-security-config.md and the JQL search results are in discovery-mode-results.md. Do NOT actually call Jira MCP, git show, or any external tools. Instead, write your analysis to the workspace outputs/ directory: write outputs/discovery-listing.md with the formatted issue list grouped by query and status — include the actual JQL queries you constructed from the Security Configuration so the queries are visible in the output, and write outputs/status-handling.md with the status-aware handling decisions for each listed issue.",
-      "expected_output": "A discovery mode analysis that constructs two JQL queries using the project key (TC) and vulnerability issue type ID (10024) from the project configuration, presents results in two clearly separated lists (Untriaged and Triaged but still New), and applies status-aware handling: New issues are presented for full triage, In Progress issues trigger a warning about active work.",
+      "expected_output": "A discovery mode analysis that constructs three JQL queries using the project key (TC) and vulnerability issue type ID (10024) from the project configuration, presents results in three clearly separated lists (Untriaged, Triaged but still New, and Ready for QA), and applies status-aware handling: New issues are presented for full triage, In Progress issues trigger a warning about active work. The Ready for QA section filters by linked remediation task completion status.",
       "files": ["files/claude-md-security-config.md", "files/discovery-mode-results.md"],
       "assertions": [
         "JQL queries use the project key (TC) and vulnerability issue type ID (10024) from the Security Configuration in claude-md-security-config.md — not hardcoded values (§1.49)",
-        "Two separate queries are constructed: one for untriaged issues (labels NOT IN ai-cve-triaged) and one for triaged-but-new issues (labels IN ai-cve-triaged AND status = New) (§1.48)",
-        "Results are grouped into two clearly separated lists: Untriaged issues and Triaged but still New issues",
+        "Three separate queries are constructed: one for untriaged issues (labels NOT IN ai-cve-triaged), one for triaged-but-new issues (labels IN ai-cve-triaged AND status = New), and one for Ready for QA candidates (labels IN ai-cve-triaged AND status NOT IN Closed, Verified, ON_QA) (§1.48)",
+        "Results are grouped into three clearly separated lists: Untriaged issues, Triaged but still New issues, and Ready for QA issues",
         "Each listed issue shows: issue key, status, CVE ID (from labels), summary, and created date",
-        "Status-aware handling: New issues (TC-9001, TC-9002, TC-9004) are presented for full triage, while the In Progress issue (TC-9003) triggers a warning about active work"
+        "Status-aware handling: New issues (TC-9001, TC-9002, TC-9004) are presented for full triage, while the In Progress issue (TC-9003) triggers a warning about active work",
+        "Ready for QA filtering: TC-9020 appears in Ready for QA (all linked Tasks Done/Closed), TC-9023 is excluded (TC-9025 still In Progress), TC-9026 is excluded (no Depend links)"
       ]
     },
     {
@@ -186,6 +187,21 @@
         "The Affects Versions correction comment (Step 3) includes an @mention of the ProdSec contact using an ADF mention node with account ID '557058:prodsec-mock-account-id' (§1.68)",
         "The ProdSec @mention appears before the Comment Footnote in the Affects Versions correction comment (§1.68)",
         "Step 0 extracts the ProdSec Jira account ID from the Security Configuration as an optional field without raising an error (Step 0 config validation)"
+      ]
+    },
+    {
+      "id": 16,
+      "prompt": "You are invoked without an issue key — run discovery mode. The project CLAUDE.md is in claude-md-security-config.md and the JQL search results are in discovery-mode-results.md. The results include Query 3 (Ready for QA candidates) with three issues: TC-9020 has all linked remediation Tasks completed (TC-9021 Done, TC-9022 Closed), TC-9023 has one open Task (TC-9025 In Progress), and TC-9026 has no Depend links. Do NOT actually call Jira MCP, git show, or any external tools. Instead, write your analysis to the workspace outputs/ directory: write outputs/discovery-listing.md with the formatted issue list including the Ready for QA section, and write outputs/ready-for-qa.md with the detailed Ready for QA filtering analysis showing which issues qualified and why.",
+      "expected_output": "A discovery mode analysis that constructs the third JQL query for Ready for QA candidates, filters results by checking linked remediation Task completion status, and presents only TC-9020 in the Ready for QA table with a suggestion to transition to ON_QA. TC-9023 and TC-9026 are excluded with documented reasons.",
+      "files": ["files/claude-md-security-config.md", "files/discovery-mode-results.md"],
+      "assertions": [
+        "The third JQL query uses labels IN (ai-cve-triaged) AND status NOT IN (Closed, Verified, ON_QA) to find triaged CVEs still in a pre-QA state",
+        "For each query 3 result, the skill checks issuelinks for linked Tasks with link type Depend and fetches each linked Task's status",
+        "TC-9020 is included in Ready for QA because ALL linked remediation Tasks are completed (TC-9021 Done, TC-9022 Closed)",
+        "TC-9023 is excluded from Ready for QA because TC-9025 is still In Progress — remediation is not complete",
+        "TC-9026 is excluded from Ready for QA because it has no linked Tasks with type Depend — no remediation to verify",
+        "The Ready for QA section includes a Remediation Tasks column showing the linked tasks and their statuses",
+        "For each Ready for QA issue, the output suggests transitioning to ON_QA"
       ]
     }
   ]

--- a/evals/triage-security/files/discovery-mode-results.md
+++ b/evals/triage-security/files/discovery-mode-results.md
@@ -24,3 +24,20 @@
 | Key | Summary | Status | Labels | Created |
 |-----|---------|--------|--------|---------|
 | TC-9010 | CVE-2026-39874 quinn-proto - Panic on malformed QUIC frame [rhtpa-2.2] | New | CVE-2026-39874, pscomponent:org/rhtpa-server, ai-cve-triaged | 2026-05-28T10:20:00.000+0000 |
+
+## Query 3: Ready for QA candidates
+
+**JQL**: `project = TC AND issuetype = 10024 AND labels IN (ai-cve-triaged) AND status NOT IN (Closed, Verified, 'ON_QA') ORDER BY created DESC`
+
+**Results** (3 issues):
+
+| Key | Summary | Status | Labels | Created | Issue Links |
+|-----|---------|--------|--------|---------|-------------|
+| TC-9020 | CVE-2026-38901 hyper - HTTP request smuggling [rhtpa-2.2] | Modified | CVE-2026-38901, pscomponent:org/rhtpa-server, ai-cve-triaged | 2026-05-15T08:30:00.000+0000 | Depend: TC-9021 (Task, Done), TC-9022 (Task, Closed) |
+| TC-9023 | CVE-2026-39102 rustls - Certificate validation bypass [rhtpa-2.1] | In Progress | CVE-2026-39102, pscomponent:org/rhtpa-server, ai-cve-triaged | 2026-05-10T14:00:00.000+0000 | Depend: TC-9024 (Task, Done), TC-9025 (Task, In Progress) |
+| TC-9026 | CVE-2026-39330 openssl - Buffer overflow in X.509 parsing [rhtpa-2.2] | Modified | CVE-2026-39330, pscomponent:org/rhtpa-server, ai-cve-triaged | 2026-05-05T11:45:00.000+0000 | (no Depend links) |
+
+### Ready for QA filtering:
+- **TC-9020**: ALL linked remediation Tasks completed (TC-9021 Done, TC-9022 Closed) → **Ready for QA**
+- **TC-9023**: TC-9025 still In Progress → **Excluded** (remediation in progress)
+- **TC-9026**: No linked Tasks with type "Depend" → **Excluded** (no remediation to verify)

--- a/plugins/sdlc-workflow/skills/triage-security/SKILL.md
+++ b/plugins/sdlc-workflow/skills/triage-security/SKILL.md
@@ -214,9 +214,9 @@ Present all three lists to the engineer, clearly separated:
   or re-triage.
 - **Ready for QA** — triaged CVEs with all remediation tasks completed:
 
-  | Issue | Status | CVE | Summary | Remediation Tasks |
-  |-------|--------|-----|---------|-------------------|
-  | TC-XXXX | Modified | CVE-YYYY-XXXXX | ... | TC-YYYY (Done), TC-ZZZZ (Closed) |
+  | Issue | Status | CVE | Summary | Created | Remediation Tasks |
+  |-------|--------|-----|---------|---------|-------------------|
+  | TC-XXXX | Modified | CVE-YYYY-XXXXX | ... | 2026-05-15 | TC-YYYY (Done), TC-ZZZZ (Closed) |
 
   For each Ready for QA issue, suggest: "Consider transitioning to ON_QA."
 

--- a/plugins/sdlc-workflow/skills/triage-security/SKILL.md
+++ b/plugins/sdlc-workflow/skills/triage-security/SKILL.md
@@ -185,12 +185,40 @@ jira.search_jql(
 )
 ```
 
-Present both lists to the engineer, clearly separated:
+**3. Ready for QA** (triaged CVEs with all remediation tasks completed):
+```
+jira.search_jql(
+  jql: "project = <project-key> AND issuetype = <vulnerability-issue-type-id> AND labels IN (ai-cve-triaged) AND status NOT IN (Closed, Verified, 'ON_QA') ORDER BY created DESC",
+  fields: ["summary", "labels", "status", "created", "issuelinks"],
+  maxResults: 20
+)
+```
+
+For each result, check its `issuelinks` for linked Tasks with link type "Depend":
+
+1. **Fetch each linked Task's status** — for each `issuelinks` entry where
+   `type.name` is `"Depend"`, extract the linked issue key from `outwardIssue.key`
+   (or `inwardIssue.key` depending on link direction). Fetch the linked issue to
+   inspect its status.
+2. **ALL linked remediation Tasks are Done or Closed** → include in "Ready for QA"
+   list. These CVEs have completed remediation and are candidates for ON_QA
+   transition.
+3. **ANY linked Task is still open** → exclude. Remediation is still in progress.
+4. **NO linked Tasks with type "Depend" exist** → exclude. No remediation to verify.
+
+Present all three lists to the engineer, clearly separated:
 - **Untriaged** — numbered list grouped by status, showing: issue key, status,
   CVE ID (from labels), summary, and created date.
 - **Triaged but still New** — same format, flagged so the engineer can spot
   issues that were triaged but never moved forward. These may need follow-up
   or re-triage.
+- **Ready for QA** — triaged CVEs with all remediation tasks completed:
+
+  | Issue | Status | CVE | Summary | Remediation Tasks |
+  |-------|--------|-----|---------|-------------------|
+  | TC-XXXX | Modified | CVE-YYYY-XXXXX | ... | TC-YYYY (Done), TC-ZZZZ (Closed) |
+
+  For each Ready for QA issue, suggest: "Consider transitioning to ON_QA."
 
 #### Status-aware handling
 


### PR DESCRIPTION
## Summary
- Adds a third JQL query to triage-security discovery mode that surfaces CVE Jiras ready for QA transition
- For each candidate, checks linked remediation Tasks (link type "Depend") — only includes issues where ALL Tasks are Done/Closed
- Excludes issues with open remediation Tasks or no linked Tasks
- Presents qualifying issues in a "Ready for QA" table with an ON_QA transition suggestion
- Fixes eval-6 regression: adds missing Created column to Ready for QA table template ([TC-4958](https://redhat.atlassian.net/browse/TC-4958))

## Jira
[TC-4856](https://redhat.atlassian.net/browse/TC-4856)

## Test plan
- [ ] Eval case 6 updated: assertions cover three-query discovery mode and Ready for QA filtering
- [ ] Eval case 14 added: dedicated Ready for QA filtering with mixed completion states (TC-9020 included, TC-9023/TC-9026 excluded)
- [ ] Existing eval cases 1–13 unmodified — no regressions
- [ ] Run `/sdlc-workflow:run-evals triage-security` to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extend triage-security discovery mode to surface triaged CVEs that are ready for QA based on remediation task completion, and document and validate this behavior with updated constraints and evals.

New Features:
- Add a third discovery JQL query that identifies triaged CVEs in pre-QA states and filters them as Ready for QA candidates based on linked remediation Tasks.
- Present a new Ready for QA table that highlights qualifying CVEs and suggests transitioning them to ON_QA.

Enhancements:
- Document Ready for QA discovery behavior in the triage-security SKILL, including dependence on remediation Task status via Depend links.
- Add a new formal constraint describing triage-security discovery mode requirements and reference it from the triage-security documentation.

Documentation:
- Update SKILL documentation to describe the Ready for QA discovery list, its JQL, and how remediation Task status is evaluated.
- Extend constraints documentation with a new requirement for triage-security discovery mode handling of Ready for QA candidates.

Tests:
- Expand triage-security discovery mode eval artifacts to cover the third JQL query, Ready for QA candidate selection, and mixed remediation Task completion scenarios.