### PR TITLE
feat(implement-task): add reuse-over-duplication decision step to Step 6

### DIFF
--- a/evals/implement-task/evals.json
+++ b/evals/implement-task/evals.json
@@ -99,6 +99,19 @@
         "The response offers the user a choice: (1) proceed with the current description, or (2) stop so they can re-run plan-feature",
         "The response stops execution and does not proceed to Step 2 or implementation planning until the user responds — following the same pause-and-ask pattern as the incomplete description handling"
       ]
+    },
+    {
+      "id": 8,
+      "prompt": "Implement task TC-9206. The task description is in task-private-reuse.md, the target repository structure is in repo-backend.md, and the project CLAUDE.md is in claude-md-mock.md. Do NOT actually modify repository files or call external tools (Jira, git, Serena). Instead, write your implementation plan to the workspace outputs/ directory: write outputs/plan.md describing which files you would modify and create, what changes you would make to each, and how you would handle the private functions in the ingestor crate. Write outputs/reuse-decision.md detailing your decision about the private functions: whether to make them public and import them or to duplicate them, and why.",
+      "expected_output": "An implementation plan that identifies the describing_packages() and suppliers() functions as private in the ingestor crate, checks that the migration crate already depends on trustify-module-ingestor, and recommends making the functions pub rather than duplicating them. The reuse decision should explicitly reference the existing dependency relationship as the reason for choosing pub over duplication.",
+      "files": ["files/task-private-reuse.md", "files/repo-backend.md", "files/claude-md-mock.md"],
+      "assertions": [
+        "The plan identifies that describing_packages() and suppliers() are private functions in modules/ingestor/src/graph/sbom/mod.rs that need to be made public",
+        "The plan checks or acknowledges that migration/Cargo.toml already depends on trustify-module-ingestor — the dependency relationship is explicitly verified before deciding to reuse",
+        "The reuse decision recommends making describing_packages() and suppliers() public (pub fn) rather than duplicating them, because the dependency already exists",
+        "The plan does NOT propose copying or inlining the function bodies into the migration crate — duplication is explicitly rejected",
+        "The reuse decision references the DRY principle or explains that reuse ensures future bug fixes apply in one place"
+      ]
     }
   ]
 }

--- a/evals/implement-task/files/task-private-reuse.md
+++ b/evals/implement-task/files/task-private-reuse.md
@@ -1,0 +1,54 @@
+<!-- SYNTHETIC TEST DATA — task requiring reuse of private functions from a dependent crate for testing reuse-over-duplication behavior -->
+
+# Mock Jira Task
+
+**Key**: TC-9206
+**Summary**: Add SBOM supplier extraction to data migration
+**Status**: To Do
+**Labels**: ai-generated-jira
+**Linked Issues**: is incorporated by TC-9001
+
+---
+
+## Repository
+trustify-backend
+
+## Target Branch
+main
+
+## Description
+Add supplier information extraction during the SBOM data migration step. The migration
+crate needs to extract describing packages and supplier information from ingested SBOMs
+to populate the new `sbom_supplier` table. The ingestor module already has private helper
+functions (`describing_packages()` and `suppliers()`) that implement this extraction logic.
+
+## Files to Modify
+- `migration/src/m0002_supplier/mod.rs` — add supplier extraction logic to the migration step
+- `modules/ingestor/src/graph/sbom/mod.rs` — make `describing_packages()` and `suppliers()` public
+
+## Files to Create
+- `migration/src/m0002_supplier/test.rs` — unit tests for the supplier extraction migration
+
+## Implementation Notes
+- The `modules/ingestor/src/graph/sbom/mod.rs` file contains two private helper functions:
+  - `fn describing_packages(sbom: &Sbom) -> Vec<PackageRef>` — extracts the list of packages that an SBOM describes
+  - `fn suppliers(sbom: &Sbom) -> Vec<SupplierInfo>` — extracts supplier information from SBOM metadata
+- These functions implement the exact logic needed for the migration, but they are currently private (`fn`, not `pub fn`)
+- The `migration` crate already depends on `trustify-module-ingestor` in its `Cargo.toml`:
+  ```toml
+  [dependencies]
+  trustify-module-ingestor = { path = "../modules/ingestor" }
+  ```
+- Since the dependency already exists, make the functions public and import them rather than duplicating the code
+
+## Acceptance Criteria
+- [ ] The migration step extracts supplier information from all ingested SBOMs
+- [ ] The extraction reuses the existing ingestor logic rather than duplicating it
+- [ ] The `sbom_supplier` table is populated correctly with supplier data
+
+## Test Requirements
+- [ ] Test that the migration step correctly extracts suppliers from a sample SBOM
+- [ ] Test that SBOMs with no suppliers produce no supplier records
+
+## Dependencies
+- Depends on: None

--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -494,6 +494,27 @@ analysis. When writing new code, match the patterns found in sibling files rathe
 new approaches. If any Implementation Notes or task instructions conflict with a discovered
 convention, follow the guidance obtained from the user during Step 4.
 
+### Reuse over duplication
+
+When the implementation needs to use a function, method, or utility that exists in another
+module or package but is not publicly exported (e.g., a private function in a Rust crate,
+an unexported function in a Go package, a non-exported function in a Node.js module),
+decide whether to make it public or duplicate it:
+
+1. **Check dependency relationship**: determine whether the source package (where the
+   function lives) is already a dependency of the target package (where you need to use it).
+   Use the project's dependency manifest (e.g., `Cargo.toml`, `package.json`, `go.mod`,
+   `pom.xml`) to verify.
+2. **If the dependency already exists**: make the function public (`pub`, `export`, etc.)
+   and import it rather than duplicating the code. This follows the DRY principle and
+   ensures future bug fixes apply in one place.
+3. **If adding a new dependency would be required**: inlining or duplicating the function
+   is acceptable — introducing a new cross-package dependency for a single utility may
+   not be worth the coupling.
+4. **Flag the decision**: when choosing between options 2 and 3, state the choice and
+   rationale in the commit message or PR description so reviewers understand why code
+   was reused or duplicated.
+
 ### Serena symbolic editing (preferred)
 
 Use the dedicated Serena instance for the task's repository (look up the instance name


### PR DESCRIPTION
Add a decision step in Step 6 that instructs the skill to check whether a private function's source package is already a dependency before duplicating it. When the dependency exists, prefer making the function public and importing it over inlining.

Implements TC-5392

Assisted-by: Claude Code

## Summary by Sourcery

Enhancements:
- Document a decision process for reusing versus duplicating non-exported functions based on existing dependency relationships, including when to make functions public, when duplication is acceptable, and how to record the rationale.