### PR TITLE
docs: document Skillsaw CI check in CONVENTIONS.md

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -68,6 +68,28 @@ Not applicable — this is a documentation repository with no runtime code.
     - **Correct**: `Json` extractor for response serialization (Axum)
     - **Incorrect**: `HttpResponse::Ok().json(...)` (Actix-Web response pattern)
 
+## CI Checks
+
+All CI checks must pass before merging. Run locally before pushing:
+
+```bash
+uvx skillsaw
+```
+
+### Skill Lint (Skillsaw)
+
+The Skillsaw linter validates agent instruction files. Token budget limits and rule configuration are defined in `.skillsaw.yaml` — check that file for current thresholds. CI workflow: `.github/workflows/skillsaw.yml` (strict mode disabled — only error-level findings fail CI).
+
+When modifying SKILL.md files, run `uvx skillsaw` locally to verify token counts stay within the configured limits before committing.
+
+### Plugin Validation
+
+```bash
+claude plugin validate plugins/sdlc-workflow
+```
+
+Validates plugin manifests under `plugins/`. CI workflow: `.github/workflows/validate-plugins.yml`.
+
 ## Commit Messages
 
 - **Format**: Conventional Commits — `type(scope): description`


### PR DESCRIPTION
## Summary

- Adds a `## CI Checks` section to `CONVENTIONS.md` with two subsections:
  - **Skill Lint (Skillsaw)**: references `.skillsaw.yaml` for token budget limits and lists `uvx skillsaw` as the local lint command
  - **Plugin Validation**: documents the `claude plugin validate` command
- Enables implement-task's Step 4 CONVENTIONS.md extraction to discover and run CI checks before committing

Implements [TC-5439](https://redhat.atlassian.net/browse/TC-5439)

## Test plan

- [x] `uvx skillsaw` runs locally and passes (0 errors)
- [x] `claude plugin validate plugins/sdlc-workflow` runs locally and passes
- [ ] Verify implement-task's Step 4 discovers the CI Checks section when processing a future task

## Summary by Sourcery

Documentation:
- Add a CI Checks section to CONVENTIONS.md describing Skillsaw linting and plugin validation commands and their associated workflows.