### PR TITLE
feat(sandbox): add project-level credential deny entries

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "sandbox": {
+    "credentials": {
+      "envVars": [
+        { "name": "GOOGLE_APPLICATION_CREDENTIALS", "mode": "deny" },
+        { "name": "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE", "mode": "deny" },
+        { "name": "GOOGLE_GHA_CREDS_PATH", "mode": "deny" },
+        { "name": "CLOUDSDK_AUTH_ACCESS_TOKEN", "mode": "deny" },
+        { "name": "CLOUDSDK_PROJECT", "mode": "deny" },
+        { "name": "CLOUDSDK_CORE_PROJECT", "mode": "deny" },
+        { "name": "GCP_PROJECT", "mode": "deny" },
+        { "name": "GCLOUD_PROJECT", "mode": "deny" },
+        { "name": "GOOGLE_CLOUD_PROJECT", "mode": "deny" },
+        { "name": "ANTHROPIC_API_KEY", "mode": "deny" },
+        { "name": "ANTHROPIC_VERTEX_PROJECT_ID", "mode": "deny" },
+        { "name": "CLOUD_ML_REGION", "mode": "deny" },
+        { "name": "GITHUB_TOKEN", "mode": "deny" },
+        { "name": "GH_TOKEN", "mode": "deny" },
+        { "name": "AWS_SECRET_ACCESS_KEY", "mode": "deny" },
+        { "name": "AWS_SESSION_TOKEN", "mode": "deny" }
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -72,6 +72,57 @@ slash commands.
 This interactively populates the required Project Configuration in your
 project's CLAUDE.md (repository registry, Jira settings, and code intelligence).
 
+## Sandbox Credential Isolation
+
+This repository includes a `.claude/settings.json` file that configures
+`sandbox.credentials.envVars` deny entries for 16 credential environment
+variables across four categories: GCP (9), Anthropic/Vertex AI (3),
+GitHub (2), and AWS (2). When the sandbox is enabled, these variables are
+stripped from Bash subprocesses while Claude Code's own runtime retains
+access for API authentication.
+
+The sandbox is **opt-in** — it is not enabled automatically. Run `/sandbox`
+at the start of each session to activate it.
+
+### Verifying the deny entries
+
+After enabling the sandbox, confirm that denied variables are stripped:
+
+```
+/sandbox
+```
+
+Then in a Bash command, check that a denied variable is empty:
+
+```bash
+echo "GITHUB_TOKEN=$GITHUB_TOKEN"
+```
+
+The output should show an empty value. If Claude Code can still call APIs
+(Jira, GitHub), the runtime retained its own access while the sandbox
+stripped the variable from the Bash subprocess.
+
+### JIRA_API_TOKEN
+
+`JIRA_API_TOKEN` is intentionally **not** included in the project-level deny
+entries. It requires `mask` mode (which redacts the value rather than
+removing it entirely), and `mask` can only be set from user-level settings,
+managed settings, or the `--settings` CLI flag — not from project-level
+`.claude/settings.json`. To mask it locally, add the following to your
+`.claude/settings.local.json`:
+
+```json
+{
+  "sandbox": {
+    "credentials": {
+      "envVars": [
+        { "name": "JIRA_API_TOKEN", "mode": "mask" }
+      ]
+    }
+  }
+}
+```
+
 ## Project Configuration
 
 For the skills to work with your project, your project's CLAUDE.md must


### PR DESCRIPTION
## Summary

- Create `.claude/settings.json` with `sandbox.credentials.envVars` deny entries for 16 credential env vars (GCP, Anthropic/Vertex AI, GitHub, AWS)
- When contributors enable the sandbox via `/sandbox`, these vars are stripped from Bash subprocesses while Claude Code retains API access
- Add sandbox credential isolation documentation to README.md (TC-5369)
- Complements the CI-level sandbox credential isolation in `eval-pr-run.yml` by extending protection to local development

Implements [TC-5365](https://redhat.atlassian.net/browse/TC-5365)

## Test plan

- [x] JSON validates (`python3 -m json.tool .claude/settings.json`)
- [x] All 16 env vars present with `deny` mode
- [x] `JIRA_API_TOKEN` absent (requires `mask` mode, user-level only)
- [x] `sandbox.enabled` not set (opt-in via `/sandbox`)
- [x] 2-space JSON indentation per CONVENTIONS.md
- [x] File tracked in git

## Summary by Sourcery

Introduce a Claude sandbox settings file that enforces project-level denial of selected credential environment variables during sandboxed execution, extending credential protection to local development.

New Features:
- Add project-level Claude sandbox configuration to deny access to common cloud and VCS credential environment variables for local runs

Enhancements:
- Align local sandbox credential isolation with existing CI protections by centralizing deny rules in .claude/settings.json
