### PR TITLE
docs(templates): add canonical security matrix template

### DIFF
--- a/docs/templates/security-matrix.template.md
+++ b/docs/templates/security-matrix.template.md
@@ -1,0 +1,49 @@
+# Security Matrix — {stream} Stream
+
+<!-- Canonical template for security matrix files. Copy this file to the path
+     specified in your Security Configuration's Version Streams table
+     (e.g., docs/security-matrix-2.2.x.md) and replace placeholders with
+     concrete values. The triage-security skill validates existing matrices
+     against this structure. -->
+
+## Version Stream
+
+<!-- Identifies which product version stream this matrix covers. -->
+
+This Konflux release repo covers the **{stream}** product version stream.
+
+## Supportability Matrix
+
+<!-- One row per product version built from this release stream.
+     trustify and trustify-ui columns contain the tag or commit hash
+     pinned in the Konflux build. -->
+
+| RHTPA Version | Build | Build Date | trustify | trustify-ui | Notes |
+|---|---|---|---|---|---|
+| {version} | {build} | {build-date} | `{trustify-ref}` | `{trustify-ui-ref}` | |
+
+### Source Pinning Method
+
+<!-- How each source repository's commit or tag is pinned in the Konflux
+     release repo. Common methods: git submodule, artifacts.lock.yaml,
+     or tag reference in a build config file. -->
+
+- **trustify**: {trustify-pinning-method}
+- **trustify-ui**: {trustify-ui-pinning-method}
+
+## Ecosystem Mappings
+
+<!-- Maps each dependency ecosystem to its lock file and inspection command.
+     Used by triage-security to check whether a specific package version
+     is present in a given product build. -->
+
+| Ecosystem | Repository | Lock File | Check Command | Upstream Branch |
+|---|---|---|---|---|
+| {ecosystem} | {repository} | `{lock-file}` | `{check-command}` | `{upstream-branch}` |
+
+## Forward Pointer
+
+<!-- Points to the next version stream's matrix, or "None" for the latest
+     development stream. Helps navigation across streams. -->
+
+{forward-pointer}


### PR DESCRIPTION
## Summary

Adds `docs/templates/security-matrix.template.md` — a canonical template capturing the required structure (sections, table columns, placeholder rows) shared by all `security-matrix-*.md` files.

- Defines all required sections: Version Stream, Supportability Matrix, Source Pinning Method, Ecosystem Mappings, Forward Pointer
- Supportability Matrix uses the exact column set: RHTPA Version | Build | Build Date | trustify | trustify-ui | Notes
- Ecosystem Mappings uses the exact column set: Ecosystem | Repository | Lock File | Check Command | Upstream Branch
- Includes inline HTML comments explaining each section's purpose
- Verified that existing matrices (2.1.x, 2.2.x, 3.0.x) conform to the template structure

## Test plan

- [x] Template renders correctly as GitHub-flavored Markdown
- [x] All required sections present with correct heading levels
- [x] Table columns match the exact specification
- [x] Existing security-matrix files (2.1.x, 2.2.x, 3.0.x) conform to template structure
- [x] Placeholder values used consistently for variable data

Refs: [TC-5135](https://redhat.atlassian.net/browse/TC-5135)