### PR TITLE
fix(implement-task): add symbol dedup and null guard guidance

### DIFF
--- a/evals/implement-task/evals.json
+++ b/evals/implement-task/evals.json
@@ -151,6 +151,32 @@
         "The plan or query-scope analysis explicitly mentions the performance impact of loading all documents — referencing that production environments have hundreds of thousands of non-target CycloneDX records",
         "The plan does NOT propose using an unfiltered query like Sbom::find() or Document::all() followed by an application-level type check to discard CycloneDX documents"
       ]
+    },
+    {
+      "id": 12,
+      "prompt": "Implement task TC-9210. The task description is in task-symbol-dedup.md, the target repository structure is in repo-backend.md, and the project CLAUDE.md is in claude-md-mock.md. Do NOT actually modify repository files or call external tools (Jira, git, Serena). Instead, write your implementation plan to the workspace outputs/ directory: write outputs/plan.md describing which files you would modify and create, what changes you would make to each, and how you would handle the SEVERITY_ORDER constant. Write outputs/symbol-search.md documenting your symbol deduplication analysis — what you searched for, where you found it, and your decision to reuse or redeclare.",
+      "expected_output": "An implementation plan where the symbol search analysis demonstrates searching the target package for SEVERITY_ORDER before declaring a new constant. The plan should find the existing definition in modules/fundamental/src/advisory/service/advisory.rs and plan to import it rather than redeclaring it in the sbom service. The symbol search document should show the search process: grepping or using find_symbol for SEVERITY_ORDER across the package, finding the match, and deciding to reuse.",
+      "files": ["files/task-symbol-dedup.md", "files/repo-backend.md", "files/claude-md-mock.md"],
+      "assertions": [
+        "The symbol search analysis describes searching the target package for SEVERITY_ORDER (or severity ordering) before declaring a new constant — using find_symbol, search_for_pattern, or grep",
+        "The symbol search analysis identifies the existing SEVERITY_ORDER definition in modules/fundamental/src/advisory/service/advisory.rs",
+        "The plan imports or reuses the existing SEVERITY_ORDER constant from the advisory module rather than declaring a duplicate in the sbom service",
+        "The plan does NOT declare a new SEVERITY_ORDER constant in modules/fundamental/src/sbom/service/sbom.rs or any other file when the existing one can be reused",
+        "The symbol search analysis covers the search scope — searching the package broadly (not just the file being edited) to find existing definitions"
+      ]
+    },
+    {
+      "id": 13,
+      "prompt": "Implement task TC-9211. The task description is in task-external-data.md, the target repository structure is in repo-backend.md, and the project CLAUDE.md is in claude-md-mock.md. Do NOT actually modify repository files or call external tools (Jira, git, Serena). Instead, write your implementation plan to the workspace outputs/ directory: write outputs/plan.md describing which files you would modify and create, what changes you would make to each, and how you would handle the nullable fields from AdvisoryIngestResult. Write outputs/null-guards.md documenting your defensive property access analysis — which fields need guards, what guard pattern you would use, and why.",
+      "expected_output": "An implementation plan where the null guards analysis identifies the three nullable fields (cves, affected_packages, severity_counts) from AdvisoryIngestResult and plans defensive access patterns for each. The plan should use Rust's idiomatic guard patterns (unwrap_or_default, as_ref, match/if-let) rather than accessing Option fields directly. The null guards document should explain why guards are needed: the data crosses a module boundary from the ingestor, and the producer's schema uses Option types.",
+      "files": ["files/task-external-data.md", "files/repo-backend.md", "files/claude-md-mock.md"],
+      "assertions": [
+        "The null guards analysis identifies all three nullable fields from AdvisoryIngestResult: cves (Option<Vec<String>>), affected_packages (Option<Vec<AffectedPackage>>), and severity_counts (Option<HashMap<String, u32>>)",
+        "The plan uses Rust's idiomatic null guard patterns for each field — unwrap_or_default(), as_ref(), map(), or if-let/match — rather than calling .unwrap() directly",
+        "The plan does NOT access any of the three Option fields without a guard — no direct .len(), .join(), or iteration on Option<T> without unwrapping safely",
+        "The null guards analysis explains why defensive access is needed: the data crosses a module boundary from the ingestor module, and the producer's schema allows None values",
+        "The test plan includes test cases for all-None inputs (cves=None, affected_packages=None, severity_counts=None) to verify the guards work correctly"
+      ]
     }
   ]
 }

--- a/evals/implement-task/files/task-external-data.md
+++ b/evals/implement-task/files/task-external-data.md
@@ -1,0 +1,60 @@
+<!-- SYNTHETIC TEST DATA — task description testing defensive property access on data from external modules -->
+
+# Mock Jira Task
+
+**Key**: TC-9211
+**Summary**: Add vulnerability summary extractor for advisory digest emails
+**Status**: To Do
+**Labels**: ai-generated-jira
+**Linked Issues**: is incorporated by TC-9001
+
+---
+
+## Repository
+trustify-backend
+
+## Target Branch
+main
+
+## Description
+Add a vulnerability summary extractor that processes advisory data from the ingestor
+module's output and produces a digest suitable for email notifications. The extractor
+reads `AdvisoryIngestResult` records produced by `IngestorService::ingest_advisory()`
+and extracts CVE identifiers, affected package counts, and severity breakdowns.
+
+The `AdvisoryIngestResult` struct contains optional and nullable fields:
+- `cves: Option<Vec<String>>` — list of CVE identifiers; may be `None` when the advisory has no CVE references
+- `affected_packages: Option<Vec<AffectedPackage>>` — packages impacted; may be `None` for advisories without package-level detail
+- `severity_counts: Option<HashMap<String, u32>>` — counts per severity level; may be `None` when severity metadata is absent
+
+The extractor must handle all nullable fields gracefully without panicking.
+
+## Files to Modify
+- `modules/fundamental/src/advisory/service/advisory.rs` — add `extract_vulnerability_summary()` method to AdvisoryService
+
+## Files to Create
+- `modules/fundamental/src/advisory/model/vulnerability_summary.rs` — VulnerabilitySummary output struct
+- `tests/api/advisory_summary.rs` — integration tests for the extractor
+
+## Implementation Notes
+- The `AdvisoryIngestResult` is defined in `modules/ingestor/src/service/mod.rs` — its fields use `Option<T>` for all aggregate data
+- Follow the existing service method pattern in `advisory.rs` — methods return `Result<T, AppError>`
+- The output `VulnerabilitySummary` struct should have non-optional fields with sensible defaults: `cve_count: u32`, `cve_list: Vec<String>`, `affected_package_count: u32`, `severity_breakdown: HashMap<String, u32>`
+- When `cves` is `None`, use an empty `Vec` and set `cve_count` to 0
+- When `affected_packages` is `None`, set `affected_package_count` to 0
+- When `severity_counts` is `None`, use an empty `HashMap`
+
+## Acceptance Criteria
+- [ ] `extract_vulnerability_summary()` produces a valid summary from a fully-populated AdvisoryIngestResult
+- [ ] `extract_vulnerability_summary()` handles None values for cves, affected_packages, and severity_counts without panicking
+- [ ] VulnerabilitySummary fields are always populated (non-optional) with sensible defaults for missing data
+- [ ] cve_count matches the length of the cve_list
+
+## Test Requirements
+- [ ] Test extraction with fully-populated AdvisoryIngestResult (all fields Some)
+- [ ] Test extraction with all-None fields (cves=None, affected_packages=None, severity_counts=None) — should return zeroed summary
+- [ ] Test extraction with mixed Some/None fields — each None field defaults independently
+- [ ] Test that cve_count is consistent with cve_list.len()
+
+## Dependencies
+- Depends on: None

--- a/evals/implement-task/files/task-symbol-dedup.md
+++ b/evals/implement-task/files/task-symbol-dedup.md
@@ -1,0 +1,51 @@
+<!-- SYNTHETIC TEST DATA — task description testing symbol deduplication behavior: constant already exists in sibling module -->
+
+# Mock Jira Task
+
+**Key**: TC-9210
+**Summary**: Add severity-sorted remediation list to SBOM risk report
+**Status**: To Do
+**Labels**: ai-generated-jira
+**Linked Issues**: is incorporated by TC-9001
+
+---
+
+## Repository
+trustify-backend
+
+## Target Branch
+main
+
+## Description
+Add a severity-sorted remediation list to the SBOM risk report endpoint. The list
+should sort advisories by severity (Critical > High > Medium > Low > None) and return
+them in descending severity order. The advisory module already defines a severity
+ordering constant `SEVERITY_ORDER` in `modules/fundamental/src/advisory/service/advisory.rs`
+that maps severity strings to numeric sort weights.
+
+## Files to Modify
+- `modules/fundamental/src/sbom/service/sbom.rs` — add severity-sorted remediation list builder to SbomService
+- `modules/fundamental/src/sbom/endpoints/get.rs` — include remediation list in SBOM details response
+
+## Files to Create
+- `tests/api/sbom_remediation.rs` — integration tests for severity-sorted remediation list
+
+## Implementation Notes
+- The advisory module's `advisory.rs` service file defines `SEVERITY_ORDER: &[&str] = &["critical", "high", "medium", "low", "none"]` — reuse this constant for sorting instead of redefining it
+- Follow the existing pattern in `sbom/service/sbom.rs` for fetching related advisories
+- The remediation list maps each advisory to a `RemediationItem { advisory_id, severity, title, fix_version }` struct
+- Sort using the `SEVERITY_ORDER` constant as the sort key — position in the array determines priority
+
+## Acceptance Criteria
+- [ ] GET /api/v2/sbom/{id} response includes a `remediations` field with severity-sorted list
+- [ ] Advisories are sorted Critical > High > Medium > Low > None
+- [ ] The severity ordering uses the existing `SEVERITY_ORDER` constant from the advisory module — no duplicate definition
+- [ ] RemediationItem struct includes advisory_id, severity, title, and fix_version fields
+
+## Test Requirements
+- [ ] Test that remediation list is sorted by severity (Critical first, None last)
+- [ ] Test that SBOM with no advisories returns empty remediation list
+- [ ] Test that multiple advisories of the same severity maintain stable ordering
+
+## Dependencies
+- Depends on: None

--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -438,6 +438,24 @@ decide whether to make it public or duplicate it:
    rationale in the commit message or PR description so reviewers understand why code
    was reused or duplicated.
 
+### Symbol deduplication
+
+Before declaring any new constant, enum, type alias, or configuration map, search the
+target package for an existing definition of the same symbol. This applies especially
+when the task description references a sibling module — the symbol may already exist there.
+
+1. **Search before declaring**: use `find_symbol`, `search_for_pattern`, or Grep to search
+   the target package (not just the file being edited) for the symbol name or its value.
+   Include common variations (e.g., `SEVERITY_ORDER`, `severityOrder`, `SeverityOrder`).
+2. **If found**: import and reuse the existing definition. If it is not exported, follow
+   the "Reuse over duplication" guidance above to decide whether to export it or inline it.
+3. **If not found**: declare the new symbol in the most appropriate shared location
+   (utilities module, constants file, or the file where it is used if truly local).
+
+> **Example:** Task says "sort remediations by severity". Before declaring
+> `const SEVERITY_ORDER = [...]`, grep the package for `SEVERITY_ORDER`. If
+> `src/remediation.js` already exports it, import from there instead of redeclaring.
+
 ### Serena symbolic editing (preferred)
 
 Use the dedicated Serena instance for the task's repository (look up the instance name
@@ -492,6 +510,19 @@ After implementing code changes, verify the following quality practices:
   functions where the name alone does not convey the full intent, add a brief
   explanation of behavior, parameters, or return value so that human reviewers can
   understand the code without reading the implementation.
+
+- **Defensive property access on external data**: when consuming data produced by another
+  module, service, or external API, add null/undefined guards before accessing nested
+  properties — especially arrays and objects that may be absent even when the upstream
+  type signature suggests otherwise. Use the language's idiomatic guard pattern (e.g.,
+  optional chaining `?.` in JavaScript/TypeScript, `if let` / `.unwrap_or_default()` in
+  Rust, `getattr(obj, 'field', default)` in Python). This applies to any property access
+  path where the data crosses a module boundary — the producer's schema may allow null,
+  return partial results, or evolve independently.
+
+  > **Example:** Upstream returns `{ cves: string[] | null }`. Before accessing
+  > `rem.cves.length` or `rem.cves.join(',')`, guard with `(rem.cves ?? [])` or
+  > equivalent.
 
 ### Documentation impact
 


### PR DESCRIPTION
## Summary

- Add **Symbol deduplication** subsection to Step 6 — requires searching the target package for existing constants, enums, and type aliases before declaring new ones
- Add **Defensive property access on external data** bullet to Code quality practices — requires null/undefined guards when consuming data from external modules
- Add eval cases 12 and 13 with fixture files to cover the new behaviors

Implements [TC-5516](https://redhat.atlassian.net/browse/TC-5516)

## Summary by Sourcery

Strengthen implement-task workflow guidance around reusing existing symbols and defensively handling external data, and add eval coverage for these behaviors.

Documentation:
- Add symbol deduplication guidance requiring searches for existing constants, enums, and type aliases before introducing new declarations.
- Document defensive property access expectations when consuming nullable or optional data from external modules or APIs.

Tests:
- Add new implement-task eval scenarios, with synthetic Jira task fixtures, to validate symbol deduplication and defensive handling of external ingest results.