### PR TITLE
feat(verify-pr): split-trust I/O — schemas, prefetch, native validation_loop

### DIFF
--- a/harness/verify-pr.yaml
+++ b/harness/verify-pr.yaml
@@ -67,7 +67,12 @@ pre_script: plugins/sdlc-workflow/scripts/pre-verify-pr.sh
 post_script: plugins/sdlc-workflow/scripts/post-verify-pr.sh
 
 validation_loop:
-  # script: added in TC-5810 alongside the schema's producer/validator.
+  # Custom validator: the result schema uses additionalProperties:false
+  # throughout to document the contract, so strip_extra_properties.py drops
+  # benign agent-added metadata before jsonschema validates (fullsend's
+  # native schema-only check would reject it). fullsend requires a script for
+  # validation_loop regardless — schema alone is not sufficient.
+  script: plugins/sdlc-workflow/scripts/validate-output-schema.sh
   schema: plugins/sdlc-workflow/schemas/verify-pr-result.schema.json
   max_iterations: 2
 

--- a/plugins/sdlc-workflow/schemas/verify-pr-input.schema.json
+++ b/plugins/sdlc-workflow/schemas/verify-pr-input.schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "verify-pr-input.schema.json",
+  "title": "Verify PR Pre-Script Input",
+  "description": "Pre-fetched task data written by the pre_script and mounted into the sandbox. The skill reads this instead of calling the issue tracker or GitHub APIs directly.",
+  "type": "object",
+  "required": ["task_id", "task", "pr_url", "github"],
+  "additionalProperties": false,
+  "properties": {
+    "task_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Issue tracker task ID (e.g., TC-4741, #42)"
+    },
+    "task": {
+      "type": "object",
+      "required": ["summary", "description", "status", "labels"],
+      "properties": {
+        "summary": { "type": "string", "minLength": 1 },
+        "description": {
+          "type": "object",
+          "description": "Task description in the issue tracker's native format (e.g., ADF for Jira)"
+        },
+        "status": { "type": "string" },
+        "labels": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "issue_links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": { "type": "string" },
+              "direction": { "type": "string", "enum": ["inward", "outward"] },
+              "key": { "type": "string" }
+            }
+          },
+          "description": "Related issues (parent, blocks, relates)"
+        },
+        "custom_fields": {
+          "type": "object",
+          "description": "Tracker-specific custom field values"
+        }
+      }
+    },
+    "pr_url": {
+      "type": "string",
+      "description": "PR URL extracted from the task, or empty if not linked"
+    },
+    "github": {
+      "type": "object",
+      "description": "GitHub tier-1 read bundle, prefetched on the trusted runner (where GH_TOKEN lives) so the sandbox needs no api.github.com egress. Every read the verify-pr skill performs against the PR is captured here.",
+      "required": ["pr_repo", "pr_number", "headRefName", "commit_sha", "diff", "stat", "reviews", "review_comments", "issue_comments", "commits"],
+      "additionalProperties": false,
+      "properties": {
+        "pr_repo": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$",
+          "description": "owner/repo parsed from pr_url"
+        },
+        "pr_number": { "type": "integer", "minimum": 1 },
+        "headRefName": {
+          "type": "string",
+          "description": "PR head branch name (gh pr view --json headRefName)"
+        },
+        "commit_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{7,40}$",
+          "description": "OID of the PR head (last) commit (gh pr view --json commits --jq '.commits[-1].oid')"
+        },
+        "diff": {
+          "type": "string",
+          "description": "Unified PR diff (gh pr diff)"
+        },
+        "stat": {
+          "type": "string",
+          "description": "PR diffstat (gh pr diff --stat)"
+        },
+        "reviews": {
+          "type": "array",
+          "description": "PR reviews (gh api repos/<repo>/pulls/<n>/reviews)"
+        },
+        "review_comments": {
+          "type": "array",
+          "description": "PR review (inline code) comments (gh api repos/<repo>/pulls/<n>/comments)"
+        },
+        "issue_comments": {
+          "type": "array",
+          "description": "PR conversation comments (gh api repos/<repo>/issues/<n>/comments)"
+        },
+        "commits": {
+          "type": "array",
+          "description": "PR commits (gh pr view --json commits)"
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "description": "Raw issue tracker response for fields not captured above",
+      "properties": {
+        "tracker": { "type": "string", "description": "Issue tracker type (e.g., jira, github)" },
+        "raw": { "type": "object", "description": "Full raw API response" }
+      }
+    }
+  }
+}

--- a/plugins/sdlc-workflow/schemas/verify-pr-result.schema.json
+++ b/plugins/sdlc-workflow/schemas/verify-pr-result.schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "verify-pr-result.schema.json",
+  "title": "Verify PR Agent Result",
+  "description": "Structured output from the verify-pr agent. Validated by fullsend's validation_loop before the post_script runs.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["report", "actions"],
+  "properties": {
+    "report": { "$ref": "#/$defs/report" },
+    "actions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/action" }
+    }
+  },
+  "$defs": {
+    "report": {
+      "type": "object",
+      "required": ["jira_issue_id", "pr_repo", "pr_number", "commit_sha", "overall", "table_md", "report_md", "report_adf", "plugin_version"],
+      "additionalProperties": false,
+      "properties": {
+        "jira_issue_id": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+        "pr_repo": { "type": "string", "pattern": "^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$" },
+        "pr_number": { "type": "integer", "minimum": 1 },
+        "commit_sha": { "type": "string", "pattern": "^[0-9a-f]{7,40}$" },
+        "overall": { "type": "string", "enum": ["PASS", "WARN", "FAIL"] },
+        "table_md": { "type": "string", "minLength": 1 },
+        "report_md": { "type": "string", "minLength": 1 },
+        "report_adf": { "type": "object" },
+        "plugin_version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" }
+      }
+    },
+    "action": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "type": "string", "enum": ["create_subtask", "create_link", "post_pr_reply", "post_pr_comment", "create_root_cause_task", "post_comment", "post_report"] }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "type": { "const": "create_subtask" } } },
+          "then": {
+            "required": ["type", "ref", "parent", "summary", "labels", "description_adf"],
+            "properties": {
+              "type": {},
+              "ref": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+              "parent": { "type": "string", "pattern": "^[A-Z]+-[0-9]+$" },
+              "summary": { "type": "string", "minLength": 1, "maxLength": 255 },
+              "labels": { "type": "array", "items": { "type": "string" } },
+              "description_adf": { "type": "object" }
+            },
+            "additionalProperties": false
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "create_link" } } },
+          "then": {
+            "required": ["type", "link_type", "inward", "outward"],
+            "properties": {
+              "type": {},
+              "link_type": { "type": "string", "enum": ["Blocks", "Related"] },
+              "inward": { "type": "string", "minLength": 1 },
+              "outward": { "type": "string", "minLength": 1 }
+            },
+            "additionalProperties": false
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "post_pr_reply" } } },
+          "then": {
+            "required": ["type", "repo", "pr_number", "comment_id", "body"],
+            "properties": {
+              "type": {},
+              "repo": { "type": "string" },
+              "pr_number": { "type": "integer", "minimum": 1 },
+              "comment_id": { "type": "integer", "minimum": 1 },
+              "body": { "type": "string", "minLength": 1 }
+            },
+            "additionalProperties": false
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "post_pr_comment" } } },
+          "then": {
+            "required": ["type", "repo", "pr_number", "body"],
+            "properties": {
+              "type": {},
+              "repo": { "type": "string" },
+              "pr_number": { "type": "integer", "minimum": 1 },
+              "body": { "type": "string", "minLength": 1 }
+            },
+            "additionalProperties": false
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "create_root_cause_task" } } },
+          "then": {
+            "required": ["type", "ref", "summary", "labels", "description_adf"],
+            "properties": {
+              "type": {},
+              "ref": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+              "summary": { "type": "string", "minLength": 1, "maxLength": 255 },
+              "labels": { "type": "array", "items": { "type": "string" } },
+              "description_adf": { "type": "object" }
+            },
+            "additionalProperties": false
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "post_comment" } } },
+          "then": {
+            "required": ["type", "issue", "body_adf"],
+            "properties": {
+              "type": {},
+              "issue": { "type": "string", "minLength": 1 },
+              "body_adf": { "type": "object" }
+            },
+            "additionalProperties": false
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "post_report" } } },
+          "then": {
+            "required": ["type"],
+            "properties": {
+              "type": {}
+            },
+            "additionalProperties": false
+          }
+        }
+      ]
+    }
+  }
+}

--- a/plugins/sdlc-workflow/scripts/pre-verify-pr.sh
+++ b/plugins/sdlc-workflow/scripts/pre-verify-pr.sh
@@ -96,8 +96,11 @@ fi
 
 echo "PR linked: ${PR_URL}"
 
-# 6. Parse owner/repo/number from the PR URL.
-if [[ ! "${PR_URL}" =~ ^https://github\.com/([^/]+/[^/]+)/pull/([0-9]+) ]]; then
+# 6. Parse owner/repo/number from the PR URL. End-anchor the pattern (allowing
+#    only an optional trailing slash) so a malformed value like `.../pull/42abc`
+#    or `.../pull/42/extra` is rejected outright instead of silently truncating
+#    the pull number to 42 and prefetching the wrong PR.
+if [[ ! "${PR_URL}" =~ ^https://github\.com/([^/]+/[^/]+)/pull/([0-9]+)/?$ ]]; then
   echo "ERROR: PR URL '${PR_URL}' is not a github.com pull request URL"
   exit 1
 fi

--- a/plugins/sdlc-workflow/scripts/pre-verify-pr.sh
+++ b/plugins/sdlc-workflow/scripts/pre-verify-pr.sh
@@ -114,7 +114,11 @@ echo "PR: ${PR_REPO}#${PR_NUM}"
 : "${GH_TOKEN:?GH_TOKEN is required to prefetch PR ${PR_REPO}#${PR_NUM}}"
 
 HEAD_REF=$(gh pr view "${PR_NUM}" -R "${PR_REPO}" --json headRefName --jq .headRefName)
-COMMIT_SHA=$(gh pr view "${PR_NUM}" -R "${PR_REPO}" --json commits --jq '.commits[-1].oid')
+# Derive the head SHA from the ref tip OID, not from `.commits[-1].oid`: gh's
+# `pr view` commits connection is bounded, so on a PR with more commits than the
+# cap `.commits[-1]` is the last commit of a truncated page rather than the head
+# — a silently-wrong SHA that still satisfies the result schema's hex pattern.
+COMMIT_SHA=$(gh pr view "${PR_NUM}" -R "${PR_REPO}" --json headRefOid --jq .headRefOid)
 
 gh pr diff "${PR_NUM}" -R "${PR_REPO}"                  > "${PRE_OUTPUT_DIR}/pr.diff"
 # `gh pr diff` has no --stat flag; derive the per-file diffstat from the patch we
@@ -134,6 +138,12 @@ fi
 gh api --paginate --slurp "repos/${PR_REPO}/pulls/${PR_NUM}/reviews"  | jq 'add' > "${PRE_OUTPUT_DIR}/reviews.json"
 gh api --paginate --slurp "repos/${PR_REPO}/pulls/${PR_NUM}/comments" | jq 'add' > "${PRE_OUTPUT_DIR}/review-comments.json"
 gh api --paginate --slurp "repos/${PR_REPO}/issues/${PR_NUM}/comments" | jq 'add' > "${PRE_OUTPUT_DIR}/issue-comments.json"
+# The bundled commits list uses gh's bounded `pr view` commits connection, so it
+# may be truncated on a very large PR. The authoritative head SHA is taken from
+# headRefOid above; this list is best-effort context for commit-traceability. If
+# a consumer ever treats it as authoritative, switch to a paginated
+# `gh api --paginate .../pulls/${PR_NUM}/commits` (which returns a different,
+# `sha`-shaped object needing reshaping to match the `oid` contract).
 gh pr view "${PR_NUM}" -R "${PR_REPO}" --json commits --jq .commits > "${PRE_OUTPUT_DIR}/commits.json"
 
 echo "GitHub read bundle prefetched to ${PRE_OUTPUT_DIR}"

--- a/plugins/sdlc-workflow/scripts/pre-verify-pr.sh
+++ b/plugins/sdlc-workflow/scripts/pre-verify-pr.sh
@@ -114,7 +114,14 @@ HEAD_REF=$(gh pr view "${PR_NUM}" -R "${PR_REPO}" --json headRefName --jq .headR
 COMMIT_SHA=$(gh pr view "${PR_NUM}" -R "${PR_REPO}" --json commits --jq '.commits[-1].oid')
 
 gh pr diff "${PR_NUM}" -R "${PR_REPO}"                  > "${PRE_OUTPUT_DIR}/pr.diff"
-gh pr diff "${PR_NUM}" -R "${PR_REPO}" --stat           > "${PRE_OUTPUT_DIR}/pr.stat"
+# `gh pr diff` has no --stat flag; derive the per-file diffstat from the patch we
+# just fetched using a supported git command. Guard the empty-diff case: `git
+# apply --stat` errors on an empty patch, which would abort under set -euo pipefail.
+if [[ -s "${PRE_OUTPUT_DIR}/pr.diff" ]]; then
+  git apply --stat "${PRE_OUTPUT_DIR}/pr.diff"         > "${PRE_OUTPUT_DIR}/pr.stat"
+else
+  : > "${PRE_OUTPUT_DIR}/pr.stat"
+fi
 gh api "repos/${PR_REPO}/pulls/${PR_NUM}/reviews"       > "${PRE_OUTPUT_DIR}/reviews.json"
 gh api "repos/${PR_REPO}/pulls/${PR_NUM}/comments"      > "${PRE_OUTPUT_DIR}/review-comments.json"
 gh api "repos/${PR_REPO}/issues/${PR_NUM}/comments"     > "${PRE_OUTPUT_DIR}/issue-comments.json"

--- a/plugins/sdlc-workflow/scripts/pre-verify-pr.sh
+++ b/plugins/sdlc-workflow/scripts/pre-verify-pr.sh
@@ -122,9 +122,15 @@ if [[ -s "${PRE_OUTPUT_DIR}/pr.diff" ]]; then
 else
   : > "${PRE_OUTPUT_DIR}/pr.stat"
 fi
-gh api "repos/${PR_REPO}/pulls/${PR_NUM}/reviews"       > "${PRE_OUTPUT_DIR}/reviews.json"
-gh api "repos/${PR_REPO}/pulls/${PR_NUM}/comments"      > "${PRE_OUTPUT_DIR}/review-comments.json"
-gh api "repos/${PR_REPO}/issues/${PR_NUM}/comments"     > "${PRE_OUTPUT_DIR}/issue-comments.json"
+# GitHub REST returns ~30 items per page; without --paginate the reviews and
+# comments are silently truncated on any active PR. --slurp aggregates the
+# per-page arrays into an array-of-pages, which `jq 'add'` concatenates back
+# into the single flat array that pre_verify_pr.py's build_github_bundle
+# expects. (--slurp cannot be combined with gh's built-in --jq, so the merge
+# uses a standalone jq.) pipefail makes a failed gh or jq abort the script.
+gh api --paginate --slurp "repos/${PR_REPO}/pulls/${PR_NUM}/reviews"  | jq 'add' > "${PRE_OUTPUT_DIR}/reviews.json"
+gh api --paginate --slurp "repos/${PR_REPO}/pulls/${PR_NUM}/comments" | jq 'add' > "${PRE_OUTPUT_DIR}/review-comments.json"
+gh api --paginate --slurp "repos/${PR_REPO}/issues/${PR_NUM}/comments" | jq 'add' > "${PRE_OUTPUT_DIR}/issue-comments.json"
 gh pr view "${PR_NUM}" -R "${PR_REPO}" --json commits --jq .commits > "${PRE_OUTPUT_DIR}/commits.json"
 
 echo "GitHub read bundle prefetched to ${PRE_OUTPUT_DIR}"

--- a/plugins/sdlc-workflow/scripts/pre-verify-pr.sh
+++ b/plugins/sdlc-workflow/scripts/pre-verify-pr.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# pre-verify-pr.sh — Validate inputs and pre-fetch Jira + GitHub data.
+#
+# Runs on the fullsend runner BEFORE the sandbox is created, where the Jira
+# and GitHub tokens live. The sandbox never sees a token — it reads only the
+# JSON this script produces.
+#
+# 1. Validates required env vars and JIRA_ISSUE_ID format
+# 2. Fetches the full Jira issue and extracts the linked PR URL
+# 3. If no PR URL: emits an ADR-0072 skip signal and exits 0 (nothing to verify)
+# 4. If a PR URL: prefetches the GitHub tier-1 read bundle (diff, stat,
+#    reviews, comments, commits, head ref + commit SHA) so the sandbox needs
+#    no api.github.com egress
+# 5. Writes the tracker-agnostic verify-pr-input.json that host_files mounts
+#    into the sandbox
+#
+# Required env vars:
+#   JIRA_ISSUE_ID     — Jira issue key (e.g., TC-4741)
+#   JIRA_SERVER_URL   — Jira instance URL
+#   JIRA_EMAIL        — Jira user email
+#   JIRA_API_TOKEN    — Jira API token
+#   GH_TOKEN          — GitHub token (only needed once a PR URL is resolved)
+#
+# Optional env vars:
+#   PRE_DIR                   — output directory (default: /tmp/fullsend-pre-output).
+#                               The harness host_files src is the default path.
+#   FULLSEND_PRESCRIPT_OUTPUT — key=value skip-signal file created by fullsend run
+#                               (pre-script output protocol v1). Guarded — older
+#                               CLIs leave it unset.
+
+set -euo pipefail
+
+# 1. Validate required env vars are set
+: "${JIRA_ISSUE_ID:?JIRA_ISSUE_ID is required}"
+: "${JIRA_SERVER_URL:?JIRA_SERVER_URL is required}"
+: "${JIRA_EMAIL:?JIRA_EMAIL is required}"
+: "${JIRA_API_TOKEN:?JIRA_API_TOKEN is required}"
+
+# 2. Validate JIRA_ISSUE_ID format
+# https://confluence.atlassian.com/adminjiraserver/changing-the-project-key-format-938847081.html
+if [[ ! "${JIRA_ISSUE_ID}" =~ ^[A-Z][A-Z0-9_]+-[0-9]+$ ]]; then
+  echo "ERROR: JIRA_ISSUE_ID '${JIRA_ISSUE_ID}' does not match expected format (e.g., TC-4741)"
+  exit 1
+fi
+
+echo "Issue: ${JIRA_ISSUE_ID}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRE_OUTPUT_DIR="${PRE_DIR:-/tmp/fullsend-pre-output}"
+mkdir -p "${PRE_OUTPUT_DIR}"
+
+# request_skip REASON — emit an ADR-0072 skip signal and exit cleanly.
+# The pre-script output protocol (v1) is line-based key=value; the guard on
+# FULLSEND_PRESCRIPT_OUTPUT matches the scaffold's GITHUB_OUTPUT guard, so a
+# missing variable (older CLI) fails open to a normal run rather than erroring.
+request_skip() {
+  local reason="$1"
+  echo "SKIP: ${reason}"
+  if [[ -n "${FULLSEND_PRESCRIPT_OUTPUT:-}" ]]; then
+    {
+      echo "skipped=true"
+      echo "reason=${reason}"
+    } >> "${FULLSEND_PRESCRIPT_OUTPUT}"
+  fi
+  exit 0
+}
+
+# 3. Fetch full issue details (validates existence + pre-fetches for sandbox)
+ISSUE_JSON=$(python3 "${SCRIPT_DIR}/jira-client.py" get_issue "${JIRA_ISSUE_ID}" --fields "*all" 2>"/tmp/fullsend-pre-jira-stderr.txt") || {
+  JIRA_STDERR=$(cat /tmp/fullsend-pre-jira-stderr.txt 2>/dev/null || echo "")
+  if echo "${JIRA_STDERR}" | grep -qi "401\|unauthorized"; then
+    echo "ERROR: Jira authentication failed — check JIRA_EMAIL and JIRA_API_TOKEN"
+  elif echo "${JIRA_STDERR}" | grep -qi "403\|forbidden"; then
+    echo "ERROR: Jira permission denied — check that the API token has access to ${JIRA_ISSUE_ID}"
+  elif echo "${JIRA_STDERR}" | grep -qi "404\|not found"; then
+    echo "ERROR: Jira issue ${JIRA_ISSUE_ID} not found"
+  else
+    echo "ERROR: Failed to fetch Jira issue ${JIRA_ISSUE_ID}"
+    echo "${JIRA_STDERR}"
+  fi
+  rm -f /tmp/fullsend-pre-jira-stderr.txt
+  exit 1
+}
+rm -f /tmp/fullsend-pre-jira-stderr.txt
+
+echo "Jira issue verified: ${JIRA_ISSUE_ID}"
+
+# 4. Extract PR URL from custom field (best-effort)
+PR_URL=$(printf '%s\n' "${ISSUE_JSON}" | python3 "${SCRIPT_DIR}/pre_verify_pr.py" extract-pr-url 2>/dev/null || echo "")
+
+# 5. No PR linked — nothing to verify. Signal a skip (ADR-0072) and stop before
+#    the sandbox is created.
+if [[ -z "${PR_URL}" ]]; then
+  request_skip "no PR URL on the Jira issue"
+fi
+
+echo "PR linked: ${PR_URL}"
+
+# 6. Parse owner/repo/number from the PR URL.
+if [[ ! "${PR_URL}" =~ ^https://github\.com/([^/]+/[^/]+)/pull/([0-9]+) ]]; then
+  echo "ERROR: PR URL '${PR_URL}' is not a github.com pull request URL"
+  exit 1
+fi
+PR_REPO="${BASH_REMATCH[1]}"
+PR_NUM="${BASH_REMATCH[2]}"
+echo "PR: ${PR_REPO}#${PR_NUM}"
+
+# 7. GitHub tier-1 prefetch — runs on the trusted runner where GH_TOKEN lives.
+#    Every read the verify-pr skill performs against the PR is captured here so
+#    the sandbox needs no api.github.com egress.
+: "${GH_TOKEN:?GH_TOKEN is required to prefetch PR ${PR_REPO}#${PR_NUM}}"
+
+HEAD_REF=$(gh pr view "${PR_NUM}" -R "${PR_REPO}" --json headRefName --jq .headRefName)
+COMMIT_SHA=$(gh pr view "${PR_NUM}" -R "${PR_REPO}" --json commits --jq '.commits[-1].oid')
+
+gh pr diff "${PR_NUM}" -R "${PR_REPO}"                  > "${PRE_OUTPUT_DIR}/pr.diff"
+gh pr diff "${PR_NUM}" -R "${PR_REPO}" --stat           > "${PRE_OUTPUT_DIR}/pr.stat"
+gh api "repos/${PR_REPO}/pulls/${PR_NUM}/reviews"       > "${PRE_OUTPUT_DIR}/reviews.json"
+gh api "repos/${PR_REPO}/pulls/${PR_NUM}/comments"      > "${PRE_OUTPUT_DIR}/review-comments.json"
+gh api "repos/${PR_REPO}/issues/${PR_NUM}/comments"     > "${PRE_OUTPUT_DIR}/issue-comments.json"
+gh pr view "${PR_NUM}" -R "${PR_REPO}" --json commits --jq .commits > "${PRE_OUTPUT_DIR}/commits.json"
+
+echo "GitHub read bundle prefetched to ${PRE_OUTPUT_DIR}"
+
+# 8. Write pre-fetched data for sandbox consumption (tracker-agnostic format,
+#    with the GitHub bundle embedded under `github`).
+printf '%s\n' "${ISSUE_JSON}" | python3 "${SCRIPT_DIR}/pre_verify_pr.py" transform \
+  "${JIRA_ISSUE_ID}" "${PR_URL}" \
+  --github-dir "${PRE_OUTPUT_DIR}" \
+  --pr-repo "${PR_REPO}" \
+  --pr-number "${PR_NUM}" \
+  --head-ref "${HEAD_REF}" \
+  --commit-sha "${COMMIT_SHA}" > "${PRE_OUTPUT_DIR}/verify-pr-input.json"
+
+echo "Pre-fetched data written to ${PRE_OUTPUT_DIR}/verify-pr-input.json"
+echo "Input validation passed"

--- a/plugins/sdlc-workflow/scripts/pre_verify_pr.py
+++ b/plugins/sdlc-workflow/scripts/pre_verify_pr.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Pre-verify-pr data extraction functions.
+
+Extracts PR URL from Jira custom fields, assembles the GitHub tier-1 read
+bundle prefetched on the runner, and transforms Jira issue JSON into the
+tracker-agnostic input schema used by the sandbox.
+
+CLI usage (called by pre-verify-pr.sh):
+    echo "$ISSUE_JSON" | python3 pre_verify_pr.py extract-pr-url
+    echo "$ISSUE_JSON" | python3 pre_verify_pr.py transform TASK_ID PR_URL \\
+        [--github-dir DIR --pr-repo REPO --pr-number N \\
+         --head-ref REF --commit-sha SHA]
+
+When the --github-* options are supplied, `transform` reads the raw GitHub
+reads from DIR (pr.diff, pr.stat, reviews.json, review-comments.json,
+issue-comments.json, commits.json) and embeds them under a `github` key.
+"""
+
+import argparse
+import json
+import sys
+
+
+def extract_pr_url(issue):
+    """Extract PR URL from Jira custom field (ADF or string).
+
+    Returns empty string if the field is missing or has no URL.
+    """
+    field = issue.get("fields", {}).get("customfield_10875")
+    if not field:
+        return ""
+    if isinstance(field, str):
+        return field
+    if isinstance(field, dict):
+        for block in field.get("content", []):
+            for inline in block.get("content", []):
+                if inline.get("type") == "inlineCard":
+                    return inline.get("attrs", {}).get("url", "")
+    return ""
+
+
+def build_github_bundle(pr_repo, pr_number, head_ref, commit_sha,
+                        diff, stat, reviews, review_comments,
+                        issue_comments, commits):
+    """Assemble the GitHub tier-1 read bundle embedded in the input.
+
+    diff/stat are raw text; the four *_comments/reviews/commits arguments
+    are already-parsed JSON (lists). Keys mirror the reads the verify-pr
+    skill performs so the sandbox needs no api.github.com egress.
+    """
+    return {
+        "pr_repo": pr_repo,
+        "pr_number": int(pr_number),
+        "headRefName": head_ref,
+        "commit_sha": commit_sha,
+        "diff": diff,
+        "stat": stat,
+        "reviews": reviews,
+        "review_comments": review_comments,
+        "issue_comments": issue_comments,
+        "commits": commits,
+    }
+
+
+def transform_to_input(issue, task_id, pr_url, github=None):
+    """Transform Jira issue JSON to tracker-agnostic input schema."""
+    fields = issue.get("fields", {})
+    result = {
+        "task_id": task_id,
+        "task": {
+            "summary": fields.get("summary", ""),
+            "description": fields.get("description", {}),
+            "status": (fields.get("status") or {}).get("name", ""),
+            "labels": fields.get("labels", []),
+            "issue_links": [
+                {
+                    "type": (link.get("type") or {}).get("name", ""),
+                    "direction": "inward" if "inwardIssue" in link else "outward",
+                    "key": (
+                        link.get("inwardIssue") or link.get("outwardIssue") or {}
+                    ).get("key", ""),
+                }
+                for link in fields.get("issuelinks", [])
+            ],
+            "custom_fields": {
+                k: v
+                for k, v in fields.items()
+                if k.startswith("customfield_")
+            },
+        },
+        "pr_url": pr_url,
+        "source": {
+            "tracker": "jira",
+            "raw": issue,
+        },
+    }
+    if github is not None:
+        result["github"] = github
+    return result
+
+
+def _read_text(path):
+    with open(path) as f:
+        return f.read()
+
+
+def _read_json(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def _github_from_dir(args):
+    """Assemble the github bundle from raw read files written by the shell."""
+    d = args.github_dir.rstrip("/")
+    return build_github_bundle(
+        pr_repo=args.pr_repo,
+        pr_number=args.pr_number,
+        head_ref=args.head_ref,
+        commit_sha=args.commit_sha,
+        diff=_read_text(f"{d}/pr.diff"),
+        stat=_read_text(f"{d}/pr.stat"),
+        reviews=_read_json(f"{d}/reviews.json"),
+        review_comments=_read_json(f"{d}/review-comments.json"),
+        issue_comments=_read_json(f"{d}/issue-comments.json"),
+        commits=_read_json(f"{d}/commits.json"),
+    )
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(prog="pre_verify_pr.py")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("extract-pr-url")
+
+    t = sub.add_parser("transform")
+    t.add_argument("task_id")
+    t.add_argument("pr_url")
+    t.add_argument("--github-dir")
+    t.add_argument("--pr-repo")
+    t.add_argument("--pr-number", type=int)
+    t.add_argument("--head-ref")
+    t.add_argument("--commit-sha")
+
+    args = parser.parse_args(argv)
+    issue = json.load(sys.stdin)
+
+    if args.command == "extract-pr-url":
+        print(extract_pr_url(issue))
+    elif args.command == "transform":
+        github = _github_from_dir(args) if args.github_dir else None
+        result = transform_to_input(issue, args.task_id, args.pr_url, github)
+        json.dump(result, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/plugins/sdlc-workflow/scripts/pre_verify_pr.py
+++ b/plugins/sdlc-workflow/scripts/pre_verify_pr.py
@@ -69,7 +69,10 @@ def transform_to_input(issue, task_id, pr_url, github=None):
         "task_id": task_id,
         "task": {
             "summary": fields.get("summary", ""),
-            "description": fields.get("description", {}),
+            # Jira may return an explicit null description; `.get(key, {})` only
+            # defaults on an ABSENT key, so `or {}` also coerces null → {} to
+            # keep task.description an object per verify-pr-input.schema.json.
+            "description": fields.get("description") or {},
             "status": (fields.get("status") or {}).get("name", ""),
             "labels": fields.get("labels", []),
             "issue_links": [

--- a/plugins/sdlc-workflow/scripts/strip_extra_properties.py
+++ b/plugins/sdlc-workflow/scripts/strip_extra_properties.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Strip additional properties from JSON based on a JSON Schema.
+
+Recursively walks the schema tree and removes properties not declared
+in `properties` or `allOf/if/then/properties` at every node where
+`additionalProperties: false`. Works with any schema structure
+including discriminated unions (allOf with if/then).
+
+CLI usage (called by validate-output-schema.sh):
+    python3 strip_extra_properties.py <json-file> <schema-file>
+
+Strips the JSON file in-place and exits 0. The caller validates after.
+"""
+
+import json
+import sys
+
+
+def _resolve_ref(ref, root):
+    node = root
+    for part in ref.lstrip("#/").split("/"):
+        node = node[part]
+    return node
+
+
+def _deref(schema, root):
+    if "$ref" in schema:
+        return _resolve_ref(schema["$ref"], root)
+    return schema
+
+
+def _matching_then(instance, branches):
+    """Find the allOf branch whose `if` matches the instance."""
+    for branch in branches:
+        if_clause = branch.get("if", {})
+        if_props = if_clause.get("properties", {})
+        match = all(
+            instance.get(k) == v.get("const")
+            for k, v in if_props.items()
+            if "const" in v
+        )
+        if match and "then" in branch:
+            return branch["then"]
+    return None
+
+
+def strip(instance, schema, root):
+    """Recursively strip properties not allowed by the schema."""
+    schema = _deref(schema, root)
+
+    if not isinstance(instance, dict) or schema.get("type") not in ("object", None):
+        return instance
+
+    then = _matching_then(instance, schema.get("allOf", []))
+    has_strict = schema.get("additionalProperties") is False
+    then_strict = then is not None and then.get("additionalProperties") is False
+
+    if has_strict or then_strict:
+        allowed = set(schema.get("properties", {}).keys())
+        if then:
+            allowed |= set(then.get("properties", {}).keys())
+        removed = [k for k in instance if k not in allowed]
+        if removed:
+            print(f"  stripped: {removed}")
+        instance = {k: v for k, v in instance.items() if k in allowed}
+
+    for key, prop_schema in schema.get("properties", {}).items():
+        if key not in instance:
+            continue
+        prop_schema = _deref(prop_schema, root)
+        if isinstance(instance[key], dict):
+            instance[key] = strip(instance[key], prop_schema, root)
+        elif isinstance(instance[key], list):
+            items_schema = prop_schema.get("items", {})
+            items_schema = _deref(items_schema, root)
+            instance[key] = [
+                strip(item, items_schema, root) if isinstance(item, dict) else item
+                for item in instance[key]
+            ]
+
+    return instance
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: strip_extra_properties.py <json-file> <schema-file>", file=sys.stderr)
+        sys.exit(1)
+
+    with open(sys.argv[1]) as f:
+        instance = json.load(f)
+    with open(sys.argv[2]) as f:
+        schema = json.load(f)
+
+    instance = strip(instance, schema, schema)
+
+    with open(sys.argv[1], "w") as f:
+        json.dump(instance, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/sdlc-workflow/scripts/test_pre_verify_pr.py
+++ b/plugins/sdlc-workflow/scripts/test_pre_verify_pr.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Tests for pre_verify_pr.py — PR URL extraction, GitHub bundle, transform."""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, script_dir)
+import pre_verify_pr
+
+
+# --- extract_pr_url ---
+
+def test_extract_pr_url_adf_inline_card():
+    issue = {"fields": {"customfield_10875": {
+        "type": "doc", "version": 1,
+        "content": [{"type": "paragraph", "content": [
+            {"type": "inlineCard", "attrs": {"url": "https://github.com/org/repo/pull/42"}}
+        ]}]
+    }}}
+    result = pre_verify_pr.extract_pr_url(issue)
+    assert result == "https://github.com/org/repo/pull/42", f"Got: {result}"
+
+
+def test_extract_pr_url_plain_string():
+    issue = {"fields": {"customfield_10875": "https://github.com/org/repo/pull/7"}}
+    result = pre_verify_pr.extract_pr_url(issue)
+    assert result == "https://github.com/org/repo/pull/7", f"Got: {result}"
+
+
+def test_extract_pr_url_missing_field():
+    issue = {"fields": {}}
+    result = pre_verify_pr.extract_pr_url(issue)
+    assert result == "", f"Expected empty string, got: {result}"
+
+
+def test_extract_pr_url_null_field():
+    issue = {"fields": {"customfield_10875": None}}
+    result = pre_verify_pr.extract_pr_url(issue)
+    assert result == "", f"Expected empty string, got: {result}"
+
+
+def test_extract_pr_url_adf_no_inline_card():
+    issue = {"fields": {"customfield_10875": {
+        "type": "doc", "version": 1,
+        "content": [{"type": "paragraph", "content": [
+            {"type": "text", "text": "no link here"}
+        ]}]
+    }}}
+    result = pre_verify_pr.extract_pr_url(issue)
+    assert result == "", f"Expected empty string, got: {result}"
+
+
+# --- build_github_bundle ---
+
+def test_build_github_bundle():
+    bundle = pre_verify_pr.build_github_bundle(
+        pr_repo="org/repo", pr_number="42", head_ref="feat/x",
+        commit_sha="abc1234", diff="diff --git a b", stat=" 1 file changed",
+        reviews=[{"id": 1}], review_comments=[{"id": 2}],
+        issue_comments=[{"id": 3}], commits=[{"oid": "abc1234"}],
+    )
+    assert bundle["pr_repo"] == "org/repo"
+    assert bundle["pr_number"] == 42  # coerced to int
+    assert bundle["headRefName"] == "feat/x"
+    assert bundle["commit_sha"] == "abc1234"
+    assert bundle["diff"] == "diff --git a b"
+    assert bundle["stat"] == " 1 file changed"
+    assert bundle["reviews"] == [{"id": 1}]
+    assert bundle["review_comments"] == [{"id": 2}]
+    assert bundle["issue_comments"] == [{"id": 3}]
+    assert bundle["commits"] == [{"oid": "abc1234"}]
+
+
+# --- transform_to_input ---
+
+def test_transform_basic():
+    issue = {"fields": {
+        "summary": "Add feature X",
+        "description": {"type": "doc", "content": []},
+        "status": {"name": "In Progress"},
+        "labels": ["backend", "api"],
+        "issuelinks": [],
+    }}
+    result = pre_verify_pr.transform_to_input(issue, "TC-100", "https://github.com/o/r/pull/1")
+    assert result["task_id"] == "TC-100"
+    assert result["task"]["summary"] == "Add feature X"
+    assert result["task"]["status"] == "In Progress"
+    assert result["task"]["labels"] == ["backend", "api"]
+    assert result["task"]["issue_links"] == []
+    assert result["pr_url"] == "https://github.com/o/r/pull/1"
+    assert result["source"]["tracker"] == "jira"
+    assert result["source"]["raw"] is issue
+
+
+def test_transform_without_github_omits_key():
+    issue = {"fields": {"summary": "S", "status": {"name": "Open"}, "labels": [], "issuelinks": []}}
+    result = pre_verify_pr.transform_to_input(issue, "TC-1", "")
+    assert "github" not in result
+
+
+def test_transform_with_github():
+    issue = {"fields": {"summary": "S", "status": {"name": "Open"}, "labels": [], "issuelinks": []}}
+    github = pre_verify_pr.build_github_bundle(
+        "o/r", 5, "b", "deadbee", "d", "s", [], [], [], [],
+    )
+    result = pre_verify_pr.transform_to_input(issue, "TC-1", "https://github.com/o/r/pull/5", github)
+    assert result["github"]["pr_repo"] == "o/r"
+    assert result["github"]["pr_number"] == 5
+    assert result["github"]["commit_sha"] == "deadbee"
+
+
+def test_transform_issue_links():
+    issue = {"fields": {
+        "summary": "S", "description": {}, "status": {"name": "Open"},
+        "labels": [], "issuelinks": [
+            {"type": {"name": "Blocks"}, "outwardIssue": {"key": "TC-200"}},
+            {"type": {"name": "Related"}, "inwardIssue": {"key": "TC-300"}},
+        ],
+    }}
+    links = pre_verify_pr.transform_to_input(issue, "TC-100", "")["task"]["issue_links"]
+    assert len(links) == 2
+    assert links[0] == {"type": "Blocks", "direction": "outward", "key": "TC-200"}
+    assert links[1] == {"type": "Related", "direction": "inward", "key": "TC-300"}
+
+
+def test_transform_custom_fields():
+    issue = {"fields": {
+        "summary": "S", "description": {}, "status": None, "labels": [],
+        "issuelinks": [],
+        "customfield_10875": "https://github.com/o/r/pull/5",
+        "customfield_99999": {"value": "something"},
+        "priority": {"name": "High"},
+    }}
+    cf = pre_verify_pr.transform_to_input(issue, "TC-1", "")["task"]["custom_fields"]
+    assert "customfield_10875" in cf
+    assert "customfield_99999" in cf
+    assert "priority" not in cf
+
+
+def test_transform_empty_fields():
+    issue = {"fields": {}}
+    result = pre_verify_pr.transform_to_input(issue, "TC-1", "")
+    assert result["task"]["summary"] == ""
+    assert result["task"]["status"] == ""
+    assert result["task"]["labels"] == []
+    assert result["task"]["issue_links"] == []
+
+
+def test_transform_null_status():
+    issue = {"fields": {"summary": "S", "status": None, "labels": [], "issuelinks": []}}
+    result = pre_verify_pr.transform_to_input(issue, "TC-1", "")
+    assert result["task"]["status"] == ""
+
+
+def test_transform_large_payload():
+    """Regression test: large payloads must work via stdin, not argv."""
+    issue = {"fields": {
+        "summary": "Large issue",
+        "description": "x" * 500_000,
+        "status": {"name": "Open"},
+        "labels": [],
+        "issuelinks": [],
+    }}
+    payload = json.dumps(issue)
+    assert len(payload) > 500_000
+
+    result = subprocess.run(
+        [sys.executable, os.path.join(script_dir, "pre_verify_pr.py"),
+         "transform", "TC-BIG", "https://example.com/pr/1"],
+        input=payload, capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"Exit {result.returncode}: {result.stderr}"
+    output = json.loads(result.stdout)
+    assert output["task_id"] == "TC-BIG"
+    assert output["task"]["summary"] == "Large issue"
+    assert "github" not in output
+
+
+def test_cli_transform_github_dir():
+    """CLI transform reads the raw GitHub files and embeds the bundle."""
+    issue = {"fields": {"summary": "S", "status": {"name": "Open"}, "labels": [], "issuelinks": []}}
+    with tempfile.TemporaryDirectory() as d:
+        with open(os.path.join(d, "pr.diff"), "w") as f:
+            f.write("diff --git a b\n")
+        with open(os.path.join(d, "pr.stat"), "w") as f:
+            f.write(" 1 file changed\n")
+        for name, payload in [
+            ("reviews.json", [{"id": 1, "state": "APPROVED"}]),
+            ("review-comments.json", [{"id": 2}]),
+            ("issue-comments.json", [{"id": 3}]),
+            ("commits.json", [{"oid": "abc1234def"}]),
+        ]:
+            with open(os.path.join(d, name), "w") as f:
+                json.dump(payload, f)
+
+        result = subprocess.run(
+            [sys.executable, os.path.join(script_dir, "pre_verify_pr.py"),
+             "transform", "TC-9", "https://github.com/o/r/pull/9",
+             "--github-dir", d, "--pr-repo", "o/r", "--pr-number", "9",
+             "--head-ref", "feat/x", "--commit-sha", "abc1234def"],
+            input=json.dumps(issue), capture_output=True, text=True,
+        )
+    assert result.returncode == 0, f"Exit {result.returncode}: {result.stderr}"
+    output = json.loads(result.stdout)
+    gh = output["github"]
+    assert gh["pr_repo"] == "o/r"
+    assert gh["pr_number"] == 9
+    assert gh["headRefName"] == "feat/x"
+    assert gh["commit_sha"] == "abc1234def"
+    assert gh["diff"] == "diff --git a b\n"
+    assert gh["stat"] == " 1 file changed\n"
+    assert gh["reviews"] == [{"id": 1, "state": "APPROVED"}]
+    assert gh["review_comments"] == [{"id": 2}]
+    assert gh["issue_comments"] == [{"id": 3}]
+    assert gh["commits"] == [{"oid": "abc1234def"}]
+
+
+# --- runner ---
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = []
+    for t in tests:
+        try:
+            t()
+            print(f"  ✓ {t.__name__}")
+        except AssertionError as e:
+            print(f"  ✗ {t.__name__}: {e}")
+            failed.append(t.__name__)
+    print(f"{'=' * 60}")
+    if failed:
+        print(f"FAILED: {len(failed)}/{len(tests)} test(s) failed")
+        sys.exit(1)
+    else:
+        print(f"SUCCESS: All {len(tests)} tests passed")
+        sys.exit(0)

--- a/plugins/sdlc-workflow/scripts/test_pre_verify_pr.py
+++ b/plugins/sdlc-workflow/scripts/test_pre_verify_pr.py
@@ -492,6 +492,85 @@ def test_pr_url_extra_path_segment_rejected():
     assert not matched, f"expected rejection, but matched with number={number!r}"
 
 
+# --- COMMIT_SHA derivation (pre-verify-pr.sh) ---
+
+def _commit_sha_command():
+    """Extract the COMMIT_SHA assignment command from pre-verify-pr.sh.
+
+    The behavioral test below runs the *actual* command the script ships (not a
+    re-typed copy), so a regression back to the bounded commits connection is
+    caught by execution, not just by source inspection.
+    """
+    with open(pre_verify_sh) as f:
+        for line in f:
+            if line.lstrip().startswith("COMMIT_SHA="):
+                return line.strip()
+    raise AssertionError("COMMIT_SHA assignment not found in pre-verify-pr.sh")
+
+
+def test_commit_sha_derived_from_head_ref_oid():
+    """The prefetched COMMIT_SHA is the PR head ref tip OID, not the last commit
+    of gh's bounded commits connection.
+
+    Runs the exact COMMIT_SHA command pre-verify-pr.sh ships against a gh stub
+    whose headRefOid and commits[-1].oid disagree (simulating a large PR whose
+    commits connection is truncated below the head). Regression for Sourcery id
+    3902563589: the old `.commits[-1].oid` read returns the truncated oid.
+    """
+    # Given a gh stub where the head ref OID and the (truncated) commits
+    # connection's last oid disagree
+    head_oid = "a" * 40
+    truncated_oid = "b" * 40
+    with tempfile.TemporaryDirectory() as d:
+        gh_stub = os.path.join(d, "gh")
+        with open(gh_stub, "w") as f:
+            f.write(
+                "#!/usr/bin/env bash\n"
+                "for arg in \"$@\"; do\n"
+                f'  if [[ "$arg" == headRefOid ]]; then echo {head_oid}; exit 0; fi\n'
+                f'  if [[ "$arg" == commits ]]; then echo {truncated_oid}; exit 0; fi\n'
+                "done\n"
+                "echo UNEXPECTED >&2; exit 1\n"
+            )
+        os.chmod(gh_stub, 0o755)
+
+        # When running the exact COMMIT_SHA assignment the script ships, with the
+        # stub gh ahead on PATH and PR_NUM/PR_REPO supplied
+        command = _commit_sha_command()
+        env = {**os.environ, "PATH": d + os.pathsep + os.environ["PATH"],
+               "PR_NUM": "275", "PR_REPO": "o/r"}
+        result = subprocess.run(
+            ["bash", "-c", command + "\nprintf '%s' \"$COMMIT_SHA\""],
+            capture_output=True, text=True, env=env,
+        )
+
+    # Then the emitted commit SHA is the head ref OID, not the truncated last commit
+    assert result.returncode == 0, f"Exit {result.returncode}: {result.stderr}"
+    assert result.stdout == head_oid, f"Got: {result.stdout!r} (stderr: {result.stderr!r})"
+    assert result.stdout != truncated_oid
+
+
+def test_pre_verify_sh_derives_commit_sha_from_head_ref_oid():
+    """Regression guard: COMMIT_SHA reads headRefOid and never the truncatable
+    commits connection (.commits[-1].oid) (Sourcery id 3902563589).
+    """
+    # Given the current pre-verify-pr.sh source
+    with open(pre_verify_sh) as f:
+        script = f.read()
+
+    # Then every COMMIT_SHA assignment reads headRefOid and none falls back to
+    # gh's bounded commits connection
+    commit_sha_lines = [
+        line for line in script.splitlines()
+        if line.lstrip().startswith("COMMIT_SHA=")
+    ]
+    assert commit_sha_lines, "no COMMIT_SHA assignment found in pre-verify-pr.sh"
+    for line in commit_sha_lines:
+        assert "headRefOid" in line, f"COMMIT_SHA not derived from headRefOid: {line!r}"
+        assert ".commits[-1]" not in line, \
+            f"COMMIT_SHA reintroduced the bounded commits read: {line!r}"
+
+
 # --- runner ---
 
 if __name__ == "__main__":

--- a/plugins/sdlc-workflow/scripts/test_pre_verify_pr.py
+++ b/plugins/sdlc-workflow/scripts/test_pre_verify_pr.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -391,6 +392,104 @@ def test_pre_verify_sh_paginates_review_comment_fetches():
             assert "--paginate" in line, f"missing --paginate: {line!r}"
             assert "--slurp" in line, f"missing --slurp: {line!r}"
             assert "jq 'add'" in line, f"missing jq 'add' merge: {line!r}"
+
+
+# --- PR-URL parsing regex (pre-verify-pr.sh) ---
+
+def _github_pr_url_regex():
+    """Extract the github.com PR-URL match regex from pre-verify-pr.sh.
+
+    The tests below run the *actual* regex the script ships (not a re-typed
+    copy), so an accidental loss of the end anchor is caught behaviorally.
+    """
+    with open(pre_verify_sh) as f:
+        for line in f:
+            if "=~" in line and "github" in line and "/pull/" in line:
+                m = re.search(r"=~\s+(\S.*?)\s+\]\]", line)
+                if m:
+                    return m.group(1)
+    raise AssertionError("github.com PR-URL regex not found in pre-verify-pr.sh")
+
+
+def _match_pr_url(url):
+    """Run pre-verify-pr.sh's exact `[[ =~ ]]` test against url.
+
+    Returns (matched, repo, number) using the same BASH_REMATCH groups the
+    script consumes downstream, so a truncating match surfaces as a wrong
+    `number` rather than a silent pass.
+    """
+    regex = _github_pr_url_regex()
+    snippet = (
+        'r="$1"; u="$2"\n'
+        'if [[ "$u" =~ $r ]]; then\n'
+        '  printf "MATCH\\t%s\\t%s" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"\n'
+        'else\n'
+        '  printf "NOMATCH"\n'
+        'fi\n'
+    )
+    result = subprocess.run(
+        ["bash", "-c", snippet, "bash", regex, url],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"bash error: {result.stderr}"
+    parts = result.stdout.split("\t")
+    if parts[0] == "MATCH":
+        return True, parts[1], parts[2]
+    return False, None, None
+
+
+def test_pr_url_wellformed_accepted():
+    """A canonical github.com PR URL parses to its owner/repo and PR number."""
+    # Given a well-formed PR URL like a Jira inlineCard stores
+    # When matched by the script's regex
+    matched, repo, number = _match_pr_url("https://github.com/org/repo/pull/42")
+
+    # Then it matches and captures the exact repo and number
+    assert matched, "well-formed URL should match"
+    assert repo == "org/repo", f"Got repo: {repo!r}"
+    assert number == "42", f"Got number: {number!r}"
+
+
+def test_pr_url_trailing_slash_accepted():
+    """A well-formed PR URL with a trailing slash still parses correctly."""
+    # Given a PR URL with a trailing slash
+    # When matched by the script's regex
+    matched, repo, number = _match_pr_url("https://github.com/org/repo/pull/42/")
+
+    # Then it matches with the same repo and number (the slash is tolerated)
+    assert matched, "trailing-slash URL should match"
+    assert repo == "org/repo", f"Got repo: {repo!r}"
+    assert number == "42", f"Got number: {number!r}"
+
+
+def test_pr_url_nonnumeric_suffix_rejected():
+    """A pull number with a trailing non-numeric suffix is rejected, not truncated.
+
+    Regression for Sourcery id 3902059934: the un-anchored regex accepted
+    `.../pull/42abc` and truncated the number to 42, so the pre-script fetched
+    the wrong PR. The end-anchored regex must reject it outright.
+    """
+    # Given a malformed URL with a non-numeric suffix on the pull number
+    # When matched by the script's regex
+    matched, _repo, number = _match_pr_url("https://github.com/org/repo/pull/42abc")
+
+    # Then it does not match (rather than truncating to 42)
+    assert not matched, f"expected rejection, but matched with number={number!r}"
+
+
+def test_pr_url_extra_path_segment_rejected():
+    """An extra path segment after the pull number is rejected, not truncated.
+
+    Regression for Sourcery id 3902059934: `.../pull/42/invalid` previously
+    matched and truncated to PR 42. The end anchor must reject it.
+    """
+    # Given a malformed URL with an extra path segment after the number
+    # When matched by the script's regex
+    matched, _repo, number = _match_pr_url(
+        "https://github.com/org/repo/pull/42/invalid")
+
+    # Then it does not match (rather than truncating to 42)
+    assert not matched, f"expected rejection, but matched with number={number!r}"
 
 
 # --- runner ---

--- a/plugins/sdlc-workflow/scripts/test_pre_verify_pr.py
+++ b/plugins/sdlc-workflow/scripts/test_pre_verify_pr.py
@@ -219,6 +219,64 @@ def test_cli_transform_github_dir():
     assert gh["commits"] == [{"oid": "abc1234def"}]
 
 
+# --- stat production (pre-verify-pr.sh) ---
+
+pre_verify_sh = os.path.join(script_dir, "pre-verify-pr.sh")
+
+
+def test_stat_produced_by_git_apply_stat():
+    """The stat mechanism (git apply --stat) yields a diffstat matching the
+    downstream github.stat contract: a per-file line plus a summary line.
+
+    Exercises the real command pre-verify-pr.sh runs, not a gh stub that
+    silently accepts the unsupported --stat flag.
+    """
+    # Given a unified diff like the one gh pr diff writes to pr.diff
+    patch = (
+        "diff --git a/foo.txt b/foo.txt\n"
+        "index 1111111..2222222 100644\n"
+        "--- a/foo.txt\n"
+        "+++ b/foo.txt\n"
+        "@@ -1,3 +1,3 @@\n"
+        " line1\n"
+        "-line2\n"
+        "+CHANGED\n"
+        " line3\n"
+    )
+    with tempfile.TemporaryDirectory() as d:
+        diff_path = os.path.join(d, "pr.diff")
+        with open(diff_path, "w") as f:
+            f.write(patch)
+
+        # When producing the stat with the exact command pre-verify-pr.sh uses
+        result = subprocess.run(
+            ["git", "apply", "--stat", diff_path],
+            capture_output=True, text=True,
+        )
+
+    # Then it succeeds and emits a git diffstat downstream can consume
+    assert result.returncode == 0, f"Exit {result.returncode}: {result.stderr}"
+    assert "foo.txt" in result.stdout, f"Got: {result.stdout!r}"
+    assert "1 file changed" in result.stdout, f"Got: {result.stdout!r}"
+
+
+def test_pre_verify_sh_uses_supported_stat_command():
+    """Regression guard: the prefetch derives the stat with git apply --stat and
+    never passes the unsupported --stat flag to gh pr diff (Sourcery id 3896899424).
+    """
+    # Given the current pre-verify-pr.sh source
+    with open(pre_verify_sh) as f:
+        script = f.read()
+
+    # Then no gh pr diff invocation uses --stat, and git apply --stat is present
+    for line in script.splitlines():
+        if line.lstrip().startswith("#"):
+            continue  # skip comments (which may mention the removed flag)
+        if "gh pr diff" in line:
+            assert "--stat" not in line, f"unsupported gh flag reintroduced: {line!r}"
+    assert "git apply --stat" in script, "expected git apply --stat stat mechanism"
+
+
 # --- runner ---
 
 if __name__ == "__main__":

--- a/plugins/sdlc-workflow/scripts/test_pre_verify_pr.py
+++ b/plugins/sdlc-workflow/scripts/test_pre_verify_pr.py
@@ -244,14 +244,17 @@ def test_stat_produced_by_git_apply_stat():
         " line3\n"
     )
     with tempfile.TemporaryDirectory() as d:
-        diff_path = os.path.join(d, "pr.diff")
-        with open(diff_path, "w") as f:
+        with open(os.path.join(d, "pr.diff"), "w") as f:
             f.write(patch)
 
-        # When producing the stat with the exact command pre-verify-pr.sh uses
+        # When producing the stat with the exact command pre-verify-pr.sh uses.
+        # Run it from the (non-repo) temp dir: `git apply --stat` is CWD-sensitive
+        # — inside a repo subdirectory it scopes the patch to that subtree and
+        # reports "0 files changed", so cwd=d keeps this a pure textual diffstat
+        # independent of where the test runner is launched.
         result = subprocess.run(
-            ["git", "apply", "--stat", diff_path],
-            capture_output=True, text=True,
+            ["git", "apply", "--stat", "pr.diff"],
+            cwd=d, capture_output=True, text=True,
         )
 
     # Then it succeeds and emits a git diffstat downstream can consume
@@ -275,6 +278,68 @@ def test_pre_verify_sh_uses_supported_stat_command():
         if "gh pr diff" in line:
             assert "--stat" not in line, f"unsupported gh flag reintroduced: {line!r}"
     assert "git apply --stat" in script, "expected git apply --stat stat mechanism"
+
+
+# --- paginated fetch aggregation (pre-verify-pr.sh) ---
+
+def test_paginated_pages_aggregate_into_flat_array():
+    """Multi-page fetches merge into one complete array, not truncated at page 1.
+
+    Exercises the exact merge pre-verify-pr.sh runs on the `gh api --paginate
+    --slurp` output — a per-page array-of-arrays piped through `jq 'add'` — and
+    asserts every page's items survive in order with their object shape intact.
+    """
+    # Given the array-of-pages that `gh api --paginate --slurp` emits: three
+    # pages, so page-2 and page-3 items only appear if pagination is honored.
+    slurped_pages = [
+        [{"id": 1}, {"id": 2}],
+        [{"id": 3}, {"id": 4}],
+        [{"id": 5}],
+    ]
+
+    # When merged with the same standalone `jq 'add'` the script pipes through
+    result = subprocess.run(
+        ["jq", "add"],
+        input=json.dumps(slurped_pages), capture_output=True, text=True,
+    )
+
+    # Then the pages flatten into one array carrying items beyond the first page
+    assert result.returncode == 0, f"Exit {result.returncode}: {result.stderr}"
+    merged = json.loads(result.stdout)
+    assert merged == [{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}, {"id": 5}], \
+        f"expected flat concatenation, got: {merged!r}"
+    assert [o["id"] for o in merged] == [1, 2, 3, 4, 5]  # order preserved
+    assert {"id": 5} in merged  # last page (beyond first) not truncated
+
+
+def test_pre_verify_sh_paginates_review_comment_fetches():
+    """Regression guard: all three gh api review/comment fetches request every
+    page and merge with `jq 'add'` (Sourcery id 3896899429), keeping the stored
+    value a flat array for pre_verify_pr.py.
+    """
+    # Given the current pre-verify-pr.sh source
+    with open(pre_verify_sh) as f:
+        script = f.read()
+
+    # Then each of the three paginated endpoints is fetched with --paginate
+    # --slurp and merged via jq add on a non-comment line.
+    endpoints = [
+        "/pulls/${PR_NUM}/reviews",
+        "/pulls/${PR_NUM}/comments",
+        "/issues/${PR_NUM}/comments",
+    ]
+    for endpoint in endpoints:
+        matches = [
+            line for line in script.splitlines()
+            if endpoint in line and not line.lstrip().startswith("#")
+        ]
+        assert matches, f"no fetch line found for {endpoint}"
+        for line in matches:
+            if "gh api" not in line:
+                continue
+            assert "--paginate" in line, f"missing --paginate: {line!r}"
+            assert "--slurp" in line, f"missing --slurp: {line!r}"
+            assert "jq 'add'" in line, f"missing jq 'add' merge: {line!r}"
 
 
 # --- runner ---

--- a/plugins/sdlc-workflow/scripts/test_pre_verify_pr.py
+++ b/plugins/sdlc-workflow/scripts/test_pre_verify_pr.py
@@ -156,6 +156,57 @@ def test_transform_null_status():
     assert result["task"]["status"] == ""
 
 
+def test_transform_null_description_coerced_to_object():
+    """An explicit null description becomes {} so task.description stays an object.
+
+    Regression for Sourcery id 3896899434: `fields.get("description", {})` only
+    defaults on an absent key, so an explicit JSON null (an issue with no
+    description) yielded task.description = null, violating the input schema.
+    """
+    # Given a Jira issue whose description field is an explicit null
+    issue = {"fields": {"summary": "S", "description": None, "status": {"name": "Open"},
+                        "labels": [], "issuelinks": []}}
+
+    # When transforming it to the tracker-agnostic input
+    result = pre_verify_pr.transform_to_input(issue, "TC-1", "")
+
+    # Then the null is coerced to an empty object, not left as null
+    assert result["task"]["description"] == {}, \
+        f"expected {{}}, got: {result['task']['description']!r}"
+    assert isinstance(result["task"]["description"], dict)
+
+
+def test_null_description_input_validates_against_schema():
+    """A produced input with a null-source description validates against the schema.
+
+    Drives the full transform (task + github bundle) for an issue with a null
+    description and asserts the result satisfies verify-pr-input.schema.json —
+    the acceptance criterion for TC-5886. Without the null coercion the instance
+    would carry task.description = null and fail (description must be an object).
+    """
+    from jsonschema import validate
+
+    # Given an issue with a null description and the prefetched github bundle a
+    # real run embeds (the schema requires `github`, so a bare task won't do)
+    issue = {"fields": {"summary": "S", "description": None, "status": {"name": "Open"},
+                        "labels": [], "issuelinks": []}}
+    github = pre_verify_pr.build_github_bundle(
+        "o/r", 5, "feat/x", "deadbee", "diff", "stat", [], [], [], [],
+    )
+
+    # When producing the input and loading the input schema
+    result = pre_verify_pr.transform_to_input(
+        issue, "TC-1", "https://github.com/o/r/pull/5", github)
+    schema_path = os.path.join(
+        script_dir, "..", "schemas", "verify-pr-input.schema.json")
+    with open(schema_path) as f:
+        schema = json.load(f)
+
+    # Then it validates cleanly (validate raises ValidationError on failure)
+    assert result["task"]["description"] == {}
+    validate(instance=result, schema=schema)
+
+
 def test_transform_large_payload():
     """Regression test: large payloads must work via stdin, not argv."""
     issue = {"fields": {

--- a/plugins/sdlc-workflow/scripts/validate-output-schema.sh
+++ b/plugins/sdlc-workflow/scripts/validate-output-schema.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# validate-output-schema.sh — Validate agent output against a JSON Schema.
+#
+# Generic script used by the harness validation_loop (ADR 0022).
+# Works for any agent — the schema path is configured in the harness.
+#
+# Required env vars:
+#   FULLSEND_OUTPUT_SCHEMA — path to the JSON Schema file
+#
+# Optional env vars:
+#   FULLSEND_OUTPUT_FILE  — filename to validate (default: agent-result.json)
+#
+# The script looks for the output file in the iteration output directory.
+# The working directory is the iteration dir (set by run.go).
+
+set -euo pipefail
+
+: "${FULLSEND_OUTPUT_SCHEMA:?FULLSEND_OUTPUT_SCHEMA must be set}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Find the output JSON file in this iteration's output directory.
+OUTPUT_DIR="output"
+if [[ ! -d "${OUTPUT_DIR}" ]]; then
+  echo "FAIL: output directory not found"
+  exit 1
+fi
+
+_output_file="${FULLSEND_OUTPUT_FILE:-agent-result.json}"
+_output_file="$(basename "${_output_file}")"
+RESULT_FILE="${OUTPUT_DIR}/${_output_file}"
+if [[ ! -f "${RESULT_FILE}" ]]; then
+  # Agents sometimes write "result.json" instead of "agent-result.json".
+  # Accept the common variant rather than burning a full retry iteration.
+  _fallback="${OUTPUT_DIR}/result.json"
+  if [[ "${_output_file}" == "agent-result.json" && -f "${_fallback}" ]]; then
+    echo "WARN: expected ${RESULT_FILE} but found ${_fallback} — using fallback"
+    RESULT_FILE="${_fallback}"
+  else
+    echo "FAIL: ${RESULT_FILE} not found"
+    exit 1
+  fi
+fi
+echo "Validating: ${RESULT_FILE} against ${FULLSEND_OUTPUT_SCHEMA}"
+
+# Validate JSON is parseable.
+if ! python3 -m json.tool "${RESULT_FILE}" > /dev/null 2>&1; then
+  echo "FAIL: ${RESULT_FILE} is not valid JSON"
+  exit 1
+fi
+
+# Validate against schema using Python's jsonschema.
+# jsonschema is required — fail hard if not installed.
+if ! python3 -c "import jsonschema" 2>/dev/null; then
+  echo "FAIL: python3 jsonschema package is not installed (required by ADR 0022)"
+  exit 1
+fi
+
+# Strip extra properties before validation. The schema stays strict
+# (additionalProperties: false) to document the contract, but the
+# stripping makes it forgiving for benign metadata the agent adds.
+python3 "${SCRIPT_DIR}/strip_extra_properties.py" "${RESULT_FILE}" "${FULLSEND_OUTPUT_SCHEMA}"
+
+if ! python3 -c "
+import json, sys
+from jsonschema import validate, ValidationError
+
+with open(sys.argv[1]) as f:
+    instance = json.load(f)
+with open(sys.argv[2]) as f:
+    schema = json.load(f)
+try:
+    validate(instance=instance, schema=schema)
+    print('PASS: output validated against schema')
+except ValidationError as e:
+    print(f'FAIL: schema validation error: {e.message}')
+    if e.path:
+        print(f'  at: {\".\".join(str(p) for p in e.path)}')
+    if 'properties' in e.schema:
+        allowed = ', '.join(sorted(e.schema['properties'].keys()))
+        print(f'  allowed properties: {allowed}')
+    sys.exit(1)
+" "${RESULT_FILE}" "${FULLSEND_OUTPUT_SCHEMA}"; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds the split-trust I/O contract for the `verify-pr` fullsend harness. The
`pre_script` prefetches everything on the trusted runner (where the Jira and
GitHub tokens live); the sandbox reads only JSON and needs no `api.github.com`
or `atlassian` egress.

- `schemas/verify-pr-input.schema.json` — tracker-agnostic pre-script input,
  extended with a `github` **tier-1 read bundle** (diff, stat, reviews,
  review_comments, issue_comments, commits, headRefName, commit_sha).
- `schemas/verify-pr-result.schema.json` — agent result contract (ported).
- `scripts/pre-verify-pr.sh` — validates env, fetches the Jira issue, resolves
  the linked PR from `customfield_10875`, prefetches every GitHub read the skill
  performs, and writes `verify-pr-input.json` for `host_files` to mount.
- `scripts/pre_verify_pr.py` — PR-URL extraction + input transform, extended
  with `build_github_bundle` and a `--github-dir` transform mode.
- `scripts/{validate-output-schema.sh,strip_extra_properties.py}` — kept per the
  Step 5 native-validator decision; wired via `validation_loop.script`.
- `scripts/test_pre_verify_pr.py` — unit tests incl. the github bundle.
- `harness/verify-pr.yaml` — set `validation_loop.script`.
- **Review fix (TC-5884):** replace the unsupported `gh pr diff --stat` with
  `git apply --stat` on the already-fetched patch, so the prefetch no longer
  aborts under `set -euo pipefail` before writing `verify-pr-input.json`; the
  empty-diff case is guarded and regression tests exercise the real stat command.
- **Review fix (TC-5885):** paginate the `gh api` reviews / review-comments /
  issue-comments fetches (`--paginate --slurp` merged with `jq 'add'`), so the
  tier-1 bundle is no longer silently truncated at the first ~30 items; the
  stored value stays a flat array of the same objects.
- **Review fix (TC-5886):** coerce a null Jira description to `{}` in
  `transform_to_input` (`fields.get("description") or {}`), so an issue with no
  description no longer produces a `task.description: null` that violates the
  `type: object` input schema; a regression test validates the null-description
  input against `verify-pr-input.schema.json`.
- **Review fix (TC-5891):** end-anchor the github.com PR-URL regex in
  `pre-verify-pr.sh` (append `/?$`), so a malformed value like `.../pull/42abc`
  or `.../pull/42/invalid` is rejected with the existing error instead of
  truncating the pull number to `42` and prefetching the wrong PR; canonical
  URLs with or without a trailing slash still parse. Regression tests run the
  script's actual regex through bash's `[[ =~ ]]` for both accepted and
  rejected inputs.
- **Review fix (TC-5924):** derive `COMMIT_SHA` from the PR head ref tip OID
  (`gh pr view --json headRefOid`) instead of `.commits[-1].oid`. gh's `pr view`
  commits connection is bounded, so on a large PR `.commits[-1]` is the last
  commit of a truncated page rather than the head — a silently-wrong
  `commit_sha` that still satisfies the result schema's hex pattern. The bundled
  commits list (same bounded connection) is now documented as best-effort
  context. A behavioral regression test runs the shipped command against a gh
  stub whose `headRefOid` and `commits[-1].oid` disagree, plus a source guard.

## Deviations from the literal task steps

Dictated by the verified fullsend v0.37.0 contract (same class as TC-5805):

- **Skip signal (step 4)** uses the pre-script output protocol v1 — line-based
  `skipped=true` / `reason=...` appended to `$FULLSEND_PRESCRIPT_OUTPUT` (guarded,
  `exit 0`) — not a JSON `{"skipped":true}` document. That env var is the
  skip-signal file, not the input path.
- **GitHub bundle is embedded** in `verify-pr-input.json` (single file) rather
  than separate in-sandbox file paths, keeping the harness change scoped to
  `validation_loop`. Input JSON stays at `/tmp/fullsend-pre-output` (the
  `host_files` src), with `PRE_DIR` overridable for host-side testing.
- **No host-side PR-head checkout (step 3)**: the prefetched PR diff is
  sufficient for verification, so the sandbox needs no writable checkout.
- **Native validator decision (step 5)**: `additionalProperties:false` rejects
  benign agent extras, so `validate-output-schema.sh` + `strip_extra_properties.py`
  are **kept** and `validation_loop.script` is set (fullsend also requires a
  script for `validation_loop` — schema alone is insufficient).

## Validation (host-side, self-contained)

- Both schemas are valid JSON.
- `test_pre_verify_pr.py`: 27/27 pass.
- Validator strips benign extras and passes; fails a bad enum (exit 1).
- Skip path exits 0 with the correct `skipped=true`/`reason` signal.
- Happy path (stub `gh` + `jira-client`) produces a `verify-pr-input.json` that
  validates against the input schema with the full `github` bundle embedded.

A full `fullsend run` still cannot pass here: `post-verify-pr.sh` is authored in
TC-5811, and the first end-to-end run gates are TC-5809/TC-5813/TC-5815.

Implements [TC-5810](https://redhat.atlassian.net/browse/TC-5810)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Implement split-trust I/O for the verify-pr harness by prefetching trusted Jira and GitHub data into schema-validated sandbox input and enabling native result validation.

New Features:
- Add a split-trust verify-pr input contract that embeds Jira data and a tier-1 GitHub read bundle for sandbox verification.
- Prefetch linked pull-request metadata, diffs, reviews, comments, and commit context on the trusted runner before sandbox execution.

Bug Fixes:
- Prevent malformed pull-request URLs, empty diffs, null Jira descriptions, incomplete paginated reads, and truncated commit connections from producing invalid or incorrect verification inputs.

Enhancements:
- Add native output validation that removes benign extra properties before validating agent results against the strict result schema.
- Add tracker-agnostic Jira-to-input transformation and GitHub bundle assembly utilities.

Tests:
- Add comprehensive unit and regression coverage for input transformation, GitHub bundle assembly, pagination, diff statistics, URL validation, null descriptions, and commit SHA selection.