### PR TITLE
fix(plan-feature): add non-plannable requirement flagging to impact map step

### DIFF
--- a/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
+++ b/plugins/sdlc-workflow/skills/plan-feature/SKILL.md
@@ -560,6 +560,8 @@ Rules:
 - Each change should be a short, concrete statement of what needs to happen (not how)
 - The map is the basis for task generation in Step 5 — every change listed here will become part of a Jira task
 
+When a requirement from the Feature description cannot be planned due to missing inputs (no design mockups available, no target repository for that requirement's domain, insufficient specification to decompose into tasks), explicitly document it in the impact map under an "Excluded requirements" section. For each excluded requirement, state the requirement and the specific missing input that prevents planning. Do not silently omit requirements — the engineer needs to know what was excluded and why so they can provide the missing inputs. This applies to MVP and non-MVP requirements alike — any requirement that cannot be decomposed into actionable tasks should be flagged rather than silently dropped.
+
 Present the map to the user for review before proceeding to task generation.
 
 Once the user approves the map, post it as a comment on the Jira feature issue using:


### PR DESCRIPTION
## Summary

- Add instruction to Step 4 (Build Repository Impact Map) to explicitly flag requirements that cannot be planned due to missing inputs (no design mockups, no target repository, insufficient specification)
- Non-plannable requirements are documented in an "Excluded requirements" section of the impact map with reasoning, rather than silently omitted
- Applies to both MVP and non-MVP requirements

Implements [TC-5056](https://redhat.atlassian.net/browse/TC-5056)

## Test plan

- [ ] Run eval-2 and verify assertion 2 passes ("Plan acknowledges that 'Better UI' cannot be planned without design mockups or frontend repository")
- [ ] Verify grep finds the new instruction: `grep -i "non-plannable\|excluded requirements\|cannot be planned\|missing inputs" plugins/sdlc-workflow/skills/plan-feature/SKILL.md`
- [ ] Read the updated Step 4 and confirm the instruction is clear about what constitutes a non-plannable requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Document a process for explicitly recording non-plannable requirements and their missing inputs in an "Excluded requirements" section of the impact map, applying to both MVP and non-MVP requirements.