### PR TITLE
fix(docs): use explicit repo name in release instructions

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -21,11 +21,11 @@ This document describes how to release a new version of the sdlc-workflow plugin
 
 4. **Push to the default branch.**
 
-5. **Create a GitHub release** — tag the release commit and create a GitHub release with notes from the changelog:
+5. **Create a GitHub release** — tag the release commit and create a GitHub release on `RHEcosystemAppEng/sdlc-plugins` with notes from the changelog:
    ```bash
    git tag vX.Y.Z <commit-sha>
-   git push origin vX.Y.Z
-   gh release create vX.Y.Z --title "vX.Y.Z" --latest --notes "<changelog section for this version>"
+   git push <remote> vX.Y.Z   # push to RHEcosystemAppEng/sdlc-plugins
+   gh release create vX.Y.Z --repo RHEcosystemAppEng/sdlc-plugins --title "vX.Y.Z" --latest --notes "<changelog section for this version>"
    ```
    Use the corresponding `CHANGELOG.md` section as the release notes body.
 


### PR DESCRIPTION
## Summary

- Replaced hardcoded `origin` remote name with `<remote>` placeholder and explicit `RHEcosystemAppEng/sdlc-plugins` repo references in release docs
- Added `--repo` flag to the `gh release create` example command

## Test plan

- [ ] Verify `docs/releasing.md` renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)