### PR TITLE
docs(plan-feature): add testing readiness template and document task generation

### DIFF
--- a/docs/templates/testing-readiness.md
+++ b/docs/templates/testing-readiness.md
@@ -1,0 +1,53 @@
+# Testing Readiness Template
+
+<!-- This template defines cross-cutting, feature-level test categories for your project.
+     Place a copy of this file at docs/testing-readiness.md in your target repository.
+     The plan-feature skill auto-discovers it at that path and generates one testing
+     task per category for each feature.
+
+     How it works:
+     - Each ## heading defines a test category (e.g., Smoke Tests, Integration Tests).
+     - Bullet points under each heading are acceptance criteria for that category.
+     - plan-feature reads the headings and criteria, then creates a Jira testing task
+       for each category. The task's Acceptance Criteria section is populated directly
+       from the bullet points listed here.
+
+     How to customize:
+     - Add, remove, or rename ## headings to match your project's testing strategy.
+     - Adjust the acceptance criteria under each heading to reflect your project's
+       quality standards and infrastructure.
+     - Categories are independent — you can have as few or as many as needed.
+
+     Opt-out:
+     - To disable testing task generation entirely, remove or do not create the
+       docs/testing-readiness.md file in your repository. plan-feature skips testing
+       task generation when the file is absent. -->
+
+## Smoke Tests
+
+<!-- Smoke tests validate the happy path for the feature end-to-end.
+     Adjust these criteria to match your project's deployment and verification workflow. -->
+
+- The feature's primary workflow completes successfully in a deployed environment
+- No errors appear in application logs during the happy-path scenario
+- The feature is accessible via its intended entry point (UI route, API endpoint, CLI command)
+
+## Integration Tests
+
+<!-- Integration tests verify cross-component or cross-service interactions introduced
+     by the feature. Adjust these criteria based on the integration boundaries in your
+     project (e.g., database, message queue, external API). -->
+
+- Components modified by the feature interact correctly with their direct dependencies
+- Data flows through the feature's full processing pipeline without corruption or loss
+- Error responses from dependent services are handled gracefully (no silent failures, no crashes)
+
+## Performance Benchmarks
+
+<!-- Performance benchmarks ensure the feature meets response-time or throughput thresholds.
+     Adjust the specific thresholds and measurement methods to match your project's SLAs
+     and performance testing infrastructure. -->
+
+- New API endpoints respond within the project's defined latency threshold under normal load
+- Bulk operations or list endpoints handle the expected data volume without timeout or excessive memory use
+- No measurable regression in existing endpoint response times after the feature is deployed

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -181,8 +181,20 @@ Converts a Jira feature into structured implementation tasks.
 
 **Workflow mode determination:** After the Repository Impact Map is approved, the skill determines whether the feature requires **feature-branch mode** (all-or-nothing delivery) or **direct-to-main mode** (incremental delivery). The decision is based on atomicity indicators — coordinated schema migrations, breaking API changes, cross-cutting refactors, or tightly coupled feature components. When any indicator is present, feature-branch mode is selected; otherwise direct-to-main mode is used. The decision is recorded as a comment on the feature issue.
 
+**Documentation and testing task generation:** In addition to implementation tasks, plan-feature can generate two types of feature-level tasks:
+
+- **Documentation tasks** are triggered when the Feature's "Documentation Considerations" section (captured during `/define-feature`) indicates doc impact — New Content, Updates to existing content, or Release Notes. The generated task describes what documentation needs updating and what type of update is needed. Documentation tasks depend on all implementation tasks so that documentation is written after the feature is implemented. When the Documentation Considerations section is absent or states "No Doc Impact", documentation task generation is skipped.
+
+- **Testing tasks** are triggered by the presence of a testing readiness template at `docs/testing-readiness.md` in the target repository. The template uses `## <Category Name>` headings to define cross-cutting test categories (e.g., Smoke Tests, Integration Tests, Performance Benchmarks), with acceptance criteria listed as bullet points under each heading. Plan-feature generates one testing task per category, using the template's acceptance criteria directly. Testing tasks depend on all implementation tasks. When no readiness template exists, testing task generation is skipped silently. See [docs/templates/testing-readiness.md](templates/testing-readiness.md) for the template format.
+
+Both task types are **additive** — they complement the per-task Test Requirements and Documentation Updates sections in individual implementation tasks, rather than replacing them. Documentation tasks cover feature-level documentation impact, while testing tasks cover cross-cutting validation that spans the entire feature.
+
+**Opt-out:** Documentation tasks are controlled by the Feature description (omit the Documentation Considerations section or state "No Doc Impact"). Testing tasks are controlled by the presence of the readiness template file (remove or do not create `docs/testing-readiness.md` to skip).
+
 **Output:**
 - Implementation tasks created in Jira (labeled `ai-generated-jira`)
+- Documentation task (when Documentation Considerations section indicates doc impact)
+- Testing tasks (one per category in `docs/testing-readiness.md`, when the file exists)
 - Impact map comment on the feature issue
 - Workflow mode decision comment on the feature issue
 - Issue links (feature incorporates tasks, task dependency chains)


### PR DESCRIPTION
## Summary

- Add `docs/templates/testing-readiness.md` — defines the format for cross-cutting testing readiness templates with example categories (Smoke Tests, Integration Tests, Performance Benchmarks) and HTML comment guidance for customization
- Update `docs/workflow.md` Plan Phase section — documents documentation task generation (triggered by Feature's Documentation Considerations section) and testing task generation (triggered by `docs/testing-readiness.md` auto-discovery), including opt-out mechanisms and additive behavior
- Update Plan Phase Output list to include documentation and testing tasks as additional outputs

Implements [TC-4879](https://redhat.atlassian.net/browse/TC-4879)

## Test plan

- [x] Template uses `## <Category Name>` heading format matching plan-feature's parser expectations
- [x] Template includes 3 example categories with 3 acceptance criteria each
- [x] Template uses HTML comments consistent with existing template patterns (`bug-template.md`, `conventions.template.md`)
- [x] Workflow documentation describes triggers, opt-out, and additive behavior for both task types
- [x] Scope containment verified — only `docs/workflow.md` (modified) and `docs/templates/testing-readiness.md` (created) are changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document automatic generation of documentation and testing tasks in the plan-feature workflow and introduce a reusable testing readiness template.

Documentation:
- Describe how documentation and testing tasks are generated during the Plan Phase, including triggers, dependencies, additive behavior, and opt-out mechanisms.
- Add a Testing Readiness template that defines cross-cutting test categories and acceptance criteria for feature-level testing tasks.