### PR TITLE
feat(triage-security): add cross-CVE traceability links and comments to Step 4.3

### DIFF
--- a/evals/triage-security/evals.json
+++ b/evals/triage-security/evals.json
@@ -109,7 +109,10 @@
         "Step 4.3 filters search results by matching PS Component (customfield_10669 = pscomponent:org/rhtpa-ui) and Stream (customfield_10832 = rhtpa-2.2)",
         "Step 4.3 traverses issuelinks on TC-8008 to find remediation task TC-8009 via the 'Depend' link type",
         "Step 4.3 compares the remediation task's bump version (1.9.0) against the current CVE's fix threshold (1.8.2) and determines the fix is already covered",
-        "Triage outcome recommends closing the issue because existing remediation task TC-8009 already bumps axios past the fix threshold — no new remediation task is created"
+        "Triage outcome recommends closing the issue because existing remediation task TC-8009 already bumps axios past the fix threshold — no new remediation task is created",
+        "After engineer confirms closure, Step 4.3 creates a Related link between the current CVE (TC-8010) and the related CVE (TC-8008) with an idempotency check on existing issuelinks before creating",
+        "After engineer confirms closure, Step 4.3 creates a Depend link from the covering remediation task (TC-8009) to the current CVE (TC-8010) with an idempotency check on existing issuelinks before creating",
+        "A comment is posted on the current CVE documenting the cross-CVE overlap finding — including the related CVE key (TC-8008), covering task key (TC-8009), library (axios), bump version (1.9.0), and fix threshold (1.8.2)"
       ]
     },
     {

--- a/evals/triage-security/evals.json
+++ b/evals/triage-security/evals.json
@@ -110,8 +110,8 @@
         "Step 4.3 traverses issuelinks on TC-8008 to find remediation task TC-8009 via the 'Depend' link type",
         "Step 4.3 compares the remediation task's bump version (1.9.0) against the current CVE's fix threshold (1.8.2) and determines the fix is already covered",
         "Triage outcome recommends closing the issue because existing remediation task TC-8009 already bumps axios past the fix threshold — no new remediation task is created",
-        "After engineer confirms closure, Step 4.3 creates a Related link between the current CVE (TC-8010) and the related CVE (TC-8008) with an idempotency check on existing issuelinks before creating",
-        "After engineer confirms closure, Step 4.3 creates a Depend link from the covering remediation task (TC-8009) to the current CVE (TC-8010) with an idempotency check on existing issuelinks before creating",
+        "Step 4.3 creates a Related link between the current CVE (TC-8010) and the related CVE (TC-8008) with an idempotency check on existing issuelinks before creating",
+        "Step 4.3 creates a Depend link from the covering remediation task (TC-8009) to the current CVE (TC-8010) with an idempotency check on existing issuelinks before creating",
         "A comment is posted on the current CVE documenting the cross-CVE overlap finding — including the related CVE key (TC-8008), covering task key (TC-8009), library (axios), bump version (1.9.0), and fix threshold (1.8.2)"
       ]
     },

--- a/plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md
+++ b/plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md
@@ -227,17 +227,10 @@ entirely.
    If no ProdSec Jira account ID is configured, omit the @mention silently.
 
    - **If a covering remediation exists:**
-     ```
-     Existing remediation task [task-key] (from [related-CVE-ID]) already bumps
-     [library] to [version], which meets or exceeds this CVE's fix threshold
-     ([fix-version]). No new remediation task needed.
 
-     Recommendation: Close this issue — the fix is already covered by [task-key].
-     [ProdSec @mention if configured]
-     ```
-
-     **After engineer confirms closure**, create traceability links and post an
-     explanatory comment before transitioning to Closed:
+     Create traceability links and post an explanatory comment as soon as the
+     overlap is confirmed (these record a factual relationship and must not be
+     deferred to a closure decision):
 
      a. **Create Related link** between the current CVE and the related CVE
         (idempotent — check existing `issuelinks` first, same pattern as
@@ -297,6 +290,16 @@ entirely.
         ```
 
         MUST include the Comment Footnote (see SKILL.md).
+
+     Then present the finding and recommendation to the engineer:
+     ```
+     Existing remediation task [task-key] (from [related-CVE-ID]) already bumps
+     [library] to [version], which meets or exceeds this CVE's fix threshold
+     ([fix-version]). No new remediation task needed.
+
+     Recommendation: Close this issue — the fix is already covered by [task-key].
+     [ProdSec @mention if configured]
+     ```
    - **If related CVEs exist but no covering remediation:**
      ```
      Related CVE Jiras found for [component] in the same stream:

--- a/plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md
+++ b/plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md
@@ -235,6 +235,68 @@ entirely.
      Recommendation: Close this issue — the fix is already covered by [task-key].
      [ProdSec @mention if configured]
      ```
+
+     **After engineer confirms closure**, create traceability links and post an
+     explanatory comment before transitioning to Closed:
+
+     a. **Create Related link** between the current CVE and the related CVE
+        (idempotent — check existing `issuelinks` first, same pattern as
+        Step 4.2):
+
+        Check the current issue's `issuelinks` array (already fetched in
+        Step 1) for an existing link where `type.name` is `"Related"` and
+        `inwardIssue.key` or `outwardIssue.key` matches the related CVE key.
+
+        If a matching link exists, skip and log:
+        > "Related link to [related-cve-key] already exists — skipping"
+
+        If no matching link exists, create the link:
+        ```
+        jira.create_link(
+          inwardIssue: <current-cve-key>,
+          outwardIssue: <related-cve-key>,
+          type: "Related"
+        )
+        ```
+
+     b. **Create Depend link** from the covering remediation task to the
+        current CVE (same link type as standard remediation linkage in
+        `remediation-templates.md`):
+
+        Check the current issue's `issuelinks` array for an existing link
+        where `type.name` is `"Depend"` and `inwardIssue.key` or
+        `outwardIssue.key` matches the covering task key.
+
+        If a matching link exists, skip and log:
+        > "Depend link to [covering-task-key] already exists — skipping"
+
+        If no matching link exists, create the link:
+        ```
+        jira.create_link(
+          inwardIssue: <current-cve-key>,
+          outwardIssue: <covering-task-key>,
+          type: "Depend"
+        )
+        ```
+
+     c. **Post a comment** on the current CVE documenting the cross-CVE
+        overlap finding. If a ProdSec Jira account ID is configured, include
+        an @mention before the Comment Footnote:
+        ```
+        Cross-CVE overlap: existing remediation task [covering-task-key] (from
+        [related-CVE-ID] / [related-cve-key]) already bumps [library] to
+        [version], which meets or exceeds this CVE's fix threshold
+        ([fix-version]).
+
+        Links created:
+        - Related: [current-cve-key] ↔ [related-cve-key] (same upstream component)
+        - Depend: [current-cve-key] → [covering-task-key] (covering remediation)
+
+        [ProdSec @mention if configured]
+        [Comment Footnote]
+        ```
+
+        MUST include the Comment Footnote (see SKILL.md).
    - **If related CVEs exist but no covering remediation:**
      ```
      Related CVE Jiras found for [component] in the same stream:


### PR DESCRIPTION
## Summary

- Adds Related and Depend link creation to Step 4.3's "covering remediation exists" path, executed after engineer confirms closure
- Both links include idempotency checks following the existing Step 4.2 pattern (check `issuelinks` before creating)
- Posts an explanatory comment on the current CVE documenting the cross-CVE overlap finding with all relevant details
- Adds 3 eval assertions to eval 8 covering the traceability behavior

Implements [TC-5009](https://redhat.atlassian.net/browse/TC-5009)

## Test plan

- [ ] Grep `jira-triage-operations.md` for `create_link` within Step 4.3 — should have both "Related" and "Depend" link creation
- [ ] Grep for idempotency check pattern within Step 4.3 — should check existing `issuelinks` before creating
- [ ] Verify the comment template includes related CVE key, covering task key, library, bump version, and fix threshold
- [ ] Verify eval 8 assertions cover cross-CVE traceability (Related link, Depend link, and comment)
- [ ] Validate `evals.json` is valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document cross-CVE traceability actions in Step 4.3 of the triage-security Jira workflow, including links and comments, and extend eval coverage for this behavior.

New Features:
- Define creation of Related and Depend Jira issue links for cross-CVE remediation coverage in Step 4.3.
- Specify posting of an explanatory cross-CVE overlap comment on the current CVE, including remediation and linkage details.

Tests:
- Add eval coverage asserting Related link, Depend link, and comment behavior for cross-CVE traceability in eval 8 and update evals configuration JSON accordingly.