### PR TITLE
feat(verify-pr): add Vertex AI provider and profile for fullsend harness

### DIFF
--- a/plugins/sdlc-workflow/profiles/fullsend-vertex-ai.yaml
+++ b/plugins/sdlc-workflow/profiles/fullsend-vertex-ai.yaml
@@ -1,0 +1,15 @@
+---
+id: fullsend-vertex-ai
+display_name: Fullsend Vertex AI
+description: Google Cloud APIs for Vertex AI inference
+category: inference
+endpoints:
+  - host: "*.googleapis.com"
+    port: 443
+    protocol: rest
+    access: read-write
+    enforcement: enforce
+binaries:
+  - "**/claude"
+  - "**/pi"
+  - "**/node"

--- a/plugins/sdlc-workflow/providers/vertex-ai.yaml
+++ b/plugins/sdlc-workflow/providers/vertex-ai.yaml
@@ -1,0 +1,5 @@
+---
+name: vertex-ai
+type: fullsend-vertex-ai
+credentials:
+  _NOOP_VERTEX_AI: ""


### PR DESCRIPTION
## Summary

Adds the two in-sandbox credential files the standalone `harness/verify-pr.yaml` already references but that were deferred to this task:

- `plugins/sdlc-workflow/providers/vertex-ai.yaml` — provider `type: fullsend-vertex-ai`
- `plugins/sdlc-workflow/profiles/fullsend-vertex-ai.yaml` — profile `id: fullsend-vertex-ai`, egress `*.googleapis.com:443`

Vertex is the **sole** in-sandbox provider (tier 4, fullsend-mandated for in-sandbox model inference). Jira and GitHub are tier-1 (prefetched host-side, Epic C) and need no in-sandbox provider — so no `jira.yaml` and no `github-ro.yaml`/`fullsend-github-ro.yaml` are created. The pair is copied verbatim from the stock agents Vertex pair.

The harness (`harness/verify-pr.yaml`) wires these via `providers:` and `openshell.profiles:`.

## Verification

- `claude plugin validate plugins/sdlc-workflow` → ✔ passed
- `uvx skillsaw` → 0 errors (grade A; warnings are pre-existing, unrelated to these YAML files)
- Provider `type` matches profile `id` (`fullsend-vertex-ai`)
- No `type: generic`, no `providers/jira.yaml`, no `providers/github-ro.yaml`, no `profiles/fullsend-github-ro.yaml`

Implements [TC-5808](https://redhat.atlassian.net/browse/TC-5808)

## Summary by Sourcery

New Features:
- Add the Fullsend Vertex AI provider and profile for sandboxed Vertex AI inference.