### PR TITLE
fix(plan-feature): clarify direct dependency requirement for create-branch bookend

### DIFF
--- a/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
@@ -924,6 +924,12 @@ bracket the intermediate implementation tasks:
   Description, Acceptance Criteria, Test Requirements, or Dependencies — these
   are listed above and must be included.
 - All intermediate tasks MUST list this task in their `## Dependencies` section.
+  This means EVERY non-documentation intermediate task must include the
+  create-branch task in its `## Dependencies` section, in addition to any
+  task-specific dependencies. Chain dependencies (Task 3 depends on Task 2,
+  which depends on Task 1) are insufficient — each task must directly list the
+  create-branch bookend. Documentation tasks may list implementation tasks as
+  dependencies instead, since documentation depends on implementation completion.
 
 **Last task — merge feature branch:**
 


### PR DESCRIPTION
## Summary

- Strengthens the create-branch bookend dependency instruction in `plan-feature/SKILL.md` to explicitly state that chain dependencies are insufficient
- Every non-documentation intermediate task must directly list the create-branch bookend in its `## Dependencies` section, in addition to any task-specific dependencies
- Documentation task exemption preserved — they may list implementation tasks as dependencies instead

Implements [TC-5055](https://redhat.atlassian.net/browse/TC-5055)

## Test plan

- [ ] Existing eval-5 assertion 7 ("All non-documentation intermediate tasks list the create-branch bookend task as a dependency") should pass
- [ ] Read the updated instruction and confirm it is unambiguous about direct vs transitive dependency requirements
- [ ] Run `grep -A 8 "All intermediate tasks MUST" plugins/sdlc-workflow/skills/plan-feature/SKILL.md` to verify the strengthened text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Clarify that all non-documentation intermediate tasks must directly list the create-branch bookend as a dependency and that chained dependencies are insufficient, while preserving the documentation-task exemption.