### PR TITLE
docs(constraints): add triage-bug Affects Version constraints

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -97,6 +97,10 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 1.85 | `plan-feature` MUST generate testing tasks when a testing readiness template exists at `docs/testing-readiness.md` in the target repository, with one task per test category in the template. | `plan-feature/SKILL.md` — Step 5 (Testing task generation) |
 | 1.86 | `plan-feature` MUST NOT generate testing tasks when no testing readiness template exists in the target repository. | `plan-feature/SKILL.md` — Step 5 (Testing task generation) |
 | 1.87 | `plan-feature` testing tasks MUST depend on all implementation tasks. | `plan-feature/SKILL.md` — Step 5 (Testing task generation) |
+| 1.88 | `triage-bug` MUST extract version info from the bug description's "Environment / Version" section during Step 1 parsing. | `triage-bug/SKILL.md` — Step 1 (Parse bug description) |
+| 1.89 | `triage-bug` MUST present the matched version to the user for confirmation before setting the affectsVersions field. | `triage-bug/SKILL.md` — Step 4.5 |
+| 1.90 | `triage-bug` MUST NOT set affectsVersions without explicit user confirmation. | `triage-bug/SKILL.md` — Step 4.5 |
+| 1.91 | `triage-bug` MUST post a gap-flagging comment when version info cannot be determined from the bug description. | `triage-bug/SKILL.md` — Step 4.5 |
 
 ### Prior Art — Cross-phase integrity (§1.33–1.35)
 
@@ -189,7 +193,7 @@ Each constraint above references its source. The full source files are:
 - `plugins/sdlc-workflow/skills/verify-pr/style-conventions.md` — Check 1 Convention applicability (§1.36), Check 2 (§1.16), Check 3 (§1.17), Check 4 (§1.18, §1.19, §1.20, §1.21), Check 5 (§1.30, §1.60), Constraints (§1.11, §1.22, §1.23), Output Format (§1.24)
 - `plugins/sdlc-workflow/skills/define-feature/SKILL.md` — Guardrails (§1.7–1.8), Important Rules (§1.9), Step 3.5 Select Priority and Fix Version (§1.72), Step 6.2 Create Feature Issue (§1.73)
 - `plugins/sdlc-workflow/skills/report-bug/SKILL.md` — Guardrails (§1.50–1.51), Step 4 Preview and Confirm (§1.52)
-- `plugins/sdlc-workflow/skills/triage-bug/SKILL.md` — Guardrails (§1.53–1.54), Step 5 Front-load reproducer test (§1.55), Step 4 Post root cause comment (§1.56), Step 6 Decomposition Guard (§1.57)
+- `plugins/sdlc-workflow/skills/triage-bug/SKILL.md` — Guardrails (§1.53–1.54), Step 1 Parse bug description (§1.88), Step 4 Post root cause comment (§1.56), Step 4.5 Affects Version Resolution (§1.89, §1.90, §1.91), Step 5 Front-load reproducer test (§1.55), Step 6 Decomposition Guard (§1.57)
 - `plugins/sdlc-workflow/skills/triage-security/SKILL.md` — Guardrails (§1.37, §1.38, §1.47), Step 0 (§1.49, §1.68), Step 0 Deployment Context (§1.77, §1.78), Step 1 Ecosystem detection (§1.48), Step 1 Data Extraction (§1.49), Step 1.5 External CVE Data Enrichment (§1.62), Step 1.7 Embargo Check (§1.70, §1.71), Discovery mode (§1.69), Step 2.1 (§1.47), Step 2.2 (§1.42), Step 2.3 (§1.48), Step 2.4 (§1.44), Step 8 (§1.43), Step 8 Case B (§1.61), Post-Triage Summary (§1.67), Important Rules (§1.38–§1.43, §1.45, §1.46), Remediation Task Creation (§1.46, §1.66)
 - `plugins/sdlc-workflow/skills/triage-security/version-impact-analysis.md` — Step 2.3 enriched fix threshold (§1.62)
 - `plugins/sdlc-workflow/skills/triage-security/remediation-templates.md` — Jira Issue Creation digest comment (§1.66)


### PR DESCRIPTION
## Summary

- Adds four deterministic constraints (§1.88–§1.91) to `docs/constraints.md` documenting the Affects Version extraction, user confirmation, and gap-flagging behavior introduced in triage-bug Step 4.5
- Updates the Traceability Index with Step 1 (§1.88) and Step 4.5 (§1.89–§1.91) references for `triage-bug/SKILL.md`

Implements [TC-5348](https://redhat.atlassian.net/browse/TC-5348)

## Test plan

- [x] Each constraint references a real section in `plugins/sdlc-workflow/skills/triage-bug/SKILL.md`
- [x] Constraint numbering (§1.88–§1.91) is sequential and does not duplicate existing entries
- [x] Traceability Index includes all new constraint numbers
- [x] Constraint wording is deterministic and pass/fail testable (no subjective language)
- [x] Plugin validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document new constraints and traceability links for triage-bug's affects version resolution workflow.

Enhancements:
- Document deterministic constraints for triage-bug affectsVersions extraction, user confirmation, and gap-flagging behavior.
- Extend the traceability index to reference new triage-bug parsing and affects version resolution steps.

Documentation:
- Add four new constraints (§1.88–§1.91) describing triage-bug environment/version handling and affectsVersions behavior in docs/constraints.md.