### PR TITLE
chore: add CODEOWNERS for sensitive path review enforcement

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,12 @@
+# Sensitive paths requiring review from Maintainers or Owners.
+# When org teams are created, replace usernames with team references.
+
+# Plugin manifests — changes affect all users (Maintainers + Owners)
+/plugins/sdlc-workflow/.claude-plugin/ @mrizzi
+/.claude-plugin/marketplace.json @mrizzi
+
+# Core methodology — highest trust required (Owners)
+/docs/methodology.md @mrizzi
+
+# Governance documents — highest trust required (Owners)
+/CONTRIBUTING.md @mrizzi

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,8 +2,8 @@
 # When org teams are created, replace usernames with team references.
 
 # Plugin manifests — changes affect all users (Maintainers + Owners)
-/plugins/sdlc-workflow/.claude-plugin/ @mrizzi
-/.claude-plugin/marketplace.json @mrizzi
+/plugins/sdlc-workflow/.claude-plugin/ @mrizzi @ruromero
+/.claude-plugin/marketplace.json @mrizzi @ruromero
 
 # Core methodology — highest trust required (Owners)
 /docs/methodology.md @mrizzi


### PR DESCRIPTION
## Summary

- Add `CODEOWNERS` file at repo root mapping sensitive paths to required reviewers
- Plugin manifest paths (`plugins/sdlc-workflow/.claude-plugin/`, `.claude-plugin/marketplace.json`) require Maintainer/Owner review
- Core methodology (`docs/methodology.md`) and governance (`CONTRIBUTING.md`) require Owner review
- Uses GitHub usernames (`@mrizzi`) — to be replaced with team references when org teams are created

Implements [TC-5080](https://redhat.atlassian.net/browse/TC-5080)

## Summary by Sourcery

Chores:
- Introduce a root CODEOWNERS file mapping plugin manifests, methodology docs, and governance docs to required reviewers.