### PR TITLE
fix(ci): harden eval-pr-run against checkout v7 fork guard with sandbox credential isolation

### DIFF
--- a/.github/workflows/eval-baseline.yml
+++ b/.github/workflows/eval-baseline.yml
@@ -20,7 +20,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3

--- a/.github/workflows/eval-pr-run.yml
+++ b/.github/workflows/eval-pr-run.yml
@@ -113,24 +113,34 @@ jobs:
 
             const skillPattern = /^plugins\/sdlc-workflow\/skills\/([^/]+)\//;
             const evalPattern = /^evals\/([^/]+)\//;
-            const seen = new Set();
+            const candidates = new Set();
+            const filenames = new Set(files.map(f => f.filename));
 
             for (const f of files) {
-              let match = f.filename.match(skillPattern) || f.filename.match(evalPattern);
-              if (match) {
-                const skill = match[1];
-                const evalFile = files.find(ef => ef.filename === `evals/${skill}/evals.json`)
-                  || await github.rest.repos.getContent({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    path: `evals/${skill}/evals.json`,
-                    ref: `refs/pull/${prNumber}/merge`
-                  }).then(() => true).catch(() => false);
-                if (evalFile) seen.add(skill);
+              const match = f.filename.match(skillPattern) || f.filename.match(evalPattern);
+              if (match) candidates.add(match[1]);
+            }
+
+            const confirmed = [];
+            for (const skill of candidates) {
+              if (filenames.has(`evals/${skill}/evals.json`)) {
+                confirmed.push(skill);
+                continue;
+              }
+              try {
+                await github.rest.repos.getContent({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  path: `evals/${skill}/evals.json`,
+                  ref: `refs/pull/${prNumber}/merge`
+                });
+                confirmed.push(skill);
+              } catch {
+                console.log(`  Skipping ${skill} — no evals.json`);
               }
             }
 
-            const skills = [...seen].join(',');
+            const skills = confirmed.join(',');
             core.setOutput('skills', skills);
             console.log(`Discovered changed skills with evals: ${skills || 'none'}`);
 

--- a/.github/workflows/eval-pr-run.yml
+++ b/.github/workflows/eval-pr-run.yml
@@ -206,9 +206,14 @@ jobs:
                 "envVars": [
                   { "name": "ANTHROPIC_VERTEX_PROJECT_ID", "mode": "deny" },
                   { "name": "CLOUD_ML_REGION", "mode": "deny" },
-                  { "name": "CLOUDSDK_AUTH_ACCESS_TOKEN", "mode": "deny" },
                   { "name": "GOOGLE_APPLICATION_CREDENTIALS", "mode": "deny" },
-                  { "name": "GCLOUD_SERVICE_KEY", "mode": "deny" }
+                  { "name": "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE", "mode": "deny" },
+                  { "name": "GOOGLE_GHA_CREDS_PATH", "mode": "deny" },
+                  { "name": "CLOUDSDK_PROJECT", "mode": "deny" },
+                  { "name": "CLOUDSDK_CORE_PROJECT", "mode": "deny" },
+                  { "name": "GCP_PROJECT", "mode": "deny" },
+                  { "name": "GCLOUD_PROJECT", "mode": "deny" },
+                  { "name": "GOOGLE_CLOUD_PROJECT", "mode": "deny" }
                 ]
               }
             }

--- a/.github/workflows/eval-pr-run.yml
+++ b/.github/workflows/eval-pr-run.yml
@@ -5,9 +5,15 @@
 # - Collaborators with write/admin permission: evals run automatically
 # - External contributors: require manual approval via eval-protected environment
 #
-# All PR identity and skill discovery is derived from the GitHub API and
-# the checked-out PR merge commit — no data from the triggering workflow
-# is trusted.
+# All PR identity and skill discovery is derived from the GitHub API —
+# no data from the triggering workflow is trusted. The discover job uses
+# pulls.listFiles (no checkout). The run-evals job checks out the base
+# branch at workspace root (trusted CLAUDE.md) and the PR merge commit
+# into a subdirectory, passed to Claude via --add-dir.
+#
+# Credential isolation: sandbox.credentials.envVars denies GCP/Vertex AI
+# env vars from sandboxed Bash subprocesses. Claude Code's own runtime
+# retains access for API authentication.
 #
 # See docs/specs/2026-05-07-eval-pr-fork-dispatch-design.md for full design.
 
@@ -89,38 +95,44 @@ jobs:
 
             core.setOutput('trusted', trusted.toString());
 
-      - name: Checkout PR merge commit
-        uses: actions/checkout@v4
-        with:
-          ref: refs/pull/${{ steps.pr.outputs.pr_number }}/merge
-          fetch-depth: 0
-
       - name: Discover changed skills
         id: discover
-        run: |
-          BASE_SHA=$(git rev-parse HEAD^1)
-          changed_files=$(git diff --name-only "$BASE_SHA"...HEAD)
-          echo "Changed files:"
-          echo "$changed_files"
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = parseInt('${{ steps.pr.outputs.pr_number }}');
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 100
+            });
 
-          skills=""
-          for file in $changed_files; do
-            skill=""
-            if [[ "$file" =~ ^plugins/sdlc-workflow/skills/([^/]+)/ ]]; then
-              skill="${BASH_REMATCH[1]}"
-            elif [[ "$file" =~ ^evals/([^/]+)/ ]]; then
-              skill="${BASH_REMATCH[1]}"
-            fi
+            console.log(`Changed files (${files.length}):`);
+            files.forEach(f => console.log(`  ${f.filename}`));
 
-            if [ -n "$skill" ] && [ -f "evals/${skill}/evals.json" ]; then
-              if [[ ! ",$skills," == *",$skill,"* ]]; then
-                skills="${skills:+${skills},}${skill}"
-              fi
-            fi
-          done
+            const skillPattern = /^plugins\/sdlc-workflow\/skills\/([^/]+)\//;
+            const evalPattern = /^evals\/([^/]+)\//;
+            const seen = new Set();
 
-          echo "skills=${skills}" >> "$GITHUB_OUTPUT"
-          echo "Discovered changed skills with evals: ${skills:-none}"
+            for (const f of files) {
+              let match = f.filename.match(skillPattern) || f.filename.match(evalPattern);
+              if (match) {
+                const skill = match[1];
+                const evalFile = files.find(ef => ef.filename === `evals/${skill}/evals.json`)
+                  || await github.rest.repos.getContent({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    path: `evals/${skill}/evals.json`,
+                    ref: `refs/pull/${prNumber}/merge`
+                  }).then(() => true).catch(() => false);
+                if (evalFile) seen.add(skill);
+              }
+            }
+
+            const skills = [...seen].join(',');
+            core.setOutput('skills', skills);
+            console.log(`Discovered changed skills with evals: ${skills || 'none'}`);
 
       - name: Update status for approval gate
         if: steps.pr.outputs.trusted != 'true' && steps.pr.outputs.pr_number != ''
@@ -163,11 +175,16 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - name: Checkout PR merge commit
-        uses: actions/checkout@v4
+      - name: Checkout base branch
+        uses: actions/checkout@v7
+
+      - name: Checkout PR merge commit into subdirectory
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ needs.discover.outputs.pr_number }}/merge
+          path: pr-head
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
@@ -178,6 +195,26 @@ jobs:
       - name: Install Claude Code
         run: curl -fsSL https://claude.ai/install.sh | bash
 
+      - name: Write sandbox settings
+        run: |
+          cat > /tmp/eval-sandbox-settings.json << 'SETTINGS'
+          {
+            "sandbox": {
+              "enabled": true,
+              "autoAllowBashIfSandboxed": true,
+              "credentials": {
+                "envVars": [
+                  { "name": "ANTHROPIC_VERTEX_PROJECT_ID", "mode": "deny" },
+                  { "name": "CLOUD_ML_REGION", "mode": "deny" },
+                  { "name": "CLOUDSDK_AUTH_ACCESS_TOKEN", "mode": "deny" },
+                  { "name": "GOOGLE_APPLICATION_CREDENTIALS", "mode": "deny" },
+                  { "name": "GCLOUD_SERVICE_KEY", "mode": "deny" }
+                ]
+              }
+            }
+          }
+          SETTINGS
+
       - name: Run PR evals
         env:
           SKILLS_CSV: ${{ needs.discover.outputs.skills }}
@@ -187,12 +224,13 @@ jobs:
           ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-6"
           ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-6"
           ANTHROPIC_MODEL: "claude-opus-4-6"
+          CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         run: |
           IFS=',' read -ra SKILLS <<< "$SKILLS_CSV"
           failed=0
 
           for skill in "${SKILLS[@]}"; do
-            eval_count=$(jq '.evals | length' "evals/${skill}/evals.json")
+            eval_count=$(jq '.evals | length' "pr-head/evals/${skill}/evals.json")
             workspace="/tmp/${skill}-eval-pr"
             mkdir -p "${workspace}"
 
@@ -201,11 +239,13 @@ jobs:
 
             claude -p "$(cat <<PROMPT
           Use the sdlc-workflow:run-evals skill for skill /${skill}.
-          Evals path: evals/${skill}/evals.json
+          Evals path: pr-head/evals/${skill}/evals.json
           Workspace: ${workspace}
           PROMPT
             )" --permission-mode dontAsk \
               --allowedTools Read Write Bash Skill Agent Glob \
+              --settings /tmp/eval-sandbox-settings.json \
+              --add-dir pr-head \
               2>&1 || {
               echo "::error::PR eval run failed for ${skill} (exit $?)"
               failed=1
@@ -242,7 +282,7 @@ jobs:
               }
             }
 
-            const pluginJson = JSON.parse(fs.readFileSync('plugins/sdlc-workflow/.claude-plugin/plugin.json', 'utf8'));
+            const pluginJson = JSON.parse(fs.readFileSync('pr-head/plugins/sdlc-workflow/.claude-plugin/plugin.json', 'utf8'));
             const version = pluginJson.version;
 
             body += '---\n';

--- a/.github/workflows/skillsaw.yml
+++ b/.github/workflows/skillsaw.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Run skillsaw
         # skillsaw v0 (0.15.0)

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Claude Code
         run: curl -fsSL https://claude.ai/install.sh | bash


### PR DESCRIPTION
## Summary

- **Root cause**: `actions/checkout@v4` received a [security backport on July 16](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/) that blocks checking out fork PR code in `workflow_run` workflows. This broke eval runs for fork PRs ([failed run](https://github.com/RHEcosystemAppEng/sdlc-plugins/actions/runs/29850225186)).
- **Discover job**: Replaced `actions/checkout` + `git diff` with `pulls.listFiles` API — no fork code checkout needed, eliminating the security concern entirely for skill discovery.
- **Run-evals job**: Base branch at workspace root (trusted CLAUDE.md/config) + PR merge commit in `pr-head/` subdirectory via `--add-dir`. Uses `sandbox.credentials.envVars` to deny GCP/Vertex AI env vars from sandboxed Bash subprocesses, plus `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` as belt-and-suspenders.
- **All workflows**: Upgraded `actions/checkout` v4 → v7 (resolves Node.js 20 deprecation warnings).

## Security model

| Layer | Before | After |
|---|---|---|
| Workspace root | Attacker-controlled (fork PR) | Trusted (base branch) |
| CLAUDE.md / .claude/ config | Attacker-controlled | Trusted (base branch) |
| PR code location | Workspace root | Subdirectory via `--add-dir` |
| Secret env vars in subprocesses | Fully accessible | Declaratively denied via `sandbox.credentials` |
| Process isolation | None | Bubblewrap PID namespace (Linux) |
| `allow-unsafe-pr-checkout` | N/A (was blocked) | Required for subdirectory checkout only |

`sandbox.credentials.envVars` with `"mode": "deny"` was [locally verified](https://redhat.atlassian.net/browse/TC-5316) to strip env vars from Bash subprocesses while Claude Code's runtime retains access for API authentication.

## Test plan

- [ ] Verify the workflow passes on a fork PR that touches skill/eval files
- [ ] Verify discover job correctly identifies changed skills via `pulls.listFiles`
- [ ] Verify eval results are posted as PR review
- [ ] Verify sandbox credential isolation prevents `env | grep VERTEX` from showing credentials in eval Bash commands
- [ ] Verify `eval-baseline.yml`, `skillsaw.yml`, `validate-plugins.yml` still pass with checkout@v7

## References

- Jira: [TC-5316](https://redhat.atlassian.net/browse/TC-5316)
- [GitHub Security Lab: Preventing pwn requests](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)
- [Claude Code Sandboxing: Protect credentials](https://code.claude.com/docs/en/sandboxing#protect-credentials)
- [claude-code-action security: Fork PRs](https://github.com/anthropics/claude-code-action/blob/main/docs/security.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden the eval-pr-run workflow for forked pull requests while updating related workflows to use the latest checkout action.

Enhancements:
- Refine eval-pr-run workflow documentation to clarify trust boundaries, PR discovery strategy, and credential isolation model.
- Change the eval discovery job to use the GitHub pulls.listFiles API instead of checking out and diffing the PR merge commit.
- Run evals against PR code checked out into a dedicated subdirectory while keeping the base branch at the workspace root as the trusted configuration source.
- Introduce Claude Code sandbox settings and environment scrubbing to prevent GCP/Vertex AI credentials from leaking into eval Bash subprocesses.
- Read plugin configuration from the PR subdirectory to ensure eval reports reflect the PR’s plugin version.

CI:
- Upgrade all GitHub workflows to use actions/checkout@v7, and enable allow-unsafe-pr-checkout only for the isolated PR subdirectory checkout in eval-pr-run.