### PR TITLE
feat(verify-pr): add read-only sandbox policy with no tier-1 egress (TC-5809)

### DIFF
--- a/plugins/sdlc-workflow/policies/verify-pr.yaml
+++ b/plugins/sdlc-workflow/policies/verify-pr.yaml
@@ -18,7 +18,9 @@ version: 1
 #     the skill/prefetch — NOT a reason to add a github egress rule here.
 #
 # curl and gh are excluded from the binary allowlist to prevent raw HTTP
-# egress with any injected token; only claude/node may open the network.
+# egress with any injected token; only the fullsend runtimes (claude/pi/node)
+# may open the network. `**/pi` is the runtime that brokers Vertex AI
+# (`*.googleapis.com`) inference, so it must be present alongside claude/node.
 #
 # include_workdir: false — the fullsend dir is not mounted into the sandbox;
 # the target repo is delivered read-only under /sandbox (readonly_repo: true).
@@ -66,4 +68,5 @@ network_policies:
         access: read-write
     binaries:
       - path: "**/claude"
+      - path: "**/pi"
       - path: "**/node"

--- a/plugins/sdlc-workflow/policies/verify-pr.yaml
+++ b/plugins/sdlc-workflow/policies/verify-pr.yaml
@@ -1,0 +1,69 @@
+version: 1
+
+# Sandbox policy for the verify-pr fullsend harness (read-only agent).
+#
+# The agent checks a PR against its Jira task's acceptance criteria. It needs
+# ONLY inference egress: Anthropic hosts + Vertex AI (`*.googleapis.com`).
+# Format confirmed against fullsend v0.37.0 upstream policies
+# (/Users/mrizzi/git/cloned/agents/policies/*): per-entry `name:` is still
+# required, hosts support `*` wildcards, and binaries use `**/…` globs.
+#
+# Split-trust I/O — deliberately NO tier-1 egress from the sandbox:
+#   * NO `*.atlassian.net` (Jira): the Jira token lives only on the runner;
+#     issue context is prefetched host-side (pre_script, TC-5810) and mounted
+#     read-only, and all Jira writes run host-side (post_script, TC-5811).
+#   * NO `api.github.com`/`github.com` (GitHub): the GitHub token lives only on
+#     the runner; PR context is prefetched host-side and writes run host-side.
+#     A `gh` read reaching api.github.com from the sandbox is a leak to fix in
+#     the skill/prefetch — NOT a reason to add a github egress rule here.
+#
+# curl and gh are excluded from the binary allowlist to prevent raw HTTP
+# egress with any injected token; only claude/node may open the network.
+#
+# include_workdir: false — the fullsend dir is not mounted into the sandbox;
+# the target repo is delivered read-only under /sandbox (readonly_repo: true).
+
+filesystem_policy:
+  include_workdir: false
+  read_only: [/var/log, /usr, /lib, /lib64, /proc, /dev/urandom, /etc, /opt]
+  read_write: [/sandbox, /tmp, /dev/null]
+landlock:
+  compatibility: best_effort
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  claude_code:
+    name: claude-code
+    endpoints:
+      # Anthropic inference + Vertex AI (googleapis) — the only egress allowed.
+      - host: "api.anthropic.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-write
+      - host: "*.googleapis.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-write
+      - host: "platform.claude.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-write
+      # Telemetry / error reporting (POST) — kept minimal.
+      - host: "statsig.anthropic.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-write
+      - host: "sentry.io"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-write
+    binaries:
+      - path: "**/claude"
+      - path: "**/node"


### PR DESCRIPTION
## Summary

Adds `plugins/sdlc-workflow/policies/verify-pr.yaml`, the read-only sandbox policy for the verify-pr fullsend harness (referenced by `harness/verify-pr.yaml`).

- **Filesystem**: read-only, `include_workdir: false`; `read_write` limited to `/sandbox`, `/tmp`, `/dev/null`.
- **Egress**: inference + telemetry only — `api.anthropic.com`, `*.googleapis.com` (Vertex AI), `platform.claude.com`, `statsig.anthropic.com`, `sentry.io`.
- **No tier-1 egress**: no `*.atlassian.net` (Jira) and no `api.github.com`/`github.com` (GitHub). Those tokens live only on the runner under the split-trust I/O model — context is prefetched host-side (pre_script) and writes run host-side (post_script). A `gh` read hitting api.github.com from the sandbox would be a leak to fix in the skill/prefetch, not a reason to add an egress rule.
- **Binary allowlist**: only the fullsend runtimes `**/claude`, `**/pi`, and `**/node` may open the network; `curl`/`gh` are excluded to block raw HTTP with any injected token.
- **Vertex runtime fix (TC-5880)**: added `**/pi` to the binary allowlist — the fullsend `pi` runtime is what brokers Vertex AI (`*.googleapis.com`) inference, and under the dual host-AND-binary match rule it must be allowlisted alongside `**/claude`/`**/node` or inference is blocked. Addresses Sourcery review feedback on this PR; matches the composed `fullsend-vertex-ai` profile and upstream vertex policies.

Format confirmed against fullsend v0.37.0 upstream policies (`agents/policies/*`): per-entry `name:` still required, `*` host wildcards, `**/…` binary globs.

## Verification

- `python3` YAML structural validation — passes.
- `claude plugin validate plugins/sdlc-workflow` — passes.
- `uvx skillsaw` — 0 errors (Grade A).
- Live `fullsend run verify-pr` egress check (task Step 3) is **deferred to TC-5810/TC-5811**: the harness references siblings not yet authored (pre/post scripts, result schema), so `fullsend run`/`lock` cannot resolve it yet; it also needs runner secrets and a Linux landlock sandbox. This matches the deferral already noted in `harness/verify-pr.yaml`.

Implements [TC-5809](https://redhat.atlassian.net/browse/TC-5809)

## Summary by Sourcery

Add a least-privilege read-only sandbox policy for verify-pr that permits only required inference and telemetry access while preventing direct Jira and GitHub egress.

New Features:
- Add a read-only sandbox policy for the verify-pr harness with inference and telemetry egress limited to approved Anthropic, Vertex AI, and monitoring endpoints.
- Restrict network-capable binaries to Claude and Node while excluding raw HTTP clients such as curl and gh.

Enhancements:
- Enforce split-trust handling by keeping Jira and GitHub services inaccessible from the sandbox and limiting filesystem access to the required paths.

Tests:
- Validate the policy structure, plugin configuration, and skills with YAML validation, plugin validation, and Skillsaw.
