### PR TITLE
fix(verify-pr): add explicit Issue Type field to Step 6d sub-task creation templates

### DIFF
--- a/evals/verify-pr/evals.json
+++ b/evals/verify-pr/evals.json
@@ -59,7 +59,8 @@
         "The report contains a Test Change Classification row with ADDITIVE — only new test files were added (tests/api/sbom_delete.rs is a new file)",
         "Convention upgrade eligibility is evaluated for review comment 30002 (index suggestion) — the review classification output (review-30002.md) or the report's Style/Conventions analysis explains whether the suggestion matches a documented or demonstrated project convention",
         "Review comment 30002 (index suggestion) does NOT result in a sub-task — the suggestion classification is correct (suggestive language, no directive) and no project convention in the fixture data backs an upgrade from suggestion to code change request",
-        "Eval Quality is N/A because no eval result reviews exist in the PR — the 3-criteria detection (author github-actions[bot], marker ## Eval Results, footer sdlc-workflow/run-evals) found no matches, so Eval Quality does not affect the Test Quality combination"
+        "Eval Quality is N/A because no eval result reviews exist in the PR — the 3-criteria detection (author github-actions[bot], marker ## Eval Results, footer sdlc-workflow/run-evals) found no matches, so Eval Quality does not affect the Test Quality combination",
+        "The sub-task creation for comment 30001 explicitly specifies Issue Type as Sub-task — the subtask-30001.md file, the report's sub-task section, or the review classification output (review-30001.md) indicates the Jira issue is created with issueTypeName Sub-task (not as a standalone Task) to ensure parent-child hierarchy with the parent task"
       ]
     },
     {

--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -485,6 +485,7 @@ For each code change request (including upgraded suggestions) that requires a fi
 create a Jira sub-task:
 
 jira.create_issue with:
+- **Issue Type:** Sub-task
 - **Parent:** the current task's Jira issue ID
 - **Summary:** concise description of the required fix
 - **Labels:** `["ai-generated-jira", "review-feedback"]`
@@ -514,6 +515,7 @@ Process `create-sub-task` actions from the Correctness sub-agent. For each actio
    files, and Root cause fields:
 
    jira.create_issue with:
+   - **Issue Type:** Sub-task
    - **Parent:** the current task's Jira issue ID
    - **Summary:** the action's Title (e.g., "Fix failing lint check: unused import in handler.rs")
    - **Labels:** `["ai-generated-jira", "review-feedback"]`
@@ -556,6 +558,7 @@ and sub-task creation below.
 3. **Create sub-task:** For each failing eval, create a Jira sub-task:
 
    jira.create_issue with:
+   - **Issue Type:** Sub-task
    - **Parent:** the current task's Jira issue ID
    - **Summary:** "Fix <eval-id> assertion failures: <brief description of failures>"
    - **Labels:** `["ai-generated-jira", "eval-failure"]`


### PR DESCRIPTION
## Summary

- Add `**Issue Type:** Sub-task` as the first field in all three `jira.create_issue` templates in Step 6d (review feedback, CI failure, and eval failure sub-tasks) to ensure Jira creates Sub-tasks with parent-child hierarchy instead of standalone Tasks
- Add eval assertion to verify-pr eval 3 to validate that sub-task creation output specifies Issue Type as Sub-task

## Bug Context

Without the explicit Issue Type field, the LLM nondeterministically infers the issue type when calling `createJiraIssue`, causing ~40% of sub-tasks to be created as standalone Tasks (type 10014) instead of Sub-tasks (type 10015). Jira silently ignores the `parent` parameter for Tasks, breaking the parent-child hierarchy.

Implements [TC-5181](https://redhat.atlassian.net/browse/TC-5181)

## Test plan

- [ ] Verify all three `jira.create_issue` templates in Step 6d include `**Issue Type:** Sub-task` as the first field
- [ ] Run verify-pr evals and confirm existing assertions pass
- [ ] Confirm the new eval 3 assertion validates Issue Type in sub-task creation output
- [ ] Run `claude plugin validate plugins/sdlc-workflow` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure Jira sub-tasks created in the verify-pr workflow are explicitly typed as Sub-task to preserve parent-child hierarchy and add evaluation coverage for this behavior.

Bug Fixes:
- Specify Issue Type as Sub-task in all Step 6d jira.create_issue templates to prevent incorrect creation of standalone Tasks instead of sub-tasks.

Enhancements:
- Clarify sub-task creation instructions in the verify-pr skill documentation by including an explicit Issue Type field.
- Extend verify-pr evals to assert that sub-task creation outputs declare Issue Type as Sub-task.