### PR TITLE
feat(implement-task): add query-scope verification for subset-targeted batch operations

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -174,6 +174,7 @@ existing instruction in a SKILL.md or CLAUDE.md file.
 | 5.11 | `implement-task` MUST add a doc comment to every test function it creates, regardless of sibling test documentation patterns. | `implement-task/SKILL.md` — Step 7 |
 | 5.12 | `implement-task` MUST add given-when-then inline comments to non-trivial test functions (tests with distinct setup, action, and assertion phases). | `implement-task/SKILL.md` — Step 7 |
 | 5.13 | `implement-task` MUST NOT add given-when-then comments to trivial tests (single assertion, no distinct setup phase). | `implement-task/SKILL.md` — Step 7 |
+| 5.14 | When implementing batch operations that target a described subset of records, `implement-task` MUST verify that the query or iteration scope is filtered accordingly — broader queries MUST be flagged for review when a narrower query is possible at the data source level. | `implement-task/SKILL.md` — Step 9 |
 
 ---
 

--- a/evals/implement-task/evals.json
+++ b/evals/implement-task/evals.json
@@ -138,6 +138,19 @@
         "The test plan describes value-based assertions for the license summary tests (e.g., assert_eq on specific license identifiers or exact counts per category) rather than using .any() or .count() > 0 existence checks",
         "The test plan follows sibling conventions for non-conflicting aspects — test naming, setup/teardown, test organization — while overriding only the assertion style"
       ]
+    },
+    {
+      "id": 11,
+      "prompt": "Implement task TC-9209. The task description is in task-query-scope.md, the target repository structure is in repo-backend.md, and the project CLAUDE.md is in claude-md-mock.md. Do NOT actually modify repository files or call external tools (Jira, git, Serena). Instead, write your implementation plan to the workspace outputs/ directory: write outputs/plan.md describing which files you would modify and create, what changes you would make to each, and how you would query the database for the migration. Write outputs/query-scope.md documenting your query-scope verification analysis — what the task targets, what query scope you chose, and why.",
+      "expected_output": "An implementation plan where the query-scope analysis identifies that the task targets only SPDX SBOMs (a subset), verifies that the sbom entity's labels column supports filtering by document type, and plans to use a filtered query (e.g., filtering by labels->>'type' = 'spdx') rather than loading all documents. The plan should explicitly reject using an unfiltered query like Sbom::find() or iterating all documents, citing the performance impact on production environments with hundreds of thousands of CycloneDX documents.",
+      "files": ["files/task-query-scope.md", "files/repo-backend.md", "files/claude-md-mock.md"],
+      "assertions": [
+        "The query-scope analysis identifies that the task targets a subset — specifically 'SPDX SBOMs' not all SBOMs — by extracting subset-indicating language from the Description section",
+        "The query-scope analysis verifies that the sbom entity's labels column (jsonb) supports filtering by document type at the database level, rather than requiring application-level filtering",
+        "The plan uses a filtered query to select only SPDX documents (e.g., WHERE labels->>'type' = 'spdx' or equivalent ORM filter) instead of loading all documents and discarding CycloneDX ones in application code",
+        "The plan or query-scope analysis explicitly mentions the performance impact of loading all documents — referencing that production environments have hundreds of thousands of non-target CycloneDX records",
+        "The plan does NOT propose using an unfiltered query like Sbom::find() or Document::all() followed by an application-level type check to discard CycloneDX documents"
+      ]
     }
   ]
 }

--- a/evals/implement-task/files/task-query-scope.md
+++ b/evals/implement-task/files/task-query-scope.md
@@ -1,0 +1,65 @@
+<!-- SYNTHETIC TEST DATA — data migration task targeting a subset of records to test query-scope verification -->
+
+# Mock Jira Task
+
+**Key**: TC-9209
+**Summary**: Re-process all SPDX SBOMs to extract package supplier information
+**Status**: To Do
+**Labels**: ai-generated-jira
+**Linked Issues**: is incorporated by TC-9001
+
+---
+
+## Repository
+trustify-backend
+
+## Target Branch
+main
+
+## Description
+Create a data migration that re-processes all SPDX SBOMs to extract package supplier
+information that was previously ignored during ingestion. The migration should iterate
+over each SPDX SBOM document, re-parse the source data, extract the `supplier` field
+from SPDX package entries, and update the corresponding `sbom_package` records in the
+database with the extracted supplier values.
+
+Only SPDX SBOMs need re-processing — CycloneDX documents already have supplier
+information populated during ingestion.
+
+## Files to Modify
+- `modules/ingestor/src/graph/sbom/mod.rs` — extract the `suppliers()` helper into a public function so the migration can reuse it
+
+## Files to Create
+- `migration/src/m0042_backfill_suppliers/mod.rs` — the data migration that re-processes SPDX SBOMs
+
+## API Changes
+- (none)
+
+## Implementation Notes
+- The `sbom` entity (`entity/src/sbom.rs`) has a `labels` column of type `jsonb` that stores
+  metadata about each document. SPDX documents have `{"type": "spdx"}` in their labels,
+  while CycloneDX documents have `{"type": "cyclonedx"}`.
+- The `suppliers()` function in `modules/ingestor/src/graph/sbom/mod.rs` already contains the
+  SPDX supplier extraction logic. It is currently private (`fn suppliers(...)`) — make it
+  `pub fn suppliers(...)` so the migration can import and reuse it. The migration crate already
+  depends on `trustify-module-ingestor` in `migration/Cargo.toml`.
+- Existing migration pattern: see `migration/src/m0001_initial/mod.rs` for the migration
+  structure. Each migration implements the `MigrationTrait` with an `up()` method.
+- The source SBOM data is stored in the `source_document` table and can be fetched by
+  `sbom_id`. Use `SourceDocument::find_by_sbom_id(id)` to retrieve the raw document bytes.
+- Production environments have hundreds of thousands of CycloneDX documents alongside
+  a smaller number of SPDX documents. The migration should only load and process SPDX
+  documents to avoid unnecessary I/O.
+
+## Acceptance Criteria
+- [ ] The migration re-processes all SPDX SBOM documents and populates supplier fields
+- [ ] CycloneDX documents are not loaded or processed by the migration
+- [ ] The `suppliers()` function in the ingestor is made public for reuse
+- [ ] The migration follows the existing migration pattern from `m0001_initial`
+
+## Test Requirements
+- [ ] Add a test that verifies the migration populates supplier information for an SPDX SBOM
+- [ ] Add a test that verifies CycloneDX SBOMs are not affected by the migration
+
+## Dependencies
+- Depends on: None

--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -959,55 +959,29 @@ lifecycle to catch partial implementations:
    connections before proceeding. If the missing stage is intentionally out of scope
    for this task, ask the user to confirm.
 
-Output the traced data flows and their completeness status to the user before proceeding.
+Output the traced data flows and their completeness status to the user.
 
-> **Example output:**
->
-> **Data-flow trace results:**
-> - `POST /api/v2/sbom` → parse request ✓ → validate ✓ → persist to DB ✓ → return response ✓ — **COMPLETE**
-> - `parseLicense()` → extract license ID ✓ → resolve to SPDX ✓ → attach to package ✗ — **INCOMPLETE** (output not connected)
+> **Example:** `POST /api/v2/sbom` → parse ✓ → validate ✓ → persist ✓ → respond ✓ — **COMPLETE**
+> `parseLicense()` → extract ✓ → resolve ✓ → attach ✗ — **INCOMPLETE** (not connected)
 
 ### Query-scope verification
 
-When the implementation writes batch operations — data migrations, batch updates,
-or any code that iterates database records — verify that the query or iteration
-scope matches the target scope described in the task.
+When implementing batch operations (data migrations, batch updates, or any code
+iterating database records), verify the query scope matches the task's target scope.
 
-1. **Extract the target scope**: review the task's **Description** section for
-   language that restricts the operation to a subset of records. Look for:
-   - Type qualifiers (e.g., "all SPDX SBOMs", "CycloneDX documents only")
-   - Status filters (e.g., "unprocessed records", "active users")
-   - Date ranges (e.g., "created before v2 migration", "last 30 days")
-   - Category selectors (e.g., "high-severity advisories", "external packages")
-2. **Inspect the query scope**: for each batch operation in the implementation,
-   examine the database query, ORM call, or iteration source. Determine whether
-   it fetches all records or applies a filter matching the target scope.
-3. **Check for scope mismatch**: if the task targets a subset but the query
-   loads all records (e.g., `Document::all()` when only SPDX documents are
-   needed), investigate whether the data source supports filtering at the query
-   level:
-   - Check for database columns, indexes, or labels that can discriminate the
-     target subset (e.g., `labels->>'type' = 'spdx'`, `status = 'active'`)
-   - Check for query builder parameters or ORM scopes that support the filter
-   - Check whether the API endpoint accepts filter parameters that would narrow
-     the result set
-4. **Flag broader queries**: if a narrower query is possible but the
-   implementation uses a broader one, flag it for review. Include:
-   - What the task targets (e.g., "only SPDX SBOMs")
-   - What the query fetches (e.g., "all documents regardless of type")
-   - The available filter mechanism (e.g., "`labels->>'type'` column supports
-     filtering by document type")
-   - The performance impact (e.g., "production environments have hundreds of
-     thousands of non-target records that would be loaded and discarded")
-5. **Accept intentional broad queries**: if the implementation deliberately
-   loads all records and filters in application code (e.g., because the filter
-   cannot be expressed at the query level, or because the full dataset is needed
-   for cross-record validation), document the rationale in a code comment.
+1. **Extract target scope**: scan the task **Description** for subset-restricting
+   language — type qualifiers, status filters, date ranges, category selectors.
+2. **Compare query scope**: check whether each batch query filters to the target
+   subset or loads all records indiscriminately.
+3. **Flag scope mismatches**: if the task targets a subset but a narrower query is
+   possible at the data source (via columns, indexes, ORM scopes, or API
+   parameters), flag for review with: target scope, actual query scope, available
+   filter, and performance impact.
+4. **Accept intentional broad queries**: when filtering cannot be expressed at the
+   query level or the full dataset is needed, document the rationale in a comment.
 
 > **Example:** Task: "re-process all SPDX SBOMs". Query: `Document::all()`.
-> Flag: database column `labels->>'type'` supports filtering — use
-> `Document::find_by_type("spdx")` instead of loading all documents and
-> discarding non-SPDX ones in application code.
+> Flag: `labels->>'type'` supports filtering — use filtered query instead.
 
 ### Contract & sibling parity
 

--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -967,6 +967,48 @@ Output the traced data flows and their completeness status to the user before pr
 > - `POST /api/v2/sbom` → parse request ✓ → validate ✓ → persist to DB ✓ → return response ✓ — **COMPLETE**
 > - `parseLicense()` → extract license ID ✓ → resolve to SPDX ✓ → attach to package ✗ — **INCOMPLETE** (output not connected)
 
+### Query-scope verification
+
+When the implementation writes batch operations — data migrations, batch updates,
+or any code that iterates database records — verify that the query or iteration
+scope matches the target scope described in the task.
+
+1. **Extract the target scope**: review the task's **Description** section for
+   language that restricts the operation to a subset of records. Look for:
+   - Type qualifiers (e.g., "all SPDX SBOMs", "CycloneDX documents only")
+   - Status filters (e.g., "unprocessed records", "active users")
+   - Date ranges (e.g., "created before v2 migration", "last 30 days")
+   - Category selectors (e.g., "high-severity advisories", "external packages")
+2. **Inspect the query scope**: for each batch operation in the implementation,
+   examine the database query, ORM call, or iteration source. Determine whether
+   it fetches all records or applies a filter matching the target scope.
+3. **Check for scope mismatch**: if the task targets a subset but the query
+   loads all records (e.g., `Document::all()` when only SPDX documents are
+   needed), investigate whether the data source supports filtering at the query
+   level:
+   - Check for database columns, indexes, or labels that can discriminate the
+     target subset (e.g., `labels->>'type' = 'spdx'`, `status = 'active'`)
+   - Check for query builder parameters or ORM scopes that support the filter
+   - Check whether the API endpoint accepts filter parameters that would narrow
+     the result set
+4. **Flag broader queries**: if a narrower query is possible but the
+   implementation uses a broader one, flag it for review. Include:
+   - What the task targets (e.g., "only SPDX SBOMs")
+   - What the query fetches (e.g., "all documents regardless of type")
+   - The available filter mechanism (e.g., "`labels->>'type'` column supports
+     filtering by document type")
+   - The performance impact (e.g., "production environments have hundreds of
+     thousands of non-target records that would be loaded and discarded")
+5. **Accept intentional broad queries**: if the implementation deliberately
+   loads all records and filters in application code (e.g., because the filter
+   cannot be expressed at the query level, or because the full dataset is needed
+   for cross-record validation), document the rationale in a code comment.
+
+> **Example:** Task: "re-process all SPDX SBOMs". Query: `Document::all()`.
+> Flag: database column `labels->>'type'` supports filtering — use
+> `Document::find_by_type("spdx")` instead of loading all documents and
+> discarding non-SPDX ones in application code.
+
 ### Contract & sibling parity
 
 Verify that modified or created code fully honors its type contracts and maintains


### PR DESCRIPTION
## Summary

- Adds a `### Query-scope verification` subsection to Step 9 (Self-Verification) in `implement-task/SKILL.md` that checks whether batch operations use appropriately filtered queries when the task description targets a subset of records
- Adds constraint 5.14 to `docs/constraints.md` reflecting the new verification rule
- Adds eval scenario (id 11) with `task-query-scope.md` fixture testing detection of query-scope mismatch in a data migration targeting SPDX SBOMs
- Condenses Query-scope verification subsection and Data-flow trace example to pass Skillsaw 16,000-token context budget

Implements [TC-5395](https://redhat.atlassian.net/browse/TC-5395)
Implements [TC-5437](https://redhat.atlassian.net/browse/TC-5437)

## Test plan
- [ ] Run `/run-evals implement-task` to verify eval 11 passes
- [ ] Verify existing evals 1–10 are unaffected
- [ ] Verify `claude plugin validate plugins/sdlc-workflow` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)