### PR TITLE
feat(triage-security): add get_remote_links to REST client

### DIFF
--- a/evals/triage-security/evals.json
+++ b/evals/triage-security/evals.json
@@ -167,14 +167,14 @@
     {
       "id": 13,
       "prompt": "Triage Vulnerability issue TC-8001. The issue details are in vuln-issue-standard.md, the security matrix is in security-matrix-mock.md, and the project CLAUDE.md is in claude-md-security-config.md. Do NOT actually call Jira MCP, git show, or any external tools. Instead, write your triage analysis to the workspace outputs/ directory: write outputs/data-extraction.md with the parsed CVE data table from Step 1, write outputs/version-impact.md with the version impact table from Step 2, and write outputs/remediation.md with the remediation task descriptions AND the description digest comment steps you would perform after creating each task.",
-      "expected_output": "A triage analysis demonstrating the full remediation flow including description digest comments. After each jira.create_issue call, the skill re-fetches the created task description, computes a SHA-256 digest using scripts/sha256-digest.py, and posts a digest comment with the marker '[sdlc-workflow] Description digest:' before creating issue links or other comments.",
+      "expected_output": "A triage analysis whose remediation output describes the full description digest protocol for each created task. The output includes the digest steps for both the upstream backport task and the downstream propagation subtask: re-fetching the description after create_issue, computing a SHA-256 digest using scripts/sha256-digest.py, and posting a digest comment with the marker '[sdlc-workflow] Description digest:' before creating issue links or other comments. Since the eval prohibits actual Jira calls, the output describes these steps as planned procedures — the grader should verify the protocol is correctly described, not that API calls were executed.",
       "files": ["files/vuln-issue-standard.md", "files/security-matrix-mock.md", "files/claude-md-security-config.md"],
       "assertions": [
-        "After creating the upstream backport task, the skill re-fetches the task description from Jira and computes a SHA-256 digest using scripts/sha256-digest.py (§1.66)",
-        "After creating the downstream propagation subtask, the skill re-fetches the task description and computes a SHA-256 digest using scripts/sha256-digest.py (§1.66)",
-        "A digest comment with marker '[sdlc-workflow] Description digest:' is posted on each remediation task — both upstream and downstream (§1.66)",
-        "Digest comments are posted BEFORE creating issue links (Depend, Blocks) or other comments on the tasks (§1.66, shared/description-digest-protocol.md Rules)",
-        "The digest is computed using scripts/sha256-digest.py with the re-fetched description, not the description string passed to create_issue (shared/description-digest-protocol.md Hashing)"
+        "The remediation output describes the digest protocol for the upstream backport task: re-fetching the task description from Jira after create_issue and computing a SHA-256 digest using scripts/sha256-digest.py (§1.66)",
+        "The remediation output describes the digest protocol for the downstream propagation subtask: re-fetching the task description from Jira after create_issue and computing a SHA-256 digest using scripts/sha256-digest.py (§1.66)",
+        "The remediation output includes the digest comment marker '[sdlc-workflow] Description digest:' in the described steps for each remediation task — both upstream and downstream (§1.66)",
+        "The remediation output sequences digest comments BEFORE issue links (Depend, Blocks) or other comments in the described procedure for each task (§1.66, shared/description-digest-protocol.md Rules)",
+        "The remediation output specifies that the digest is computed from the re-fetched description (via Jira API after create_issue), not from the description string passed to create_issue (shared/description-digest-protocol.md Hashing)"
       ]
     },
     {

--- a/plugins/sdlc-workflow/scripts/jira-client.py
+++ b/plugins/sdlc-workflow/scripts/jira-client.py
@@ -603,7 +603,11 @@ def get_remote_links(issue_key: str) -> List[Dict[str, Any]]:
     result = make_request('GET', f"issue/{issue_key}/remotelink")
     if isinstance(result, list):
         return result
-    return result.get('remoteLinks', [result] if result else [])
+    if not result:
+        return []
+    if not isinstance(result, dict):
+        raise ValueError(f"Unexpected response type from remotelink API: {type(result).__name__}")
+    return result.get('remoteLinks', [result])
 
 
 def get_project_metadata(project_key: str) -> Dict[str, Any]:

--- a/plugins/sdlc-workflow/scripts/jira-client.py
+++ b/plugins/sdlc-workflow/scripts/jira-client.py
@@ -591,6 +591,21 @@ def get_user_info() -> Dict[str, Any]:
     return make_request('GET', 'myself')
 
 
+def get_remote_links(issue_key: str) -> List[Dict[str, Any]]:
+    """Get remote links for a JIRA issue.
+
+    Args:
+        issue_key: Issue key (e.g., TC-123)
+
+    Returns:
+        List of remote link objects
+    """
+    result = make_request('GET', f"issue/{issue_key}/remotelink")
+    if isinstance(result, list):
+        return result
+    return result.get('remoteLinks', [result] if result else [])
+
+
 def get_project_metadata(project_key: str) -> Dict[str, Any]:
     """Get project metadata including issue types and fields.
 
@@ -674,6 +689,10 @@ def main(argv=None):
     # get_user_info
     subparsers.add_parser('get_user_info', help='Get current user info')
 
+    # get_remote_links
+    get_remote_links_parser = subparsers.add_parser('get_remote_links', help='Get remote links for issue')
+    get_remote_links_parser.add_argument('issue_key', help='Issue key (e.g., TC-123)')
+
     # get_project_metadata
     project_parser = subparsers.add_parser('get_project_metadata', help='Get project metadata')
     project_parser.add_argument('project_key', help='Project key')
@@ -727,6 +746,9 @@ def main(argv=None):
 
     elif args.command == 'get_user_info':
         result = get_user_info()
+
+    elif args.command == 'get_remote_links':
+        result = get_remote_links(args.issue_key)
 
     elif args.command == 'get_project_metadata':
         result = get_project_metadata(args.project_key)

--- a/plugins/sdlc-workflow/skills/triage-security/SKILL.md
+++ b/plugins/sdlc-workflow/skills/triage-security/SKILL.md
@@ -147,8 +147,7 @@ Follow the JIRA Access protocol in `shared/jira-access-strategy.md`.
 - `jira.create_link(...)` → `python3 scripts/jira-client.py create_link --inward <key> --outward <key> --link-type <type>`
 - `jira.transition_issue(id, status)` → First `get_transitions <id>`, then `transition_issue <id> --transition-id <id>`
 - `jira.add_comment(id, text)` → `python3 scripts/jira-client.py add_comment <id> --comment-md "<text>"`
-- `jira.get_issue_remote_links(id)` → not available via REST client; if MCP is
-  unavailable, warn the user and skip upstream reference extraction
+- `jira.get_issue_remote_links(id)` → `python3 scripts/jira-client.py get_remote_links <id>`
 
 **Exception for Bash tool:** When using REST API fallback, this skill may use
 `bash -c "python3 scripts/jira-client.py <command>"` for JIRA operations only.


### PR DESCRIPTION
## Summary

Adds `get_remote_links` command to the Jira REST API client (`jira-client.py`), providing a fallback for `getJiraIssueRemoteIssueLinks` MCP when unavailable. Updates `triage-security/SKILL.md` Step 0.5 to document the new command instead of warning that it's not available.

- **Eval-13 fix (TC-4985):** Reworded eval-13 assertions from execution-evidence language to output-checking language, fixing a 5/5→0/5 regression caused by grader correctly identifying plan output as non-executed steps when the eval prompt prohibits actual Jira calls.

**Jira:** [TC-4903](https://redhat.atlassian.net/browse/TC-4903), [TC-4985](https://redhat.atlassian.net/browse/TC-4985)

## Changes

- **`plugins/sdlc-workflow/scripts/jira-client.py`** — Added `get_remote_links` API function, argparser entry, and dispatch case following existing command patterns
- **`plugins/sdlc-workflow/skills/triage-security/SKILL.md`** — Updated REST fallback table to show `get_remote_links <id>` instead of "not available via REST client"
- **`evals/triage-security/evals.json`** — Reworded eval-13 assertions and expected_output for dry-run compatibility

## Test plan

- [x] `python3 jira-client.py get_remote_links --help` shows correct usage
- [x] Command appears in main `--help` output
- [x] Module-level import and function signature verified
- [x] evals.json JSON validity verified
- [ ] Manual test with real Jira credentials (optional, deferred to reviewer)
- [ ] Verify eval-13 passes >=80% on CI re-run

## Summary by Sourcery

Add Jira REST client support for fetching issue remote links and update triage-security documentation to use the new command as the fallback for remote link retrieval.

New Features:
- Introduce a get_remote_links command in the Jira REST client to retrieve remote links for a given issue.

Documentation:
- Update triage-security skill documentation to reference the new get_remote_links REST command instead of indicating the capability is unavailable.