### PR TITLE
feat(jira-client): add priority and fixVersion REST API fallback

### DIFF
--- a/plugins/sdlc-workflow/scripts/jira-client.py
+++ b/plugins/sdlc-workflow/scripts/jira-client.py
@@ -447,6 +447,8 @@ def create_issue(
     issue_type: str,
     labels: Optional[List[str]] = None,
     assignee_id: Optional[str] = None,
+    priority: Optional[str] = None,
+    fix_versions: Optional[List[str]] = None,
     custom_fields: Optional[Dict[str, Any]] = None
 ) -> Dict[str, Any]:
     """Create JIRA issue with markdown description.
@@ -458,6 +460,8 @@ def create_issue(
         issue_type: Issue type ID or name
         labels: Optional list of labels
         assignee_id: Optional assignee account ID
+        priority: Optional priority name (e.g., "Major")
+        fix_versions: Optional list of fixVersion names
         custom_fields: Optional custom field values (field_id: value)
 
     Returns:
@@ -477,6 +481,12 @@ def create_issue(
 
     if assignee_id:
         data["fields"]["assignee"] = {"id": assignee_id}
+
+    if priority:
+        data["fields"]["priority"] = {"name": priority}
+
+    if fix_versions:
+        data["fields"]["fixVersions"] = [{"name": v} for v in fix_versions]
 
     if custom_fields:
         data["fields"].update(custom_fields)
@@ -603,6 +613,31 @@ def get_project_metadata(project_key: str) -> Dict[str, Any]:
     return make_request('GET', f"project/{project_key}")
 
 
+def get_priorities() -> List[Dict[str, Any]]:
+    """Get available priority levels.
+
+    Returns:
+        List of priority objects with id, name, description, and iconUrl
+    """
+    return make_request('GET', 'priority')
+
+
+def get_versions(project_key: str, unreleased_only: bool = False) -> List[Dict[str, Any]]:
+    """Get project fixVersions.
+
+    Args:
+        project_key: Project key (e.g., TC)
+        unreleased_only: If True, filter to non-released, non-archived versions
+
+    Returns:
+        List of version objects with id, name, released, archived, releaseDate
+    """
+    versions = make_request('GET', f"project/{project_key}/versions")
+    if unreleased_only:
+        versions = [v for v in versions if not v.get('released') and not v.get('archived')]
+    return versions
+
+
 # =============================================================================
 # CLI Interface
 # =============================================================================
@@ -638,6 +673,8 @@ def main(argv=None):
     create_issue_parser.add_argument('--issue-type', required=True, help='Issue type ID or name')
     create_issue_parser.add_argument('--labels', help='Comma-separated labels')
     create_issue_parser.add_argument('--assignee-id', help='Assignee account ID')
+    create_issue_parser.add_argument('--priority', help='Priority name (e.g., Major)')
+    create_issue_parser.add_argument('--fix-versions', help='Comma-separated fixVersion names')
 
     # update_issue
     update_issue_parser = subparsers.add_parser('update_issue', help='Update issue fields')
@@ -678,6 +715,15 @@ def main(argv=None):
     project_parser = subparsers.add_parser('get_project_metadata', help='Get project metadata')
     project_parser.add_argument('project_key', help='Project key')
 
+    # get_priorities
+    subparsers.add_parser('get_priorities', help='Get available priority levels')
+
+    # get_versions
+    versions_parser = subparsers.add_parser('get_versions', help='Get project fixVersions')
+    versions_parser.add_argument('project_key', help='Project key')
+    versions_parser.add_argument('--unreleased-only', action='store_true',
+                                 help='Filter to non-released, non-archived versions')
+
     # Parse and execute
     args = parser.parse_args(argv)
 
@@ -688,13 +734,16 @@ def main(argv=None):
 
     elif args.command == 'create_issue':
         labels = args.labels.split(',') if args.labels else None
+        fix_versions = [v.strip() for v in args.fix_versions.split(',')] if args.fix_versions else None
         result = create_issue(
             args.project,
             args.summary,
             args.description_md,
             args.issue_type,
             labels=labels,
-            assignee_id=args.assignee_id
+            assignee_id=args.assignee_id,
+            priority=args.priority,
+            fix_versions=fix_versions,
         )
 
     elif args.command == 'update_issue':
@@ -730,6 +779,12 @@ def main(argv=None):
 
     elif args.command == 'get_project_metadata':
         result = get_project_metadata(args.project_key)
+
+    elif args.command == 'get_priorities':
+        result = get_priorities()
+
+    elif args.command == 'get_versions':
+        result = get_versions(args.project_key, args.unreleased_only)
 
     # Print result as JSON
     if result:

--- a/plugins/sdlc-workflow/scripts/jira-client.py
+++ b/plugins/sdlc-workflow/scripts/jira-client.py
@@ -486,7 +486,7 @@ def create_issue(
         data["fields"]["priority"] = {"name": priority}
 
     if fix_versions:
-        data["fields"]["fixVersions"] = [{"name": v} for v in fix_versions]
+        data["fields"]["fixVersions"] = [{"name": v} for v in fix_versions if v]
 
     if custom_fields:
         data["fields"].update(custom_fields)
@@ -733,7 +733,7 @@ def main(argv=None):
         result = get_issue(args.issue_key, args.fields)
 
     elif args.command == 'create_issue':
-        labels = args.labels.split(',') if args.labels else None
+        labels = [l.strip() for l in args.labels.split(',')] if args.labels else None
         fix_versions = [v.strip() for v in args.fix_versions.split(',')] if args.fix_versions else None
         result = create_issue(
             args.project,

--- a/plugins/sdlc-workflow/scripts/test_jira_client.py
+++ b/plugins/sdlc-workflow/scripts/test_jira_client.py
@@ -392,77 +392,168 @@ def test_get_versions_unreleased_only_filters_correctly():
         {"id": "5", "name": "1.2.0", "released": False, "archived": True},
     ]
 
-    # When filtering with unreleased_only=True (test the filtering logic directly)
-    filtered = [v for v in all_versions if not v.get('released') and not v.get('archived')]
+    original_make_request = jira_client.make_request
+    jira_client.make_request = lambda method, endpoint, data=None: all_versions
+    try:
+        # When calling get_versions with unreleased_only=True
+        filtered = get_versions("TEST", unreleased_only=True)
 
-    # Then only non-released, non-archived versions remain
-    assert len(filtered) == 2, f"Expected 2 versions, got {len(filtered)}"
-    assert filtered[0]["name"] == "1.1.0"
-    assert filtered[1]["name"] == "2.0.0"
+        # Then only non-released, non-archived versions remain
+        assert len(filtered) == 2, f"Expected 2 versions, got {len(filtered)}"
+        assert filtered[0]["name"] == "1.1.0"
+        assert filtered[1]["name"] == "2.0.0"
+
+        # When calling with unreleased_only=False, no filtering happens
+        unfiltered = get_versions("TEST", unreleased_only=False)
+        assert len(unfiltered) == 5, f"Expected 5 versions, got {len(unfiltered)}"
+    finally:
+        jira_client.make_request = original_make_request
 
     print("✓ get_versions unreleased_only filter test passed")
 
 
 def test_create_issue_priority_field_mapping():
     """Verifies that create_issue maps priority parameter to correct Jira field structure."""
-    # Given a priority name
-    priority_name = "Major"
+    captured = {}
+    original_make_request = jira_client.make_request
 
-    # When building fields (test the field construction logic)
-    data = {"fields": {}}
-    if priority_name:
-        data["fields"]["priority"] = {"name": priority_name}
+    def fake_make_request(method, endpoint, data=None):
+        captured["data"] = data
+        return {"key": "TEST-1", "id": "1"}
 
-    # Then the field structure matches Jira's expected format
-    assert data["fields"]["priority"] == {"name": "Major"}
+    jira_client.make_request = fake_make_request
+    try:
+        # When creating an issue with a priority
+        create_issue("TC", "Test", "desc", "Task", priority="Major")
+
+        # Then the priority field is correctly mapped
+        assert captured["data"]["fields"]["priority"] == {"name": "Major"}
+    finally:
+        jira_client.make_request = original_make_request
 
     print("✓ create_issue priority field mapping test passed")
 
 
 def test_create_issue_fix_versions_field_mapping():
     """Verifies that create_issue maps fix_versions list to correct Jira fixVersions array."""
-    # Given a list of version names
-    fix_versions = ["RHTPA 1.5.0", "RHTPA 1.6.0"]
+    captured = {}
+    original_make_request = jira_client.make_request
 
-    # When building fields (test the field construction logic)
-    data = {"fields": {}}
-    if fix_versions:
-        data["fields"]["fixVersions"] = [{"name": v} for v in fix_versions]
+    def fake_make_request(method, endpoint, data=None):
+        captured["data"] = data
+        return {"key": "TEST-1", "id": "1"}
 
-    # Then each version is wrapped in a name object
-    assert len(data["fields"]["fixVersions"]) == 2
-    assert data["fields"]["fixVersions"][0] == {"name": "RHTPA 1.5.0"}
-    assert data["fields"]["fixVersions"][1] == {"name": "RHTPA 1.6.0"}
+    jira_client.make_request = fake_make_request
+    try:
+        # When creating an issue with fix_versions
+        create_issue("TC", "Test", "desc", "Task", fix_versions=["RHTPA 1.5.0", "RHTPA 1.6.0"])
+
+        # Then each version is wrapped in a name object
+        fv = captured["data"]["fields"]["fixVersions"]
+        assert len(fv) == 2, f"Expected 2 fixVersions, got {len(fv)}"
+        assert fv[0] == {"name": "RHTPA 1.5.0"}
+        assert fv[1] == {"name": "RHTPA 1.6.0"}
+    finally:
+        jira_client.make_request = original_make_request
 
     print("✓ create_issue fix_versions field mapping test passed")
 
 
 def test_create_issue_omits_priority_when_none():
     """Verifies that create_issue omits priority field when not provided."""
-    # Given no priority
-    data = {"fields": {}}
-    priority = None
-    if priority:
-        data["fields"]["priority"] = {"name": priority}
+    captured = {}
+    original_make_request = jira_client.make_request
 
-    # Then priority is not in fields
-    assert "priority" not in data["fields"]
+    def fake_make_request(method, endpoint, data=None):
+        captured["data"] = data
+        return {"key": "TEST-1", "id": "1"}
+
+    jira_client.make_request = fake_make_request
+    try:
+        create_issue("TC", "Test", "desc", "Task")
+        assert "priority" not in captured["data"]["fields"]
+    finally:
+        jira_client.make_request = original_make_request
 
     print("✓ create_issue omits priority when None test passed")
 
 
 def test_create_issue_omits_fix_versions_when_none():
     """Verifies that create_issue omits fixVersions field when not provided."""
-    # Given no fix_versions
-    data = {"fields": {}}
-    fix_versions = None
-    if fix_versions:
-        data["fields"]["fixVersions"] = [{"name": v} for v in fix_versions]
+    captured = {}
+    original_make_request = jira_client.make_request
 
-    # Then fixVersions is not in fields
-    assert "fixVersions" not in data["fields"]
+    def fake_make_request(method, endpoint, data=None):
+        captured["data"] = data
+        return {"key": "TEST-1", "id": "1"}
+
+    jira_client.make_request = fake_make_request
+    try:
+        create_issue("TC", "Test", "desc", "Task")
+        assert "fixVersions" not in captured["data"]["fields"]
+    finally:
+        jira_client.make_request = original_make_request
 
     print("✓ create_issue omits fix_versions when None test passed")
+
+
+def test_create_issue_all_optional_fields_together():
+    """Verifies that create_issue correctly merges all optional fields into the payload."""
+    captured = {}
+    original_make_request = jira_client.make_request
+
+    def fake_make_request(method, endpoint, data=None):
+        captured["data"] = data
+        return {"key": "TEST-1", "id": "1"}
+
+    jira_client.make_request = fake_make_request
+    try:
+        # When creating an issue with all optional fields
+        create_issue(
+            "TC", "Test", "desc", "Task",
+            labels=["ai-generated-jira", "feature"],
+            assignee_id="user-123",
+            priority="Major",
+            fix_versions=["1.5.0", "1.6.0"],
+            custom_fields={"customfield_10010": "value"},
+        )
+
+        # Then all fields are present and correctly structured
+        fields = captured["data"]["fields"]
+        assert fields["labels"] == ["ai-generated-jira", "feature"]
+        assert fields["assignee"] == {"id": "user-123"}
+        assert fields["priority"] == {"name": "Major"}
+        assert fields["fixVersions"] == [{"name": "1.5.0"}, {"name": "1.6.0"}]
+        assert fields["customfield_10010"] == "value"
+    finally:
+        jira_client.make_request = original_make_request
+
+    print("✓ create_issue all optional fields together test passed")
+
+
+def test_create_issue_fix_versions_filters_empty_names():
+    """Verifies that create_issue filters out empty version names from fixVersions."""
+    captured = {}
+    original_make_request = jira_client.make_request
+
+    def fake_make_request(method, endpoint, data=None):
+        captured["data"] = data
+        return {"key": "TEST-1", "id": "1"}
+
+    jira_client.make_request = fake_make_request
+    try:
+        # When creating an issue with empty version names mixed in
+        create_issue("TC", "Test", "desc", "Task", fix_versions=["1.0", "", "2.0"])
+
+        # Then empty names are filtered out
+        fv = captured["data"]["fields"]["fixVersions"]
+        assert len(fv) == 2, f"Expected 2 fixVersions (empty filtered), got {len(fv)}"
+        assert fv[0] == {"name": "1.0"}
+        assert fv[1] == {"name": "2.0"}
+    finally:
+        jira_client.make_request = original_make_request
+
+    print("✓ create_issue fix_versions filters empty names test passed")
 
 
 def run_all_tests():
@@ -485,6 +576,8 @@ def run_all_tests():
         test_create_issue_fix_versions_field_mapping,
         test_create_issue_omits_priority_when_none,
         test_create_issue_omits_fix_versions_when_none,
+        test_create_issue_all_optional_fields_together,
+        test_create_issue_fix_versions_filters_empty_names,
     ]
 
     failed = []

--- a/plugins/sdlc-workflow/scripts/test_jira_client.py
+++ b/plugins/sdlc-workflow/scripts/test_jira_client.py
@@ -20,6 +20,8 @@ jira_client = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(jira_client)
 markdown_to_adf = jira_client.markdown_to_adf
 sanitize_adf = jira_client.sanitize_adf
+get_versions = jira_client.get_versions
+create_issue = jira_client.create_issue
 
 
 def test_code_block_with_blank_lines():
@@ -379,6 +381,90 @@ def test_create_issue_adf_has_no_tasklist():
     print("✓ create_issue ADF has no taskList test passed")
 
 
+def test_get_versions_unreleased_only_filters_correctly():
+    """Verifies that get_versions with unreleased_only filters out released and archived versions."""
+    # Given a list of versions with mixed released/archived states
+    all_versions = [
+        {"id": "1", "name": "1.0.0", "released": True, "archived": False},
+        {"id": "2", "name": "1.1.0", "released": False, "archived": False},
+        {"id": "3", "name": "0.9.0", "released": True, "archived": True},
+        {"id": "4", "name": "2.0.0", "released": False, "archived": False},
+        {"id": "5", "name": "1.2.0", "released": False, "archived": True},
+    ]
+
+    # When filtering with unreleased_only=True (test the filtering logic directly)
+    filtered = [v for v in all_versions if not v.get('released') and not v.get('archived')]
+
+    # Then only non-released, non-archived versions remain
+    assert len(filtered) == 2, f"Expected 2 versions, got {len(filtered)}"
+    assert filtered[0]["name"] == "1.1.0"
+    assert filtered[1]["name"] == "2.0.0"
+
+    print("✓ get_versions unreleased_only filter test passed")
+
+
+def test_create_issue_priority_field_mapping():
+    """Verifies that create_issue maps priority parameter to correct Jira field structure."""
+    # Given a priority name
+    priority_name = "Major"
+
+    # When building fields (test the field construction logic)
+    data = {"fields": {}}
+    if priority_name:
+        data["fields"]["priority"] = {"name": priority_name}
+
+    # Then the field structure matches Jira's expected format
+    assert data["fields"]["priority"] == {"name": "Major"}
+
+    print("✓ create_issue priority field mapping test passed")
+
+
+def test_create_issue_fix_versions_field_mapping():
+    """Verifies that create_issue maps fix_versions list to correct Jira fixVersions array."""
+    # Given a list of version names
+    fix_versions = ["RHTPA 1.5.0", "RHTPA 1.6.0"]
+
+    # When building fields (test the field construction logic)
+    data = {"fields": {}}
+    if fix_versions:
+        data["fields"]["fixVersions"] = [{"name": v} for v in fix_versions]
+
+    # Then each version is wrapped in a name object
+    assert len(data["fields"]["fixVersions"]) == 2
+    assert data["fields"]["fixVersions"][0] == {"name": "RHTPA 1.5.0"}
+    assert data["fields"]["fixVersions"][1] == {"name": "RHTPA 1.6.0"}
+
+    print("✓ create_issue fix_versions field mapping test passed")
+
+
+def test_create_issue_omits_priority_when_none():
+    """Verifies that create_issue omits priority field when not provided."""
+    # Given no priority
+    data = {"fields": {}}
+    priority = None
+    if priority:
+        data["fields"]["priority"] = {"name": priority}
+
+    # Then priority is not in fields
+    assert "priority" not in data["fields"]
+
+    print("✓ create_issue omits priority when None test passed")
+
+
+def test_create_issue_omits_fix_versions_when_none():
+    """Verifies that create_issue omits fixVersions field when not provided."""
+    # Given no fix_versions
+    data = {"fields": {}}
+    fix_versions = None
+    if fix_versions:
+        data["fields"]["fixVersions"] = [{"name": v} for v in fix_versions]
+
+    # Then fixVersions is not in fields
+    assert "fixVersions" not in data["fields"]
+
+    print("✓ create_issue omits fix_versions when None test passed")
+
+
 def run_all_tests():
     """Run all tests and report results."""
     tests = [
@@ -394,6 +480,11 @@ def run_all_tests():
         test_sanitize_adf_handles_nested_tasklist,
         test_sanitize_adf_noop_for_bulletlist,
         test_create_issue_adf_has_no_tasklist,
+        test_get_versions_unreleased_only_filters_correctly,
+        test_create_issue_priority_field_mapping,
+        test_create_issue_fix_versions_field_mapping,
+        test_create_issue_omits_priority_when_none,
+        test_create_issue_omits_fix_versions_when_none,
     ]
 
     failed = []

--- a/plugins/sdlc-workflow/scripts/test_jira_client_cli.py
+++ b/plugins/sdlc-workflow/scripts/test_jira_client_cli.py
@@ -156,6 +156,64 @@ def test_error_message_includes_help():
     print("✓ Error message includes help test passed")
 
 
+def test_get_priorities_help():
+    """Verifies that get_priorities subcommand is registered and shows help."""
+    exit_code, stdout, stderr = run_cli_command(['get_priorities', '--help'])
+
+    # --help causes SystemExit(0)
+    assert exit_code == 0, f"Expected exit code 0, got {exit_code}"
+    assert "get_priorities" in stdout, f"Expected 'get_priorities' in help output, got: {stdout}"
+
+    print("✓ get_priorities --help test passed")
+
+
+def test_get_versions_help():
+    """Verifies that get_versions subcommand is registered with project_key arg and --unreleased-only flag."""
+    exit_code, stdout, stderr = run_cli_command(['get_versions', '--help'])
+
+    assert exit_code == 0, f"Expected exit code 0, got {exit_code}"
+    assert "project_key" in stdout, f"Expected 'project_key' in help output, got: {stdout}"
+    assert "--unreleased-only" in stdout, f"Expected '--unreleased-only' in help output, got: {stdout}"
+
+    print("✓ get_versions --help test passed")
+
+
+def test_create_issue_help_shows_priority_flag():
+    """Verifies that create_issue --help shows the --priority flag."""
+    exit_code, stdout, stderr = run_cli_command(['create_issue', '--help'])
+
+    assert exit_code == 0, f"Expected exit code 0, got {exit_code}"
+    assert "--priority" in stdout, f"Expected '--priority' in help output, got: {stdout}"
+
+    print("✓ create_issue --help shows --priority flag test passed")
+
+
+def test_create_issue_help_shows_fix_versions_flag():
+    """Verifies that create_issue --help shows the --fix-versions flag."""
+    exit_code, stdout, stderr = run_cli_command(['create_issue', '--help'])
+
+    assert exit_code == 0, f"Expected exit code 0, got {exit_code}"
+    assert "--fix-versions" in stdout, f"Expected '--fix-versions' in help output, got: {stdout}"
+
+    print("✓ create_issue --help shows --fix-versions flag test passed")
+
+
+def test_create_issue_fix_versions_comma_parsing():
+    """Verifies that --fix-versions splits comma-separated values into a list."""
+    # Given comma-separated version names
+    raw = "RHTPA 1.5.0,RHTPA 1.6.0"
+
+    # When parsing (same logic as the CLI dispatch)
+    parsed = [v.strip() for v in raw.split(',')]
+
+    # Then each version is a separate entry
+    assert len(parsed) == 2, f"Expected 2 versions, got {len(parsed)}"
+    assert parsed[0] == "RHTPA 1.5.0"
+    assert parsed[1] == "RHTPA 1.6.0"
+
+    print("✓ create_issue --fix-versions comma parsing test passed")
+
+
 def run_all_tests():
     """Run all CLI validation tests and report results."""
     tests = [
@@ -164,6 +222,11 @@ def run_all_tests():
         test_invalid_json_unclosed_brace,
         test_error_message_includes_position,
         test_error_message_includes_help,
+        test_get_priorities_help,
+        test_get_versions_help,
+        test_create_issue_help_shows_priority_flag,
+        test_create_issue_help_shows_fix_versions_flag,
+        test_create_issue_fix_versions_comma_parsing,
     ]
 
     failed = []

--- a/plugins/sdlc-workflow/shared/jira-rest-fallback.md
+++ b/plugins/sdlc-workflow/shared/jira-rest-fallback.md
@@ -352,6 +352,51 @@ cd <plugin-root> && python3 scripts/jira-client.py get_user_info
 cd <plugin-root> && python3 scripts/jira-client.py get_project_metadata TC
 ```
 
+**Get Priorities:**
+```bash
+cd <plugin-root> && python3 scripts/jira-client.py get_priorities
+```
+
+Returns JSON array:
+```json
+[
+  {"id": "1", "name": "Blocker", "description": "..."},
+  {"id": "2", "name": "Critical", "description": "..."},
+  {"id": "3", "name": "Major", "description": "..."}
+]
+```
+
+**Get Project Versions:**
+```bash
+cd <plugin-root> && python3 scripts/jira-client.py get_versions TC
+```
+
+With `--unreleased-only` to filter out released and archived versions:
+```bash
+cd <plugin-root> && python3 scripts/jira-client.py get_versions TC --unreleased-only
+```
+
+Returns JSON array:
+```json
+[
+  {"id": "62648", "name": "RHTPA 1.5.0", "released": false, "archived": false},
+  {"id": "62649", "name": "RHTPA 1.6.0", "released": false, "archived": false}
+]
+```
+
+**Create Issue with Priority and Fix Versions:**
+```bash
+cd <plugin-root> && \
+  python3 scripts/jira-client.py create_issue \
+    --project TC \
+    --summary "New feature request" \
+    --description-md "Feature **description** in markdown." \
+    --issue-type "10142" \
+    --labels ai-generated-jira \
+    --priority Major \
+    --fix-versions "RHTPA 1.5.0,RHTPA 1.6.0"
+```
+
 ## Error Handling
 
 The Python client automatically maps HTTP errors to user-friendly messages:

--- a/plugins/sdlc-workflow/skills/define-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/define-feature/SKILL.md
@@ -324,8 +324,19 @@ From the response, extract:
 For fixVersions, filter to show only **unreleased, non-archived** versions by default
 (where `released` is `false` and `archived` is `false`).
 
-If MCP fails, follow the same REST API fallback pattern from Step 0.5. If REST API
-is also unavailable, skip this step and inform the user:
+**On MCP failure, if REST API chosen (Step 0.5):**
+
+Fetch priorities:
+```bash
+python3 scripts/jira-client.py get_priorities
+```
+
+Fetch fixVersions (filtered to unreleased, non-archived):
+```bash
+python3 scripts/jira-client.py get_versions <project-key> --unreleased-only
+```
+
+If REST API is also unavailable, skip this step and inform the user:
 
 > "Could not fetch available priorities and fixVersions. Skipping metadata fields."
 
@@ -509,9 +520,8 @@ python3 scripts/jira-client.py create_issue \
   --issue-type "<feature-issue-type-id>" \
   --labels ai-generated-jira \
   --assignee-id "$ACCOUNT_ID" \         # omit if no self-assignment
-  --fields-json '{"priority": {"name": "<selected-priority>"}, "fixVersions": [{"name": "<selected-version>"}]}'
-  # omit priority from --fields-json if skipped
-  # omit fixVersions from --fields-json if skipped
+  --priority "<selected-priority>" \    # omit if priority skipped
+  --fix-versions "<selected-version>"   # omit if fixVersion skipped
 ```
 
 The Python client automatically converts markdown to ADF.

--- a/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
@@ -110,8 +110,10 @@ Before attempting any JIRA operations (Steps 1, 2.5, 4, 6), determine the access
 - `jira.get_issue(id)` → `python3 scripts/jira-client.py get_issue <id> --fields "*all"`
 - `jira.add_comment(id, text)` → `python3 scripts/jira-client.py add_comment <id> --comment-md "<text>"`
 - `jira.get_project_issue_types(project)` → `python3 scripts/jira-client.py get_project_metadata <project-key>`
-- `jira.create_issue(...)` → `python3 scripts/jira-client.py create_issue --project <key> --summary "<summary>" --description-md "<desc>" --issue-type Task --labels <labels>`
+- `jira.create_issue(...)` → `python3 scripts/jira-client.py create_issue --project <key> --summary "<summary>" --description-md "<desc>" --issue-type Task --labels <labels> --priority "<priority>" --fix-versions "<v1>,<v2>"`
 - `jira.create_issue_link(...)` → `python3 scripts/jira-client.py create_link --inward <issue1> --outward <issue2> --link-type <type>`
+- `jira.get_priorities()` → `python3 scripts/jira-client.py get_priorities`
+- `jira.get_versions(project)` → `python3 scripts/jira-client.py get_versions <project-key> --unreleased-only`
 
 Refer to `shared/jira-rest-fallback.md` for complete implementation details.
 
@@ -148,6 +150,8 @@ Extract:
 - links (especially Figma)
 - `priority`: extract `fields.priority.name` and `fields.priority.id` (e.g., `{"name": "Major", "id": "10002"}`). If the priority name is `"Undefined"`, treat it as unset — do not store or propagate it.
 - `fixVersions`: extract the `fields.fixVersions` array (e.g., `[{"name": "RHTPA 1.5.0", "id": "62648"}]`). If the array is empty, treat it as unset.
+
+**On MCP failure, if REST API chosen (Step 0.5):** use `get_issue <id> --fields "*all"` — the response includes `fields.priority` and `fields.fixVersions` in the same structure.
 
 ## Step 2 – Inspect Figma Design
 
@@ -795,6 +799,8 @@ additional_fields: {
      - If `fixVersion scope` is `"feature"`: do NOT propagate fixVersions to tasks.
      - If `### Jira Field Defaults` does not exist or `fixVersion scope` is absent: default to `"both"` (propagate to tasks).
   If either condition is not met, omit the `fixVersions` key entirely from `additional_fields`.
+
+**On MCP failure, if REST API chosen (Step 0.5):** use the `--priority` and `--fix-versions` flags on `create_issue` (see REST API equivalents in Step 0.5). Omit the flag entirely when the value should not be propagated.
 
 As each task is created, record a mapping of **task number/title → Jira key** (e.g. "Task 1 — Add CSV endpoint" → PROJ-231). This mapping is needed for link creation below.
 


### PR DESCRIPTION
## Summary

- Add `get_priorities` and `get_versions` commands to `jira-client.py` for listing available priority levels and project fixVersions
- Add `--priority` and `--fix-versions` flags to `create_issue` command for setting priority and fixVersions during issue creation
- Update `jira-rest-fallback.md` with usage examples for all new commands and flags
- Add REST API fallback sections to define-feature and plan-feature SKILL.md files for priority and fixVersion operations

Implements [TC-4875](https://redhat.atlassian.net/browse/TC-4875)

## Test plan

- [x] `get_priorities --help` shows help text
- [x] `get_versions --help` shows project_key arg and --unreleased-only flag
- [x] `create_issue --help` shows --priority and --fix-versions flags
- [x] Unit tests verify field mapping for priority and fixVersions
- [x] Unit tests verify unreleased-only filtering logic
- [x] All 17 unit tests pass
- [x] All 10 CLI tests pass
- [x] `claude plugin validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add Jira REST client support for managing issue priority and fixVersions via new CLI commands and flags, and align workflow documentation with these REST API fallbacks.

New Features:
- Expose get_priorities CLI command and API for listing available Jira priority levels.
- Expose get_versions CLI command and API for listing project fixVersions with optional unreleased-only filtering.
- Extend create_issue to accept priority and fix_versions parameters and corresponding CLI flags.

Documentation:
- Update Jira REST fallback guide with examples for fetching priorities/versions and creating issues with priority and fixVersions.
- Update define-feature and plan-feature workflow skills to use the new REST fallback commands and create_issue flags for priority and fixVersion handling.

Tests:
- Add unit tests for fixVersion unreleased-only filtering and field mapping for priority and fixVersions in issue creation.
- Add CLI tests validating help output for new commands and flags and parsing of comma-separated fixVersions values.