### PR TITLE
feat(triage-security): add staleness detection for security-matrix.md

### DIFF
--- a/docs/templates/security-matrix.md
+++ b/docs/templates/security-matrix.md
@@ -1,3 +1,5 @@
+<!-- Last-Updated: {{last-updated-timestamp}} -->
+
 # Security Matrix Template
 
 <!-- TODO: Copy this template into the project working directory at the path specified in

--- a/evals/triage-security/evals.json
+++ b/evals/triage-security/evals.json
@@ -230,6 +230,31 @@
         "Step 1.7 requires explicit engineer confirmation (Yes/No) before proceeding to Step 2 — the gate is a confirmation prompt, not an informational message (§1.70)",
         "The embargo warning gate does NOT trigger for Low or Moderate severity CVEs (CVSS < 7.0) — it is skipped silently when severity is below threshold (§1.70)"
       ]
+    },
+    {
+      "id": 19,
+      "prompt": "Triage Vulnerability issue TC-8001. The issue details are in vuln-issue-standard.md, the security matrix is in security-matrix-stale-mock.md (which has a Last-Updated timestamp of 2026-05-01T10:00:00Z — more than 14 days old), and the project CLAUDE.md is in claude-md-security-config.md. Do NOT actually call Jira MCP, git show, or any external tools. Instead, write your triage analysis to the workspace outputs/ directory: write outputs/staleness-check.md with the Step 0.3 staleness detection output including the warning message and user options.",
+      "expected_output": "A staleness check that detects the security-matrix.md timestamp (2026-05-01T10:00:00Z) is older than the 14-day default threshold and presents a warning with three options: refresh now, proceed anyway, or stop.",
+      "files": ["files/vuln-issue-standard.md", "files/security-matrix-stale-mock.md", "files/claude-md-security-config.md"],
+      "assertions": [
+        "Step 0.3 reads the Last-Updated timestamp from the security-matrix.md HTML comment and parses the ISO 8601 value",
+        "Step 0.3 detects that the matrix is older than the 14-day default threshold and displays a staleness warning",
+        "The staleness warning includes the stream name, the last-updated date, and the number of days since the last update",
+        "The warning presents three options: refresh now (re-run setup Step 10.6), proceed anyway, or stop",
+        "Step 0.3 runs before Step 0.5 (JIRA Access Initialization) — no Jira operations are attempted before the staleness check"
+      ]
+    },
+    {
+      "id": 20,
+      "prompt": "Triage Vulnerability issue TC-8001. The issue details are in vuln-issue-standard.md, the security matrix is in security-matrix-mock.md (which has a recent Last-Updated timestamp within the 14-day threshold), and the project CLAUDE.md is in claude-md-security-config.md. Do NOT actually call Jira MCP, git show, or any external tools. Instead, write your triage analysis to the workspace outputs/ directory: write outputs/staleness-check.md documenting the Step 0.3 result, and write outputs/data-extraction.md with the parsed CVE data table from Step 1.",
+      "expected_output": "Step 0.3 reads the Last-Updated timestamp, finds it within the 14-day threshold, and proceeds silently to the next step without any warning or user prompt.",
+      "files": ["files/vuln-issue-standard.md", "files/security-matrix-mock.md", "files/claude-md-security-config.md"],
+      "assertions": [
+        "Step 0.3 reads the Last-Updated timestamp from the security-matrix.md HTML comment",
+        "Step 0.3 determines the matrix is within the 14-day threshold and proceeds without displaying a staleness warning",
+        "No user prompt or options are presented for a fresh matrix — the check is silent on success",
+        "The triage continues to Step 0.5 and beyond without interruption from the staleness check"
+      ]
     }
   ]
 }

--- a/evals/triage-security/files/security-matrix-stale-mock.md
+++ b/evals/triage-security/files/security-matrix-stale-mock.md
@@ -1,5 +1,5 @@
-<!-- Last-Updated: 2026-06-28T10:00:00Z -->
-<!-- SYNTHETIC TEST DATA — mock security-matrix.md files for two version streams for triage-security eval testing -->
+<!-- Last-Updated: 2026-05-01T10:00:00Z -->
+<!-- SYNTHETIC TEST DATA — stale security-matrix.md fixture for staleness detection eval testing -->
 
 # Stream 1: rhtpa-release.0.3.z (2.1.x stream)
 

--- a/plugins/sdlc-workflow/skills/setup/SKILL.md
+++ b/plugins/sdlc-workflow/skills/setup/SKILL.md
@@ -585,7 +585,11 @@ If the user accepts, for each Version Stream:
    - **Retag status** — whether this version shares the same source commits as another
 3. Write the discovered rows into the Supportability Matrix table in the stream's
    `security-matrix.md`
-4. Present the populated matrix to the user for review before writing
+4. Write or update the `<!-- Last-Updated: <ISO-8601-timestamp> -->` HTML comment at
+   the very first line of the file. Use the current UTC timestamp in ISO 8601 format
+   (e.g., `<!-- Last-Updated: 2026-06-29T14:30:00Z -->`). This timestamp is consumed
+   by triage-security's Step 0.3 staleness check.
+5. Present the populated matrix to the user for review before writing
 
 ## Step 11 – Validate
 

--- a/plugins/sdlc-workflow/skills/triage-security/SKILL.md
+++ b/plugins/sdlc-workflow/skills/triage-security/SKILL.md
@@ -35,6 +35,7 @@ Do **not** use for:
 | Step | Name | Input | Output |
 |------|------|-------|--------|
 | 0 | Validate Configuration | CLAUDE.md | Project key, Cloud ID, Security Config |
+| 0.3 | Matrix Staleness Check | security-matrix.md timestamps | Staleness warning or proceed |
 | 0.5 | Jira Access | -- | MCP or REST API connection |
 | 1 | Data Extraction | Vulnerability issue key | CVE ID, library, affected range, remote links |
 | 1.5 | External CVE Data Enrichment | CVE ID | Structured version ranges, cross-validated fix thresholds |
@@ -138,6 +139,47 @@ Extract the following from the configuration for use in later steps:
   If not configured, Step 1.7 is skipped entirely.
 - **Version Streams** — Konflux release repo URLs and local paths from Security Configuration
 - **Source Repositories** — source repo names and URLs from Security Configuration
+
+## Step 0.3 – Matrix Staleness Check
+
+Before proceeding with triage, verify that each version stream's `security-matrix.md`
+has been updated recently enough to reflect the current release landscape. A stale
+matrix can cause triage to miss newly released versions or use outdated source commit
+references.
+
+For each row in the **Version Streams** table in Security Configuration:
+
+1. **Read the matrix file** at the configured **Security Matrix Path** (relative to
+   the project working directory).
+2. **Extract the timestamp** from the `<!-- Last-Updated: <ISO-8601> -->` HTML comment
+   at the top of the file. Parse the ISO 8601 value.
+3. **Check for staleness** — compare the timestamp against the current date. If the
+   matrix is older than **14 days** (the default threshold), warn the user:
+
+   > "Security matrix for stream **<stream>** was last updated on <date>
+   > (<N> days ago). The matrix may not reflect recent releases.
+   >
+   > Options:
+   > 1. **Refresh now** — re-run matrix population (setup Step 10.6) for this stream
+   > 2. **Proceed anyway** — continue triage with the current matrix
+   > 3. **Stop** — halt triage so I can investigate"
+
+   Wait for the user's choice before proceeding.
+
+4. **If no timestamp found** — the matrix predates staleness tracking. Warn:
+
+   > "Security matrix for stream **<stream>** has no Last-Updated timestamp.
+   > Consider running `/setup` to populate it with a timestamp for future
+   > staleness checks."
+
+   Proceed without blocking — absence of a timestamp is not an error.
+
+5. **If the matrix file does not exist** — this is handled by Step 2.1's existing
+   fallback logic. Skip the staleness check for this stream.
+
+If the user chooses **Refresh now**, invoke the matrix population logic from setup
+Step 10.6 for the selected stream. After population completes (which writes an
+updated `Last-Updated` timestamp), continue with the refreshed matrix.
 
 ## Step 0.5 – JIRA Access Initialization
 

--- a/plugins/sdlc-workflow/skills/triage-security/version-impact-analysis.md
+++ b/plugins/sdlc-workflow/skills/triage-security/version-impact-analysis.md
@@ -267,6 +267,12 @@ for the stream.
    > "⚠️ SBOM verification skipped — cosign not available / SBOM download failed.
    > Using rpms.lock.yaml classification only."
 
+   **Output requirement:** the dependency chain output for RPM packages MUST
+   always include an SBOM verification status line — either the comparison
+   result (sub-step 6) or the skip notice above. This line is mandatory even
+   though the cosign verification itself is optional; omitting it leaves the
+   engineer without visibility into whether SBOM cross-validation was attempted.
+
 4. **Base image reference** (when origin is base image) — extract the `FROM`
    reference from the Dockerfile to identify the update path:
    ```bash

--- a/plugins/sdlc-workflow/skills/triage-security/version-impact-analysis.md
+++ b/plugins/sdlc-workflow/skills/triage-security/version-impact-analysis.md
@@ -8,8 +8,11 @@ ship the vulnerable dependency by reading lock files at pinned source commits.
 
 For each row in the **Version Streams** table in Security Configuration, read the
 `security-matrix.md` file at the path given in the **Security Matrix Path** column,
-resolved relative to the project's working directory. Each `security-matrix.md`
-covers one version stream and contains:
+resolved relative to the project's working directory. Step 0.3 already verified
+that each matrix file's `Last-Updated` timestamp is recent — if staleness was
+detected, the user chose to refresh or proceed before reaching this step.
+
+Each `security-matrix.md` covers one version stream and contains:
 
 - **Version stream** — which product versions this repo covers (e.g., `2.1.x`)
 - **Supportability matrix** — a table mapping each version to source commits


### PR DESCRIPTION
## Summary

- Add Step 0.3 matrix staleness check to triage-security skill that reads `<!-- Last-Updated: ... -->` timestamps from security-matrix.md files and warns when older than 14 days
- Update setup Step 10.6 to write ISO 8601 timestamp after matrix population
- Add timestamp placeholder to security-matrix.md template for new project scaffolding
- Add two eval scenarios (IDs 17-18) for stale and fresh matrix detection
- Fix eval-5 SBOM verification assertion by adding explicit output requirement for the SBOM verification status line in RPM dependency chain output (TC-4989)

Implements [TC-4905](https://redhat.atlassian.net/browse/TC-4905)

## Test plan

- [ ] Verify eval 17 (stale matrix) triggers staleness warning with 3 options
- [ ] Verify eval 18 (fresh matrix) proceeds silently without warning
- [ ] Verify eval-5 SBOM verification assertion passes
- [ ] Verify `claude plugin validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a staleness check step to triage-security that inspects Last-Updated timestamps in security-matrix.md before triage and integrates matrix refresh flow, ensure setup writes ISO 8601 timestamps into matrices, scaffold new matrices with a timestamp placeholder, and extend triage-security evals with fresh vs stale matrix scenarios.

New Features:
- Introduce Step 0.3 in triage-security to detect stale security-matrix.md files and prompt users to refresh, proceed, or stop triage.
- Add timestamp support to security-matrix scaffolding and population so matrices carry a Last-Updated ISO 8601 marker for staleness checks.
- Add new eval fixtures and scenarios to validate behavior with both fresh and stale security matrices.

Enhancements:
- Clarify version-impact-analysis behavior by documenting reliance on prior staleness verification in Step 0.3.

Tests:
- Add synthetic security-matrix fixtures and eval cases to cover staleness detection and non-stale flows in triage-security.