### PR TITLE
docs: add Contributing section and changelog entry for contributors ladder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the sdlc-workflow plugin are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Contributors ladder with CONTRIBUTING.md, CODEOWNERS, and GitHub Issue templates (TC-5072)
+
 ## [0.12.2] - 2026-07-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ workflow.
 - [Conventions Template](docs/templates/conventions.md) — Template for
   documenting your project's coding conventions
 
+## Contributing
+
+We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for the
+contributors ladder, promotion criteria, and workflows for issues and pull
+requests.
+
 ## License
 
 Apache-2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

- Add a Contributing section to README.md referencing CONTRIBUTING.md for contributor guidance
- Add an [Unreleased] changelog entry for the contributors ladder infrastructure (CONTRIBUTING.md, CODEOWNERS, GitHub Issue templates)

Implements [TC-5082](https://redhat.atlassian.net/browse/TC-5082)

## Summary by Sourcery

Document contributor guidance and record the new contributors ladder infrastructure in the changelog.

Documentation:
- Add a Contributing section in the README pointing to CONTRIBUTING.md for contributor guidance, promotion criteria, and workflows.

Chores:
- Add an Unreleased changelog entry describing the contributors ladder infrastructure including CONTRIBUTING.md, CODEOWNERS, and GitHub issue templates.