### PR TITLE
feat(implement-task): add dead parameter detection and sibling pattern override

### DIFF
--- a/evals/implement-task/evals.json
+++ b/evals/implement-task/evals.json
@@ -112,6 +112,32 @@
         "The plan does NOT propose copying or inlining the function bodies into the migration crate — duplication is explicitly rejected",
         "The reuse decision references the DRY principle or explains that reuse ensures future bug fixes apply in one place"
       ]
+    },
+    {
+      "id": 9,
+      "prompt": "Implement task TC-9207. The task description is in task-dead-parameter.md, the target repository structure is in repo-backend.md, and the project CLAUDE.md is in claude-md-mock.md. Do NOT actually modify repository files or call external tools (Jira, git, Serena). Instead, write your implementation plan to the workspace outputs/ directory: write outputs/plan.md describing which files you would modify, what changes you would make to each, and how you would handle the version_filter parameter after removing the filtering logic. Write outputs/parameter-cleanup.md detailing your approach to removing dead parameters and updating call sites.",
+      "expected_output": "An implementation plan that recognizes removing the version-based filtering logic from SbomService::list leaves the version_filter parameter dead. The plan should include removing the parameter from the function signature and updating all 3 call sites (endpoint handler, search service, tests) to stop passing the version_filter argument. The parameter cleanup document should explain the dead parameter detection reasoning.",
+      "files": ["files/task-dead-parameter.md", "files/repo-backend.md", "files/claude-md-mock.md"],
+      "assertions": [
+        "The plan identifies that removing the version filtering logic from SbomService::list leaves the version_filter parameter unused — it does not simply rename it to _version_filter",
+        "The plan includes removing the version_filter parameter from the SbomService::list function signature, not just removing the filter logic in the body",
+        "The plan identifies and updates all 3 call sites: the endpoint handler in list.rs, the search service in search/service/mod.rs, and the tests in tests/api/sbom.rs",
+        "The parameter cleanup document explains that dead parameters should be removed rather than prefixed with an underscore — underscore prefixes suppress compiler warnings but leave unnecessary API surface",
+        "The plan includes re-running tests after removing the parameter and updating call sites to verify nothing broke"
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "Implement task TC-9208. The task description is in task-sibling-override.md, the target repository structure is in repo-backend.md, and the project CLAUDE.md is in claude-md-mock.md. Do NOT actually modify repository files or call external tools (Jira, git, Serena). Instead, write your implementation plan to the workspace outputs/ directory: write outputs/plan.md describing which files you would modify and create, what changes you would make to each. Write outputs/conventions.md listing the conventions you discovered from sibling analysis, including any conflicts with the skill's built-in quality guidance. Write outputs/test-plan.md describing the test assertion approach you would use.",
+      "expected_output": "An implementation plan where the conventions output identifies the sibling .filter().any() and .filter().count() > 0 assertion patterns from advisory.rs and sbom.rs tests, flags the conflict with the skill's 'prefer value-based assertions over length-only checks' guidance, and states that the skill guidance takes precedence. The test plan should describe value-based assertions (e.g., assert_eq on specific license names and counts) rather than copying the sibling existence-check patterns.",
+      "files": ["files/task-sibling-override.md", "files/repo-backend.md", "files/claude-md-mock.md"],
+      "assertions": [
+        "The conventions output identifies the sibling assertion patterns — specifically the .filter().any() and .filter().count() > 0 patterns from tests/api/advisory.rs and tests/api/sbom.rs",
+        "The conventions output flags a conflict between the sibling assertion patterns and the skill's built-in 'prefer value-based assertions over length-only checks' guidance",
+        "The conventions output states that the skill guidance takes precedence over the sibling patterns — sibling conventions are defaults, not overrides of explicit skill instructions",
+        "The test plan describes value-based assertions for the license summary tests (e.g., assert_eq on specific license identifiers or exact counts per category) rather than using .any() or .count() > 0 existence checks",
+        "The test plan follows sibling conventions for non-conflicting aspects — test naming, setup/teardown, test organization — while overriding only the assertion style"
+      ]
     }
   ]
 }

--- a/evals/implement-task/files/task-dead-parameter.md
+++ b/evals/implement-task/files/task-dead-parameter.md
@@ -1,0 +1,65 @@
+<!-- SYNTHETIC TEST DATA — task that removes code using a function parameter, leaving the parameter dead -->
+
+# Mock Jira Task
+
+**Key**: TC-9207
+**Summary**: Remove version-based filter from SBOM list endpoint
+**Status**: To Do
+**Labels**: ai-generated-jira
+**Linked Issues**: is incorporated by TC-9001
+
+---
+
+## Repository
+trustify-backend
+
+## Target Branch
+main
+
+## Description
+Remove the version-based filtering logic from the SBOM list endpoint. The `version_filter`
+parameter in `SbomService::list` was used to filter SBOMs by a specific version string,
+but this filter is no longer needed — version filtering has been moved to the client side.
+Remove the filter logic from the service method body.
+
+## Files to Modify
+- `modules/fundamental/src/sbom/service/sbom.rs` — remove version-based filtering logic from the `list` method
+- `modules/fundamental/src/sbom/endpoints/list.rs` — remove the `version` query parameter extraction and stop passing it to the service method
+- `tests/api/sbom.rs` — remove or update the `test_list_sboms_version_filtered` test
+
+## Files to Create
+- (none)
+
+## API Changes
+- `GET /api/v2/sbom` — CHANGED: remove `version` query parameter support
+
+## Implementation Notes
+- The `SbomService::list` method in `modules/fundamental/src/sbom/service/sbom.rs` currently has this signature:
+  ```rust
+  pub async fn list(
+      &self,
+      search: Query,
+      paginated: Paginated,
+      version_filter: &str,
+      tx: &Transactional<'_>,
+  ) -> Result<PaginatedResults<SbomSummary>, AppError>
+  ```
+- The `version_filter` parameter is used in the method body to apply a `VersionMatches` filter to the query. Remove the filter logic but keep the rest of the query pipeline intact.
+- The endpoint handler in `modules/fundamental/src/sbom/endpoints/list.rs` extracts the `version` query param and passes it to `SbomService::list`. After the service method no longer accepts `version_filter`, the handler should stop extracting and passing it.
+- There are 3 call sites for `SbomService::list`:
+  1. `modules/fundamental/src/sbom/endpoints/list.rs` — the REST endpoint handler
+  2. `modules/search/src/service/mod.rs` — the search service calls `list` with an empty version filter
+  3. `tests/api/sbom.rs` — integration tests pass various version filter values
+
+## Acceptance Criteria
+- [ ] The `list` method in SbomService no longer filters by version
+- [ ] The `version` query parameter is no longer extracted or accepted by the endpoint
+- [ ] All call sites compile and pass without the version_filter argument
+- [ ] Existing tests that don't depend on version filtering still pass
+
+## Test Requirements
+- [ ] Remove or update `test_list_sboms_version_filtered` since the feature is removed
+- [ ] Verify other SBOM list tests still pass without changes
+
+## Dependencies
+- Depends on: None

--- a/evals/implement-task/files/task-sibling-override.md
+++ b/evals/implement-task/files/task-sibling-override.md
@@ -1,0 +1,77 @@
+<!-- SYNTHETIC TEST DATA — task where sibling test patterns conflict with skill's built-in quality guidance -->
+
+# Mock Jira Task
+
+**Key**: TC-9208
+**Summary**: Add package license summary endpoint with tests
+**Status**: To Do
+**Labels**: ai-generated-jira
+**Linked Issues**: is incorporated by TC-9001
+
+---
+
+## Repository
+trustify-backend
+
+## Target Branch
+main
+
+## Description
+Add a REST endpoint that returns a summary of license types for packages within an SBOM.
+The endpoint aggregates package licenses by type (permissive, copyleft, unknown) and
+returns counts plus the list of specific license identifiers in each category.
+
+## Files to Modify
+- `modules/fundamental/src/package/endpoints/mod.rs` — register the new route
+- `modules/fundamental/src/package/model/mod.rs` — add `pub mod license_summary;`
+
+## Files to Create
+- `modules/fundamental/src/package/model/license_summary.rs` — LicenseSummary response struct
+- `modules/fundamental/src/package/endpoints/license_summary.rs` — GET handler for /api/v2/sbom/{id}/license-summary
+- `tests/api/package_license.rs` — integration tests for the new endpoint
+
+## API Changes
+- `GET /api/v2/sbom/{id}/license-summary` — NEW: returns `{ permissive: { count: N, licenses: [...] }, copyleft: { count: N, licenses: [...] }, unknown: { count: N, licenses: [...] } }`
+
+## Implementation Notes
+- Follow the existing endpoint pattern in `modules/fundamental/src/package/endpoints/list.rs`
+- Use the `package_license` entity from `entity/src/package_license.rs` for the JOIN query
+- Error handling: return `AppError` with `.context()` wrapping
+
+### Sibling test patterns
+The existing integration tests in `tests/api/advisory.rs` and `tests/api/sbom.rs` use a
+common assertion pattern for validating list responses:
+
+```rust
+// Pattern from tests/api/advisory.rs:
+let has_critical = result.items.iter()
+    .filter(|a| a.severity == "Critical")
+    .any(|_| true);
+assert!(has_critical, "should contain a Critical advisory");
+
+// Pattern from tests/api/sbom.rs:
+let matching = result.items.iter()
+    .filter(|s| s.name.contains("openssl"))
+    .count();
+assert!(matching > 0, "should find at least one openssl SBOM");
+```
+
+These patterns check for existence but do not verify specific values. The new tests
+for `package_license.rs` should follow the project's conventions for structure, setup,
+and naming — but review whether the assertion style above is the best pattern for the
+new tests.
+
+## Acceptance Criteria
+- [ ] GET /api/v2/sbom/{id}/license-summary returns categorized license counts
+- [ ] Returns 404 when SBOM ID does not exist
+- [ ] Each category includes both a count and a list of license identifiers
+- [ ] Licenses are deduplicated within each category
+
+## Test Requirements
+- [ ] Test that a valid SBOM with known package licenses returns correct categorized counts
+- [ ] Test that a non-existent SBOM ID returns 404
+- [ ] Test that an SBOM with no packages returns all zeros with empty license lists
+- [ ] Test that duplicate licenses within a category are counted only once
+
+## Dependencies
+- Depends on: None

--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -364,6 +364,15 @@ If a convention conflict is detected — the task description or Implementation 
 contradict an established convention — flag it to the user and ask for guidance before
 proceeding with implementation.
 
+**Skill guidance takes precedence over sibling patterns:** When a discovered sibling
+pattern conflicts with the skill's built-in quality guidance (e.g., Step 7 says "prefer
+value-based assertions" but sibling tests use `.any()` existence checks, or Step 7 says
+"document every test function" but siblings have no doc comments), the skill's guidance
+takes precedence. Record the conflict in the convention output — note the sibling pattern
+and the overriding skill guidance — but follow the skill guidance, not the sibling
+pattern. Sibling conventions are a default to adopt when the skill has no opinion; they
+are not a license to override explicit skill instructions.
+
 > **Example output:**
 >
 > **Discovered conventions (from sibling analysis):**
@@ -642,6 +651,12 @@ convention analysis. When writing new tests, match the assertion patterns, respo
 validation style, error case coverage, and naming conventions found in sibling test files
 rather than inventing new approaches.
 
+**Skill guidance overrides sibling patterns:** The test conventions from Step 4 are
+defaults — they apply when this step has no stronger opinion. The guidance below
+(value-based assertions, parameterized tests, test documentation) is the skill's explicit
+quality standard. When a sibling pattern conflicts with any guidance below, follow the
+skill guidance and note the deviation from the sibling pattern in your convention output.
+
 **Prefer value-based assertions over length-only checks:** When verifying collections or
 response data, assert on the actual values — not just the count. Assert on specific items
 or key fields so that test failures reveal *what* changed, not just *how many*. Length
@@ -752,6 +767,40 @@ commit.
 > **Untracked file check results:**
 > - `src/data/schema.json` — **REFERENCED** by `src/parser.rs` via `include_str!("data/schema.json")` — stage for commit?
 > - `src/data/fixtures.json` — in directory with modified files but no code references found — stage for commit?
+
+### Dead parameter detection
+
+When the implementation removes code that references function parameters, scan the
+modified functions for parameters that are no longer used in the function body.
+
+1. **Identify candidate functions**: from the `git diff`, find functions where code
+   was removed (lines with `-` prefix). For each such function, check whether any
+   removed line was the only reference to a parameter.
+2. **Detect dead parameters**: look for indicators that a parameter is unused:
+   - Underscore-prefixed parameters (`_version`, `_ctx`) — languages like Rust and
+     Python use this convention to suppress unused-variable warnings, but the correct
+     fix is removal, not renaming.
+   - Compiler or linter warnings about unused parameters in the build output from
+     Step 7 or Step 9's CI checks.
+   - Parameters that appear in the function signature but have zero references in the
+     function body (search the function body for the parameter name).
+3. **Remove dead parameters**: for each confirmed dead parameter:
+   - Remove the parameter from the function signature.
+   - Use Serena's `find_referencing_symbols` (or Grep as fallback) to find all call
+     sites of the function.
+   - Update every call site to remove the corresponding argument.
+   - If the parameter is part of a trait or interface method, check whether other
+     implementations use it — only remove if no implementation references it.
+4. **Re-run tests**: after removing parameters and updating call sites, re-run the
+   relevant tests to confirm nothing broke.
+
+> **Example:**
+>
+> A function `fn filter_by_status(items: &[Item], version: &str)` had its body
+> changed to no longer use `version`. The agent renamed it to `_version` to suppress
+> the compiler warning. The correct action is to remove the `version` parameter
+> entirely, update all callers from `filter_by_status(items, "1.0")` to
+> `filter_by_status(items)`, and re-run tests.
 
 ### Sensitive-pattern check
 

--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -364,14 +364,11 @@ If a convention conflict is detected — the task description or Implementation 
 contradict an established convention — flag it to the user and ask for guidance before
 proceeding with implementation.
 
-**Skill guidance takes precedence over sibling patterns:** When a discovered sibling
-pattern conflicts with the skill's built-in quality guidance (e.g., Step 7 says "prefer
-value-based assertions" but sibling tests use `.any()` existence checks, or Step 7 says
-"document every test function" but siblings have no doc comments), the skill's guidance
-takes precedence. Record the conflict in the convention output — note the sibling pattern
-and the overriding skill guidance — but follow the skill guidance, not the sibling
-pattern. Sibling conventions are a default to adopt when the skill has no opinion; they
-are not a license to override explicit skill instructions.
+**Skill guidance takes precedence over sibling patterns:** When a sibling pattern
+conflicts with this skill's built-in quality guidance (e.g., Step 7's "prefer value-based
+assertions" vs sibling `.any()` checks), follow the skill guidance. Record the conflict
+in the convention output but do not adopt the sibling pattern. Sibling conventions are
+defaults when the skill has no opinion — not overrides of explicit skill instructions.
 
 > **Example output:**
 >
@@ -613,12 +610,9 @@ endpoint contract against the backend repository before writing the call.
 If no Serena instance is available for the backend repository, use Grep, Glob, and Read
 on the backend repo to perform the same verification.
 
-> **Example output:**
->
-> **Cross-repo API verification results:**
-> - `GET /api/v2/sboms` — path ✓, method ✓, response shape ✓ (matches `SbomSummary` in `modules/fundamental/src/sbom/model/summary.rs`)
-> - `DELETE /api/v2/sbom/{id}` — path ✗ — **MISMATCH** (backend uses `/api/v2/sboms/{id}` with trailing 's', see `modules/fundamental/src/sbom/endpoints/mod.rs:48`)
-> - `GET /api/v2/risk-assessment/group/{groupId}` — sort order ✗ — **MISMATCH** (frontend picks `assessments[0]` expecting newest, but backend returns `ORDER BY created_at ASC` — oldest first, see `modules/risk/src/assessment/endpoints/mod.rs:92`)
+> **Example:** `GET /api/v2/sboms` — ✓. `DELETE /api/v2/sbom/{id}` — path mismatch
+> (backend uses `/sboms/{id}`). `GET /api/v2/risk-assessment/group/{id}` — sort mismatch
+> (frontend picks `[0]` expecting newest, backend returns oldest first).
 
 ### Code quality practices
 
@@ -652,10 +646,9 @@ validation style, error case coverage, and naming conventions found in sibling t
 rather than inventing new approaches.
 
 **Skill guidance overrides sibling patterns:** The test conventions from Step 4 are
-defaults — they apply when this step has no stronger opinion. The guidance below
-(value-based assertions, parameterized tests, test documentation) is the skill's explicit
-quality standard. When a sibling pattern conflicts with any guidance below, follow the
-skill guidance and note the deviation from the sibling pattern in your convention output.
+defaults. The guidance below (value-based assertions, parameterized tests, test
+documentation) is the skill's explicit quality standard and takes precedence over
+conflicting sibling patterns. Note any deviation in the convention output.
 
 **Prefer value-based assertions over length-only checks:** When verifying collections or
 response data, assert on the actual values — not just the count. Assert on specific items
@@ -773,34 +766,20 @@ commit.
 When the implementation removes code that references function parameters, scan the
 modified functions for parameters that are no longer used in the function body.
 
-1. **Identify candidate functions**: from the `git diff`, find functions where code
-   was removed (lines with `-` prefix). For each such function, check whether any
-   removed line was the only reference to a parameter.
-2. **Detect dead parameters**: look for indicators that a parameter is unused:
-   - Underscore-prefixed parameters (`_version`, `_ctx`) — languages like Rust and
-     Python use this convention to suppress unused-variable warnings, but the correct
-     fix is removal, not renaming.
-   - Compiler or linter warnings about unused parameters in the build output from
-     Step 7 or Step 9's CI checks.
-   - Parameters that appear in the function signature but have zero references in the
-     function body (search the function body for the parameter name).
-3. **Remove dead parameters**: for each confirmed dead parameter:
-   - Remove the parameter from the function signature.
-   - Use Serena's `find_referencing_symbols` (or Grep as fallback) to find all call
-     sites of the function.
-   - Update every call site to remove the corresponding argument.
-   - If the parameter is part of a trait or interface method, check whether other
-     implementations use it — only remove if no implementation references it.
-4. **Re-run tests**: after removing parameters and updating call sites, re-run the
-   relevant tests to confirm nothing broke.
+1. **Identify candidates**: from `git diff`, find functions where removed lines
+   contained the only reference to a parameter.
+2. **Detect dead parameters**: look for underscore-prefixed parameters (`_version`,
+   `_ctx`), compiler/linter warnings about unused parameters, or parameters with
+   zero references in the function body. The correct fix is removal, not renaming.
+3. **Remove dead parameters**: remove the parameter from the signature, use
+   `find_referencing_symbols` (or Grep) to find all call sites, and update every
+   caller to remove the corresponding argument. For trait/interface methods, only
+   remove if no implementation references the parameter.
+4. **Re-run tests** to confirm nothing broke.
 
-> **Example:**
->
-> A function `fn filter_by_status(items: &[Item], version: &str)` had its body
-> changed to no longer use `version`. The agent renamed it to `_version` to suppress
-> the compiler warning. The correct action is to remove the `version` parameter
-> entirely, update all callers from `filter_by_status(items, "1.0")` to
-> `filter_by_status(items)`, and re-run tests.
+> **Example:** `fn filter_by_status(items: &[Item], version: &str)` no longer uses
+> `version` after a code change. Remove the parameter and update all callers from
+> `filter_by_status(items, "1.0")` to `filter_by_status(items)`.
 
 ### Sensitive-pattern check
 
@@ -843,17 +822,9 @@ documented.
    is intentional. Do **not** proceed to commit until the user confirms or the
    missing use case is restored.
 
-> **Example:**
->
-> Original text: "Normalize the input by stripping leading/trailing whitespace."
-> (applies to both JSON and raw text)
->
-> Replacement text: "Normalize the input by parsing as JSON and re-serializing."
-> (applies only to JSON — raw text would fail)
->
-> **Flag:** "Raw text input" use case was covered by the original normalization
-> but is not addressed by the replacement. Confirm this is intentional or update
-> the text to handle both cases.
+> **Example:** Original: "Normalize by stripping whitespace" (covers JSON and raw text).
+> Replacement: "Normalize by parsing as JSON" (drops raw text support). Flag the
+> scope narrowing and confirm with the user.
 
 ### Eval coverage currency
 
@@ -929,14 +900,8 @@ not caught.
    descriptions, documentation), apply the same cross-section validation to those
    output files before committing.
 
-> **Example output:**
->
-> **Cross-section reference consistency results:**
-> - Entity `AdvisoryService` — **MISMATCH**:
->   - Files to Modify: `modules/fundamental/src/advisory/service/mod.rs`
->   - Implementation Notes: `modules/fundamental/src/advisory/service/advisory.rs`
->   - Resolution: actual file is `service/mod.rs` — Implementation Notes path is incorrect
-> - Entity `SbomParser` — paths consistent across sections ✓
+> **Example:** Entity `AdvisoryService` listed as `service/mod.rs` in Files to Modify
+> but `service/advisory.rs` in Implementation Notes — resolve by inspecting the actual codebase.
 
 ### Duplication check
 
@@ -1068,13 +1033,8 @@ the analysis across module boundaries to detect pattern inconsistencies.
    established cross-module pattern before proceeding. If the deviation is
    intentional, ask the user to confirm before proceeding.
 
-> **Example output:**
->
-> **Cross-module shared entity analysis results:**
-> - Entity `source_document` — 2 modules interact:
->   - `ingestor/graph/mod.rs`: uses nested transaction with `ON CONFLICT DO UPDATE` for duplicate-key handling
->   - `risk_assessment/service/mod.rs` (new code): uses plain `insert()` with no conflict handling — **ANOMALY**
->   - Recommendation: adopt the ingestor's `ON CONFLICT` pattern to handle duplicate inserts gracefully
+> **Example:** Entity `source_document` — `ingestor/graph/mod.rs` uses `ON CONFLICT DO UPDATE`
+> but new code in `risk_assessment/service/mod.rs` uses plain `insert()` — adopt the ingestor's pattern.
 
 #### Caller-site parity
 
@@ -1114,19 +1074,9 @@ other caller in the codebase uses that pattern.
 
 Output the contract verification, sibling parity, cross-module shared entity, and caller-site parity results to the user before proceeding.
 
-> **Example output:**
->
-> **Contract & sibling parity results:**
-> - `StorageProvider` implements `Provider` trait — `get()` ✓, `list()` ✓, `delete()` ✓, `update()` ✗ — **GAP** (missing `update` method)
-> - Sibling parity with `S3Provider`, `GcsProvider`:
->   - Retry logic ✓ (all siblings use exponential backoff)
->   - Logging ✗ — `StorageProvider` missing `info!()` on successful operations — **GAP**
->   - Config options ✓ (all accept `ProviderConfig`)
-> - Caller-site parity for `useDeleteSbomMutation`:
->   - 3 existing callers found: `SbomList.tsx`, `SbomDetail.tsx`, `SbomActions.tsx`
->   - Success handling: all use `queryClient.invalidateQueries()` + toast notification
->   - New code uses `window.location.reload()` — **ANOMALY** (0 of 3 callers use this pattern)
->   - Error handling ✓ (all callers including new code use `onError` toast)
+> **Example:** Contract: `StorageProvider` missing `update()` from `Provider` trait.
+> Sibling parity: `StorageProvider` missing `info!()` logging present in `S3Provider`/`GcsProvider`.
+> Caller-site: new code uses `window.location.reload()` but 3 existing callers use `queryClient.invalidateQueries()`.
 
 ## Step 10 – Commit and Push
 


### PR DESCRIPTION
## Summary

- Add dead parameter detection sub-step to Step 9 (Self-Verification): after removing code that uses function parameters, scan for unused parameters and remove them from signatures and call sites instead of renaming with underscore prefix
- Add skill guidance precedence to Steps 4 and 7: when sibling code patterns conflict with the skill's built-in quality guidance, the skill guidance takes precedence over sibling conventions
- Add eval coverage for both new behaviors (evals 9 and 10) with corresponding task fixtures
- Condense SKILL.md prose and examples to pass the 16,000-token context budget lint check (TC-5431)

Both gaps were exposed by reviewer feedback on PR #2547 (TC-5406).

Implements [TC-5430](https://redhat.atlassian.net/browse/TC-5430)

## Test plan

- [ ] Manual review of updated SKILL.md text for clarity and correctness
- [ ] Verify evals.json is valid JSON and new eval entries reference correct fixture files
- [ ] Run implement-task evals to baseline the new scenarios
- [ ] Verify Skill Lint CI check passes (no context-budget errors)