### PR TITLE
feat(report-bug): add Environment/Version required section to default bug template

### DIFF
--- a/docs/templates/bug-template.md
+++ b/docs/templates/bug-template.md
@@ -22,6 +22,7 @@
 | Steps to reproduce | `### **Steps to Reproduce**` |
 | Expected Result | `### **Expected Result**` |
 | Actual Result | `### **Actual Result**` |
+| Environment / Version | `### **Environment / Version**` |
 | Attachments | `### **Attachments**` |
 
 ## Optional Sections


### PR DESCRIPTION
## Summary

- Add "Environment / Version" row to the Required Sections table in the default bug template (`docs/templates/bug-template.md`)
- The new section is placed after "Actual Result" and before "Attachments", prompting users to provide product version, deployment method, and affected area
- Since the report-bug skill is data-driven from the template table, this change automatically makes the skill prompt for the new section — no SKILL.md changes needed

Implements [TC-5311](https://redhat.atlassian.net/browse/TC-5311)

## Test Plan

- [x] Template renders correctly in Markdown with the new row
- [x] Report-bug skill picks up the new section without SKILL.md changes (data-driven validation confirmed by reading SKILL.md Step 3a)

## Summary by Sourcery

Documentation:
- Add Environment / Version as a required section in the default bug report template between Actual Result and Attachments.