### PR TITLE
feat(triage-bug): add Affects Version extraction and resolution

### DIFF
--- a/evals/triage-bug/evals.json
+++ b/evals/triage-bug/evals.json
@@ -42,6 +42,44 @@
         "Decomposition Guard offers the user two options: Proceed with single Task or Split into separate Bugs (Step 6)",
         "The skill does NOT silently create a single Task bundling both fixes — it waits for user input (Step 6 stop rule)"
       ]
+    },
+    {
+      "id": 4,
+      "prompt": "Triage Bug issue ACME-510. The issue details are in bug-issue-with-version.md, the bug template is in bug-template-mock.md, the repository context is in repo-context-mock.md, and the project CLAUDE.md is in claude-md-bug-config.md. Do NOT actually call Jira MCP, Serena, or any external tools. Instead, write your triage analysis to the workspace outputs/ directory: write outputs/bug-parsing.md with the parsed description sections from Step 1 (including Environment / Version), write outputs/version-resolution.md with the Affects Version resolution from Step 4.5 (version extraction, available versions, matching, and the confirmation prompt you would present to the user), write outputs/investigation.md with the codebase investigation findings from Steps 2-3, write outputs/root-cause.md with the root cause analysis from Step 4, and write outputs/task-description.md with the full Task description you would create in Step 5.",
+      "expected_output": "A complete triage demonstrating: correct extraction of the Environment / Version section content, version identifier '0.9.0' extracted from the section, matched against available Jira version 'RHTPA 0.9.0' (ID: 62643), and a confirmation prompt asking whether to set it as the Affects Version on ACME-510.",
+      "files": ["files/bug-issue-with-version.md", "files/bug-template-mock.md", "files/repo-context-mock.md", "files/claude-md-bug-config.md"],
+      "assertions": [
+        "Bug parsing extracts the Environment / Version section content including 'Product version: 0.9.0' (Step 1)",
+        "Version resolution extracts '0.9.0' as the version identifier from the Environment / Version section (Step 4.5.2)",
+        "Version resolution presents the available Jira versions from the fixture's version table (Step 4.5.3)",
+        "Version resolution matches extracted '0.9.0' against Jira version 'RHTPA 0.9.0' (ID: 62643) using substring matching (Step 4.5.4)",
+        "Version resolution presents a confirmation prompt asking whether to set 'RHTPA 0.9.0' as the Affects Version on ACME-510 (Step 4.5.5)",
+        "Since affectsVersions is not already set, sub-step 4.5.1 (existing field check) is skipped or notes the field is empty (Step 4.5.1)"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Triage Bug issue ACME-511. The issue details are in bug-issue-no-version.md, the bug template is in bug-template-mock.md, the repository context is in repo-context-mock.md, and the project CLAUDE.md is in claude-md-bug-config.md. Do NOT actually call Jira MCP, Serena, or any external tools. Instead, write your triage analysis to the workspace outputs/ directory: write outputs/bug-parsing.md with the parsed description sections from Step 1 (including Environment / Version), write outputs/version-resolution.md with the Affects Version resolution from Step 4.5 showing why version could not be determined, write outputs/investigation.md with the codebase investigation findings, write outputs/root-cause.md with the root cause analysis, and write outputs/task-description.md with the full Task description.",
+      "expected_output": "A complete triage demonstrating: correct extraction of the Environment / Version section with vague content ('Not sure which version — using whatever is deployed on staging'), determination that no version identifier can be extracted, and a gap comment that would be posted on the bug stating that Affects Version could not be determined.",
+      "files": ["files/bug-issue-no-version.md", "files/bug-template-mock.md", "files/repo-context-mock.md", "files/claude-md-bug-config.md"],
+      "assertions": [
+        "Bug parsing extracts the Environment / Version section content including the vague text (Step 1)",
+        "Version resolution determines that no version identifier can be extracted from the vague description (Step 4.5.2)",
+        "Version resolution outputs the gap comment: 'Affects Version could not be determined from the bug description — please set manually.' (Step 4.5.6)",
+        "The gap comment includes the Comment Footnote (Step 4.5.6)"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Triage Bug issue ACME-500. The issue details are in bug-issue-standard.md, the bug template is in bug-template-mock.md, the repository context is in repo-context-mock.md, and the project CLAUDE.md is in claude-md-bug-config.md. Note that ACME-500 already has 'Affects Version/s: 0.9.0' set on the issue. Do NOT actually call Jira MCP, Serena, or any external tools. Instead, write your triage analysis to the workspace outputs/ directory: write outputs/bug-parsing.md with the parsed description sections from Step 1, write outputs/version-resolution.md with the Affects Version resolution from Step 4.5 showing how the existing value is handled, write outputs/investigation.md with the codebase investigation findings, write outputs/root-cause.md with the root cause analysis, and write outputs/task-description.md with the full Task description.",
+      "expected_output": "A complete triage demonstrating: detection that affectsVersions is already populated with '0.9.0', and a prompt asking the user whether to keep, replace, or augment the existing Affects Version value.",
+      "files": ["files/bug-issue-standard.md", "files/bug-template-mock.md", "files/repo-context-mock.md", "files/claude-md-bug-config.md"],
+      "assertions": [
+        "Bug metadata extraction records that affectsVersions is already populated with '0.9.0' (Step 1)",
+        "Version resolution detects the existing Affects Version/s value and presents it to the user (Step 4.5.1)",
+        "Version resolution offers three options: Keep, Replace, or Augment the existing value (Step 4.5.1)",
+        "The skill does NOT silently overwrite or skip the existing value — it waits for user input (Step 4.5.1)"
+      ]
     }
   ]
 }

--- a/evals/triage-bug/files/bug-issue-no-version.md
+++ b/evals/triage-bug/files/bug-issue-no-version.md
@@ -1,0 +1,45 @@
+<!-- SYNTHETIC TEST DATA — bug issue with empty Environment/Version section for triage-bug Affects Version gap eval testing -->
+
+# Mock Jira Bug Issue
+
+**Key**: ACME-511
+**Summary**: Dark mode toggle does not persist across browser sessions
+**Issue Type**: Bug (ID: 10020)
+**Status**: New
+**Labels**: reported-by-user
+**Component**: sdlc-workflow
+**Affects Version/s**: (none)
+**Web URL**: https://mock-jira.example.com/browse/ACME-511
+
+---
+
+## Description
+
+### **Issue Description**
+
+When a user enables dark mode via the settings panel and then closes and reopens the
+browser, the application reverts to light mode. The preference is not persisted.
+
+### **Steps to Reproduce**
+
+1. Open the application in a browser.
+2. Navigate to Settings > Appearance.
+3. Toggle "Dark Mode" to ON.
+4. Close the browser completely.
+5. Reopen the browser and navigate back to the application.
+
+### **Expected Result**
+
+The application should load in dark mode, matching the user's last preference.
+
+### **Actual Result**
+
+The application loads in light mode. The dark mode toggle is reset to OFF.
+
+### **Environment / Version**
+
+Not sure which version — using whatever is deployed on staging.
+
+### **Attachments**
+
+None.

--- a/evals/triage-bug/files/bug-issue-with-version.md
+++ b/evals/triage-bug/files/bug-issue-with-version.md
@@ -1,0 +1,59 @@
+<!-- SYNTHETIC TEST DATA — bug issue with version info in Environment/Version section for triage-bug Affects Version eval testing -->
+
+# Mock Jira Bug Issue
+
+**Key**: ACME-510
+**Summary**: API response missing pagination headers when filtering by date range
+**Issue Type**: Bug (ID: 10020)
+**Status**: New
+**Labels**: reported-by-user
+**Component**: sdlc-workflow
+**Affects Version/s**: (none)
+**Web URL**: https://mock-jira.example.com/browse/ACME-510
+
+**Available Jira Versions**:
+
+| Jira ID | Name          | Released | Release Date |
+|---------|---------------|----------|--------------|
+| 62643   | RHTPA 0.9.0   | yes      | 2025-06-15   |
+| 62644   | RHTPA 1.0.0   | yes      | 2025-09-01   |
+| 62645   | RHTPA 1.1.0   | no       | 2026-01-15   |
+
+---
+
+## Description
+
+### **Issue Description**
+
+When calling the `/api/v2/advisories` endpoint with `filterDateRange` query parameters,
+the response is missing the `X-Total-Count` and `Link` pagination headers. The response
+body contains the correct filtered results, but clients relying on pagination headers
+cannot determine total pages.
+
+### **Steps to Reproduce**
+
+1. Start the backend service locally.
+2. Call `GET /api/v2/advisories?publishedAfter=2025-01-01&publishedBefore=2025-06-30&limit=10`.
+3. Inspect the response headers.
+
+### **Expected Result**
+
+The response should include:
+- `X-Total-Count: <n>` header with the total number of matching advisories
+- `Link: <url>; rel="next"` header when more pages exist
+
+### **Actual Result**
+
+The response body contains the correct filtered advisories, but the `X-Total-Count`
+and `Link` headers are absent. Non-filtered requests (without `publishedAfter`/`publishedBefore`)
+return pagination headers correctly.
+
+### **Environment / Version**
+
+Product version: 0.9.0
+OS: RHEL 9.2
+Deployment: OpenShift 4.14
+
+### **Attachments**
+
+None.

--- a/plugins/sdlc-workflow/skills/triage-bug/SKILL.md
+++ b/plugins/sdlc-workflow/skills/triage-bug/SKILL.md
@@ -37,6 +37,7 @@ Do **not** use for:
 | 2 | Reproduce/Trace | Steps to Reproduce | Reproduction outcome or trace findings |
 | 3 | Codebase Investigation | Repository Registry | Affected files, symbols, patterns |
 | 4 | Root Cause Analysis | Investigation findings | Root cause comment on Bug |
+| 4.5 | Affects Version Resolution | Version section + Jira versions | Affects Version set or gap flagged |
 | 5 | Generate Task | Root cause + template | Linked Task with reproducer test |
 | 5b | Link Task to Bug | Task key, Bug key | Issue link (Task blocks Bug) |
 | 5c | Post Digest | Task description | Integrity digest comment |
@@ -172,6 +173,8 @@ Before attempting any JIRA operations (Steps 1, 4, 5, 5b, 5c), determine the acc
 - `jira.add_comment(id, text)` → `python3 scripts/jira-client.py add_comment <id> --comment-md "<text>"`
 - `jira.create_issue(...)` → `python3 scripts/jira-client.py create_issue --project <key> --summary "<summary>" --description-md "<desc>" --issue-type Task --labels <labels>`
 - `jira.create_issue_link(...)` → `python3 scripts/jira-client.py create_link --inward <issue1> --outward <issue2> --link-type <type>`
+- `jira.edit_issue(id, fields={"versions": [...]})` → `python3 scripts/jira-client.py update_issue <id> --fields-json '{"versions": [{"name": "<version-name>"}]}'`
+- `jira.get_versions(project)` → `python3 scripts/jira-client.py get_versions <project-key>`
 
 Refer to `shared/jira-rest-fallback.md` for complete implementation details.
 
@@ -206,6 +209,7 @@ heading (or end of description). Required sections are:
 - **Steps to Reproduce** (mapped from the template's "Steps to reproduce" row)
 - **Expected Result** (mapped from the template's "Expected Result" row)
 - **Actual Result** (mapped from the template's "Actual Result" row)
+- **Environment / Version** (mapped from the template's "Environment / Version" row)
 
 For each **Optional Section**, extract the content if present:
 
@@ -228,7 +232,9 @@ Also extract from the Bug issue:
 - **Summary** — the bug title
 - **Labels** — for context
 - **Component** — if set, helps narrow codebase investigation
-- **Affects Version/s** — if set, helps scope the investigation
+- **Affects Version/s** — if set, helps scope the investigation. Also record
+  whether `affectsVersions` (the `versions` Jira field) is already populated
+  with one or more values, so Step 4.5 can decide whether to skip or augment.
 
 ## Step 2 – Reproduce/Trace
 
@@ -338,6 +344,120 @@ diagnostic context. The comment should include:
 Use ADF `contentFormat` for the comment. Append the Comment Footnote.
 
 jira.add_comment(<jira-bug-id>, <root-cause-analysis>)
+
+## Step 4.5 – Affects Version Resolution
+
+After root cause analysis, resolve and set the Affects Version field on the Bug issue.
+
+### 4.5.1 – Check existing field
+
+If the bug's `affectsVersions` field is already populated with one or more versions
+(recorded in Step 1), display them and ask the user whether to keep, replace, or
+augment:
+
+```
+Affects Version/s is already set: [RHTPA 0.9.0]
+
+Options:
+1. Keep — leave the current value and skip to Step 5
+2. Replace — clear and set a new value
+3. Augment — add additional versions alongside the current ones
+
+Choose (1/2/3):
+```
+
+If the user chooses "1. Keep", skip the remaining sub-steps and proceed to Step 5.
+
+### 4.5.2 – Extract version from description
+
+Parse the **Environment / Version** section content (extracted in Step 1) for version
+identifiers. Look for patterns like:
+
+- Explicit version numbers (e.g., `0.9.0`, `2.1.1`)
+- Product-prefixed versions (e.g., `RHTPA 2.1.0`)
+- Version keywords followed by numbers (e.g., `version 1.2.3`)
+
+If the section is empty, contains only vague text (e.g., "latest", "unknown"), or no
+version pattern can be extracted, skip to sub-step 4.5.6 (gap flagging).
+
+### 4.5.3 – Discover available Jira versions
+
+Call the Jira API to get available project versions, following the triage-security
+Step 3.1 pattern in `plugins/sdlc-workflow/skills/triage-security/jira-triage-operations.md`.
+
+1. Call `getJiraIssueTypeMetaWithFields` for the Bug issue type:
+   ```
+   jira.getJiraIssueTypeMetaWithFields(
+     projectIdOrKey: "<project-key>",
+     issueTypeId: "<bug-issue-type-id>"
+   )
+   ```
+2. Extract the `versions` field's `allowedValues` array. Each entry contains:
+   - `id` — the Jira version ID (used for mutations)
+   - `name` — the display name (e.g., `RHTPA 0.9.0`)
+   - `released` — boolean indicating release status
+   - `releaseDate` — planned or actual release date
+
+**REST API fallback:** `python3 scripts/jira-client.py get_versions <project-key>`
+
+Present the available versions for context:
+
+```
+Available Jira versions:
+
+| Jira ID | Name          | Released | Release Date |
+|---------|---------------|----------|--------------|
+| 62643   | RHTPA 0.9.0   | yes      | 2025-06-15   |
+| 62644   | RHTPA 1.0.0   | yes      | 2025-09-01   |
+| ...     | ...           | ...      | ...          |
+```
+
+### 4.5.4 – Match
+
+Compare the extracted version text against the available Jira version names. Use
+substring matching (e.g., extracted `0.9.0` matches Jira version `RHTPA 0.9.0`).
+If multiple versions match, present all candidates.
+
+### 4.5.5 – Confirm with user
+
+Present the matched version(s) and ask for confirmation:
+
+```
+Extracted version info: "0.9.0"
+Matched Jira version: RHTPA 0.9.0 (ID: 62643)
+
+Set this as the Affects Version on <bug-key>? (yes/no/skip)
+```
+
+- **yes**: proceed to set the field.
+- **no**: ask the user to select from the available versions list, or enter a
+  version manually.
+- **skip**: skip Affects Version setting entirely and proceed to Step 5.
+
+After confirmation, update the Affects Version field:
+
+```
+jira.edit_issue(<bug-key>, fields={
+  "versions": [{"id": "<version-id>"}]
+})
+```
+
+Use the Jira version IDs discovered in sub-step 4.5.3, not hardcoded values.
+When augmenting (from sub-step 4.5.1), merge the new version(s) with the existing
+ones.
+
+### 4.5.6 – Flag gap
+
+If version information cannot be extracted from the description (sub-step 4.5.2),
+or no match is found against available Jira versions (sub-step 4.5.4), post a
+comment on the Bug:
+
+```
+jira.add_comment(<bug-key>, "Affects Version could not be determined from the
+bug description — please set manually.")
+```
+
+Append the Comment Footnote.
 
 ## Step 5 – Generate Task
 


### PR DESCRIPTION
## Summary

- Add Affects Version awareness to the triage-bug skill: extracts version info from the bug's "Environment / Version" section, matches against available Jira project versions, and sets `affectsVersions` after user confirmation
- Insert new Step 4.5 (Affects Version Resolution) with sub-steps for existing field check, version extraction, Jira version discovery, substring matching, user confirmation, and gap flagging
- Add REST API fallback mappings for version operations to Step 0.5
- Add three eval cases with fixtures covering version-found, version-not-found (gap comment), and version-already-set scenarios

Implements [TC-5347](https://redhat.atlassian.net/browse/TC-5347)

## Test plan

- [ ] Verify `python3 -m json.tool evals/triage-bug/evals.json > /dev/null` passes (JSON validity)
- [ ] Run eval case 4: bug with version "0.9.0" → version extracted, matched against RHTPA 0.9.0, confirmation prompt shown
- [ ] Run eval case 5: bug with vague version info → gap comment posted
- [ ] Run eval case 6: bug with existing affectsVersions → keep/replace/augment prompt shown
- [ ] Manual smoke test: run `/triage-bug` with a bug that has version info and verify the confirmation prompt appears

## Summary by Sourcery

Add Affects Version resolution to the triage-bug workflow, including extracting version information from bug descriptions, matching against Jira project versions, and updating the bug field with user confirmation or flagging gaps.

New Features:
- Introduce Step 4.5 Affects Version Resolution in the triage-bug skill to guide detection and setting of the Affects Version field.
- Add awareness of the Environment / Version section and existing Affects Version/s field to drive version resolution decisions.

Enhancements:
- Extend Jira REST fallback mappings to support editing issues with versions and retrieving project versions for triage-bug.
- Document a structured user interaction flow for handling existing Affects Version values, matching discovered versions, and confirming updates.

Tests:
- Add synthetic eval fixtures for bugs with explicit version info, missing/unclear version info, and pre-populated Affects Version/s to validate the new resolution behavior.