### PR TITLE
fix(ci): skip eval-baseline workflow on fork repositories

### DIFF
--- a/.github/workflows/eval-baseline.yml
+++ b/.github/workflows/eval-baseline.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   eval-baseline:
+    if: github.event.repository.fork != true
     name: Create Eval Baselines
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Add `if: github.event.repository.fork != true` guard to the `eval-baseline` job to prevent it from running on fork repositories where GCP secrets are unavailable
- Uses the portable `github.event.repository.fork` property instead of hardcoding the repository name, so the guard works automatically if the repo is transferred or renamed

## Context
The `eval-baseline.yml` workflow triggers on `push` to `main` with no fork guard. When a fork syncs from upstream, commits touching skill/eval files match the path filter and the workflow fires — then fails at GCP auth because secrets aren't available on forks. See [failing run](https://github.com/mrizzi/sdlc-plugins/actions/runs/29996962063/job/89172815408).

Only `eval-baseline.yml` is affected — the other 5 workflows either don't need secrets or already have fork safety measures (e.g., `eval-pr-run.yml` uses `workflow_run` dispatch).

## Test plan
- [ ] Verify workflow YAML is valid (CI lint)
- [ ] Confirm the workflow no longer triggers on fork pushes to main

Closes: TC-5351

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Add a conditional to the eval-baseline job so it only runs when the repository is not a fork.