### PR TITLE
chore(ci): add Dependabot for GitHub Actions version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/eval-pr-run.yml
+++ b/.github/workflows/eval-pr-run.yml
@@ -42,7 +42,7 @@ jobs:
       trusted: ${{ steps.pr.outputs.trusted }}
     steps:
       - name: Set pending commit status
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -57,7 +57,7 @@ jobs:
 
       - name: Resolve PR identity and check trust
         id: pr
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             // listPullRequestsAssociatedWithCommit returns empty for fork PRs
@@ -97,7 +97,7 @@ jobs:
 
       - name: Discover changed skills
         id: discover
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const prNumber = parseInt('${{ steps.pr.outputs.pr_number }}');
@@ -146,7 +146,7 @@ jobs:
 
       - name: Update status for approval gate
         if: steps.pr.outputs.trusted != 'true' && steps.pr.outputs.pr_number != ''
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -280,7 +280,7 @@ jobs:
         env:
           SKILLS_CSV: ${{ needs.discover.outputs.skills }}
           PR_NUMBER: ${{ needs.discover.outputs.pr_number }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
@@ -342,7 +342,7 @@ jobs:
           DISCOVER_RESULT: ${{ needs.discover.result }}
           EVALS_RESULT: ${{ needs.run-evals.result }}
           GATE_RESULT: ${{ needs.gate.result }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const discoverResult = process.env.DISCOVER_RESULT;

--- a/.github/workflows/eval-pr-run.yml
+++ b/.github/workflows/eval-pr-run.yml
@@ -42,7 +42,7 @@ jobs:
       trusted: ${{ steps.pr.outputs.trusted }}
     steps:
       - name: Set pending commit status
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -57,7 +57,7 @@ jobs:
 
       - name: Resolve PR identity and check trust
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // listPullRequestsAssociatedWithCommit returns empty for fork PRs
@@ -97,7 +97,7 @@ jobs:
 
       - name: Discover changed skills
         id: discover
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const prNumber = parseInt('${{ steps.pr.outputs.pr_number }}');
@@ -146,7 +146,7 @@ jobs:
 
       - name: Update status for approval gate
         if: steps.pr.outputs.trusted != 'true' && steps.pr.outputs.pr_number != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -280,7 +280,7 @@ jobs:
         env:
           SKILLS_CSV: ${{ needs.discover.outputs.skills }}
           PR_NUMBER: ${{ needs.discover.outputs.pr_number }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -342,7 +342,7 @@ jobs:
           DISCOVER_RESULT: ${{ needs.discover.result }}
           EVALS_RESULT: ${{ needs.run-evals.result }}
           GATE_RESULT: ${{ needs.gate.result }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const discoverResult = process.env.DISCOVER_RESULT;


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` with weekly checks for GitHub Actions version updates
- Once merged, Dependabot will automatically open PRs for outdated actions (e.g., `actions/github-script` v7 → v9, which currently causes Node.js 20 deprecation warnings)

## Test plan

- [ ] Merge and verify Dependabot opens a PR for `actions/github-script` v7 → v9 within a week

🤖 Generated with [Claude Code](https://claude.com/claude-code)