### PR TITLE
fix(ci): install bubblewrap for sandbox credential isolation

### DIFF
--- a/.github/workflows/eval-pr-run.yml
+++ b/.github/workflows/eval-pr-run.yml
@@ -202,6 +202,9 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
 
+      - name: Install sandbox dependencies
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends bubblewrap socat
+
       - name: Install Claude Code
         run: curl -fsSL https://claude.ai/install.sh | bash
 


### PR DESCRIPTION
## Summary

- Installs `bubblewrap` and `socat` on the Linux runner before running Claude Code
- Required by `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` (added in PR #250)
- Without it, Claude Code exits immediately with: `bubblewrap is required for subprocess env scrubbing and isolation`

## Context

PR #250 added sandbox credential isolation to `eval-pr-run.yml`. The first real run ([#29994355284](https://github.com/RHEcosystemAppEng/sdlc-plugins/actions/runs/29994355284)) failed because the GitHub Actions Ubuntu runner doesn't have `bubblewrap` pre-installed.

## Test plan

- [ ] Merge and verify PR #251's eval-pr-run workflow passes (re-trigger by pushing to the PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Add a CI step to install bubblewrap and socat on the GitHub Actions Ubuntu runner used by the eval-pr-run workflow.