### PR TITLE
docs(verify-pr): sync github-bundle schema descriptions to shipped derivations

### DIFF
--- a/plugins/sdlc-workflow/schemas/verify-pr-input.schema.json
+++ b/plugins/sdlc-workflow/schemas/verify-pr-input.schema.json
@@ -67,7 +67,7 @@
         "commit_sha": {
           "type": "string",
           "pattern": "^[0-9a-f]{7,40}$",
-          "description": "OID of the PR head (last) commit (gh pr view --json commits --jq '.commits[-1].oid')"
+          "description": "OID of the PR head ref tip commit (gh pr view --json headRefOid --jq .headRefOid)"
         },
         "diff": {
           "type": "string",
@@ -75,7 +75,7 @@
         },
         "stat": {
           "type": "string",
-          "description": "PR diffstat (gh pr diff --stat)"
+          "description": "PR diffstat (git apply --stat on the fetched pr.diff; gh pr diff has no --stat flag)"
         },
         "reviews": {
           "type": "array",


### PR DESCRIPTION
## Summary

Fixes two stale command references in the `github` read bundle of
`plugins/sdlc-workflow/schemas/verify-pr-input.schema.json`. Both are
documentation-only doc-string drift — the field **values** produced by
`pre-verify-pr.sh` are already correct; only the descriptions lagged behind
prior review fixes.

- `commit_sha` — was described as `gh pr view --json commits --jq '.commits[-1].oid'`;
  now describes `gh pr view --json headRefOid --jq .headRefOid`, matching the
  **TC-5924** fix (the `pr view` commits connection is bounded, so `.commits[-1]`
  can be a truncated-page tip rather than the head).
- `stat` — was described as `gh pr diff --stat` (an unsupported flag); now
  describes `git apply --stat` on the already-fetched `pr.diff`, matching the
  **TC-5884** fix.

Surfaced as a non-blocking nit by the verify-pr run on PR #275 (HEAD 80caa6be).
The schema remains valid JSON.

Implements [TC-5929](https://redhat.atlassian.net/browse/TC-5929)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Synchronize verify-pr schema descriptions with the shipped GitHub bundle derivations.

Enhancements:
- Synchronize the verify-pr GitHub bundle schema descriptions for `commit_sha` and `stat` with the commands and derivations actually used.

Documentation:
- Update verify-pr schema documentation to reference the head commit SHA and statistics generated from the fetched diff.