### PR TITLE
fix(implement-task): add fork detection to Step 10 PR creation flows

### DIFF
--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -1073,10 +1073,34 @@ Use a scope when relevant (e.g. `feat(api): add AIBOM endpoint`).
 The footer MUST reference the Jira issue ID.
 Always include `--trailer="Assisted-by: Claude Code"` to attribute AI assistance.
 
+### Fork detection
+
+Before creating a PR, detect whether the working directory is a fork by checking
+for an `upstream` remote:
+
+```
+git remote get-url upstream 2>/dev/null
+```
+
+- If the command succeeds, an `upstream` remote exists — the user is working in a fork.
+  Parse `<upstream-owner/repo>` from the upstream remote URL and `<fork-owner>` from
+  the origin remote URL. Handle both HTTPS (`https://github.com/<owner>/<repo>.git`)
+  and SSH (`git@github.com:<owner>/<repo>.git`) URL formats.
+- If the command fails, no upstream remote exists — skip fork-specific flags and use
+  the default `gh pr create` behavior.
+
 **Default flow (no Target PR, no Bookend Type):**
 
 Push the branch and open a pull request. Always specify `--base <target-branch>`
-explicitly to ensure the PR targets the correct branch:
+explicitly to ensure the PR targets the correct branch.
+
+When a fork is detected (upstream remote exists):
+
+```
+gh pr create -R <upstream-owner/repo> --head <fork-owner>:<branch> --base <target-branch> ...
+```
+
+When no fork is detected:
 
 ```
 gh pr create --base <target-branch> ...
@@ -1115,7 +1139,15 @@ instead of creating a new PR:
 
 When Bookend Type is `merge-branch`, create a PR from the feature branch to main.
 No new commits are needed — the PR aggregates all commits already on the feature
-branch:
+branch.
+
+When a fork is detected (upstream remote exists):
+
+```
+gh pr create -R <upstream-owner/repo> --head <fork-owner>:<feature-branch-name> --base main ...
+```
+
+When no fork is detected:
 
 ```
 gh pr create --base main --head <feature-branch-name> ...


### PR DESCRIPTION
## Summary

- Add fork detection sub-step to Step 10 that checks for an `upstream` git remote before PR creation
- When a fork is detected, `gh pr create` uses `-R <upstream-owner/repo>` and `--head <fork-owner>:<branch>` to target the upstream repository
- When no fork is detected, existing behavior is preserved unchanged
- Both default flow and merge-branch bookend flow are updated; Target PR flow was already correct

Implements [TC-5315](https://redhat.atlassian.net/browse/TC-5315)

## Summary by Sourcery

Documentation:
- Update implement-task skill documentation to describe fork-aware PR creation commands for default and merge-branch bookend flows.