### PR TITLE
docs+ci: enforce Python test execution (pytest workflow + CONVENTIONS.md)

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -2,9 +2,15 @@ name: Python Tests
 
 on:
   push:
-    branches: [main]
+    # TEMPORARY: the TC-5787-verify-pr-fullsend-v037 entry runs the suite on the
+    # feature branch before it merges to main. Remove it (leave only `main`) once
+    # the feature branch is merged — tracked by TC-5816.
+    branches: [main, TC-5787-verify-pr-fullsend-v037]
   pull_request:
-    branches: [main]
+    # TEMPORARY: the TC-5787-verify-pr-fullsend-v037 entry makes this workflow run
+    # as a required check on PRs targeting the feature branch (e.g. PR #285).
+    # Remove it (leave only `main`) once the feature branch merges to main — TC-5816.
+    branches: [main, TC-5787-verify-pr-fullsend-v037]
 
 jobs:
   pytest:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,26 @@
+name: Python Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pytest:
+    name: Script Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install test dependencies
+        run: pip install pytest jsonschema
+
+      - name: Run pytest
+        run: python3 -m pytest plugins/sdlc-workflow/scripts/ -q

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,6 +16,13 @@ jobs:
   pytest:
     name: Script Unit Tests
     runs-on: ubuntu-latest
+    strategy:
+      # Run every version so one failure doesn't hide others.
+      fail-fast: false
+      matrix:
+        # No declared minimum Python; test the range contributors are likely
+        # to run locally, up to the latest stable (3.14, Oct 2025).
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -23,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install test dependencies
         run: pip install pytest jsonschema

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -34,7 +34,7 @@
 - **`plugins/sdlc-workflow/`** — main plugin directory
   - **`skills/<skill-name>/`** — individual skill directories, each containing a `SKILL.md` file
   - **`shared/`** — shared resources like `task-description-template.md`
-  - **`scripts/`** — executable Python and shell helpers (e.g., `execute-actions.py`, `jira-client.py`, `pre-verify-pr.sh`) with a `pytest` unit-test suite (`test_*.py`) alongside them
+  - **`scripts/`** — executable Python and shell helpers (e.g., `execute-actions.py`, `jira-client.py`, `pre-verify-pr.sh`); the core Python modules have a `pytest` unit-test suite (`test_*.py`) alongside them, while `strip_extra_properties.py` and the shell helpers are not yet unit-tested
   - **`.claude-plugin/`** — plugin manifest (`plugin.json`)
 - **`.claude-plugin/`** — marketplace manifest at root level (`marketplace.json`)
 - **`.serena/`** — Serena configuration files
@@ -60,11 +60,14 @@ tests (see **Testing Conventions**).
   3. Run `/agents` to verify no plugin agents are missing
   4. Edit a `SKILL.md`, then `/reload-plugins` to verify changes are picked up
 - **CI validation**: Uses `claude plugin validate` on all plugin directories under `plugins/`
-- **Automated unit tests (mandatory)**: The Python scripts under
-  `plugins/sdlc-workflow/scripts/` have a `pytest` suite in sibling `test_*.py` files
-  (e.g., `test_execute_actions.py`, `test_jira_client.py`, `test_pre_verify_pr.py`).
-  Any change to a script under `scripts/` **must** add or update the matching test and
-  keep the whole suite green. Run it before every commit and before opening or updating
+- **Automated unit tests (mandatory)**: The core Python modules under
+  `plugins/sdlc-workflow/scripts/` (`execute-actions.py`, `jira-client.py`,
+  `pre_verify_pr.py`) have a `pytest` suite in sibling `test_*.py` files
+  (`test_execute_actions.py`, `test_jira_client.py`, `test_jira_client_cli.py`,
+  `test_pre_verify_pr.py`). `strip_extra_properties.py` and the shell helpers
+  (`pre-verify-pr.sh`, `post-verify-pr.sh`, `validate-output-schema.sh`) are not yet
+  unit-tested. Any change to a script under `scripts/` **must** add or update the
+  matching test and keep the whole suite green. Run it before every commit and before opening or updating
   a PR:
   ```bash
   python3 -m pytest plugins/sdlc-workflow/scripts/ -q
@@ -113,9 +116,12 @@ Validates plugin manifests under `plugins/`. CI workflow: `.github/workflows/val
 
 ### Python Unit Tests
 
-The executable scripts under `plugins/sdlc-workflow/scripts/` are covered by a `pytest`
-suite in sibling `test_*.py` files. Run the full suite and keep it green whenever you
-touch anything under `scripts/`:
+The core Python modules under `plugins/sdlc-workflow/scripts/` (`execute-actions.py`,
+`jira-client.py`, `pre_verify_pr.py`) are covered by a `pytest` suite in sibling
+`test_*.py` files; `strip_extra_properties.py` and the shell helpers
+(`pre-verify-pr.sh`, `post-verify-pr.sh`, `validate-output-schema.sh`) are not yet
+covered. Run the full suite and keep it green whenever you touch anything under
+`scripts/`:
 
 ```bash
 python3 -m pytest plugins/sdlc-workflow/scripts/ -q
@@ -178,7 +184,7 @@ requests targeting `main`). Run it locally before pushing so failures surface be
 
 ## Dependencies
 
-- **No external dependencies** — this repository contains only documentation and configuration files
+- **No external dependencies for the plugins themselves** — the Claude Code plugins are Markdown, YAML, and JSON. The repository also ships executable Python and shell helpers under `plugins/sdlc-workflow/scripts/`: these require Python 3 (`validate-output-schema.sh` additionally requires the `jsonschema` package at runtime), and the test suite requires `pytest` (plus `jsonschema`)
 - **Runtime dependency**: Claude Code CLI (users must have Claude Code installed to use the plugins)
 - **Plugin system**: Uses Claude Code's plugin marketplace and validation system (`claude plugin validate`)
 - **Version synchronization**: The plugin version must be kept in sync between:

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -9,7 +9,7 @@
 - **Primary format**: Markdown documentation
 - **Configuration**: YAML (`.serena/project.yml`) and JSON (plugin manifests)
 - **Plugin system**: Claude Code plugin format
-- **No source code**: This is a documentation-heavy repository — skills are defined in Markdown (`SKILL.md` files) rather than traditional programming languages
+- **Documentation-first, with Python tooling**: Skills are defined in Markdown (`SKILL.md` files), but the repository also ships executable Python and shell helpers under `plugins/sdlc-workflow/scripts/` that back the workflow. Changes to those scripts require running their automated test suite (see **Testing Conventions**)
 
 ## Code Style
 
@@ -34,7 +34,7 @@
 - **`plugins/sdlc-workflow/`** — main plugin directory
   - **`skills/<skill-name>/`** — individual skill directories, each containing a `SKILL.md` file
   - **`shared/`** — shared resources like `task-description-template.md`
-  - **`scripts/`** — utility scripts (if any)
+  - **`scripts/`** — executable Python and shell helpers (e.g., `execute-actions.py`, `jira-client.py`, `pre-verify-pr.sh`) with a `pytest` unit-test suite (`test_*.py`) alongside them
   - **`.claude-plugin/`** — plugin manifest (`plugin.json`)
 - **`.claude-plugin/`** — marketplace manifest at root level (`marketplace.json`)
 - **`.serena/`** — Serena configuration files
@@ -46,7 +46,11 @@
 
 ## Error Handling
 
-Not applicable — this is a documentation repository with no runtime code.
+The Markdown skills have no runtime error handling, but the Python scripts under
+`plugins/sdlc-workflow/scripts/` do. They must fail fast and loud: validate inputs,
+exit non-zero (`sys.exit(1)`) with a message on `stderr` on error, and never swallow
+an exception into a silent fallback. Cover both the success and the failure path with
+tests (see **Testing Conventions**).
 
 ## Testing Conventions
 
@@ -56,7 +60,17 @@ Not applicable — this is a documentation repository with no runtime code.
   3. Run `/agents` to verify no plugin agents are missing
   4. Edit a `SKILL.md`, then `/reload-plugins` to verify changes are picked up
 - **CI validation**: Uses `claude plugin validate` on all plugin directories under `plugins/`
-- **No automated tests**: Skills are validated through CI and manual testing; no unit test framework
+- **Automated unit tests (mandatory)**: The Python scripts under
+  `plugins/sdlc-workflow/scripts/` have a `pytest` suite in sibling `test_*.py` files
+  (e.g., `test_execute_actions.py`, `test_jira_client.py`, `test_pre_verify_pr.py`).
+  Any change to a script under `scripts/` **must** add or update the matching test and
+  keep the whole suite green. Run it before every commit and before opening or updating
+  a PR:
+  ```bash
+  python3 -m pytest plugins/sdlc-workflow/scripts/ -q
+  ```
+  A passing run is a precondition for merge, not an optional step — do not commit a
+  script change without running it.
 - **Fixture documentation**: Eval and test fixture files must include a leading comment header in the file's native comment syntax (e.g., `<!-- ... -->` for Markdown/HTML, `// ...` for JSON with comments, `# ...` for YAML) explaining that the content is deliberate test material. Use the canonical prefixes below so tooling (linters, scanners, grep filters) can reliably identify annotated fixtures. Two categories require annotation:
   - **Adversarial fixtures** — files containing intentionally adversarial, malicious-looking, or unusual content (e.g., injection vectors, malformed input, security-sensitive patterns). Use the prefix `ADVERSARIAL TEST FIXTURE — <purpose>` (e.g., `<!-- ADVERSARIAL TEST FIXTURE — contains intentional injection patterns for eval testing -->`).
   - **Synthetic data fixtures** — files representing synthetic or mock entities (e.g., fake repository structures, mock Jira issues, fabricated API responses). Use the prefix `SYNTHETIC TEST DATA — <purpose>` (e.g., `<!-- SYNTHETIC TEST DATA — names, URLs, and identifiers are fictional -->`).
@@ -70,10 +84,17 @@ Not applicable — this is a documentation repository with no runtime code.
 
 ## CI Checks
 
-All CI checks must pass before merging. Run locally before pushing:
+All checks must pass before merging. Run locally before pushing:
 
 ```bash
+# 1. Skill instruction lint
 uvx skillsaw
+
+# 2. Plugin manifest validation
+claude plugin validate plugins/sdlc-workflow
+
+# 3. Python unit tests — required whenever anything under scripts/ changes
+python3 -m pytest plugins/sdlc-workflow/scripts/ -q
 ```
 
 ### Skill Lint (Skillsaw)
@@ -89,6 +110,22 @@ claude plugin validate plugins/sdlc-workflow
 ```
 
 Validates plugin manifests under `plugins/`. CI workflow: `.github/workflows/validate-plugins.yml`.
+
+### Python Unit Tests
+
+The executable scripts under `plugins/sdlc-workflow/scripts/` are covered by a `pytest`
+suite in sibling `test_*.py` files. Run the full suite and keep it green whenever you
+touch anything under `scripts/`:
+
+```bash
+python3 -m pytest plugins/sdlc-workflow/scripts/ -q
+```
+
+This suite is **required before every commit that changes a script and before merge**.
+It is not yet wired into a GitHub Actions workflow, so it will not block the PR
+automatically — running it locally (and confirming a green run in the PR) is the
+current enforcement point. Adding a CI workflow that runs it is a recommended
+follow-up.
 
 ## Commit Messages
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -121,11 +121,9 @@ touch anything under `scripts/`:
 python3 -m pytest plugins/sdlc-workflow/scripts/ -q
 ```
 
-This suite is **required before every commit that changes a script and before merge**.
-It is not yet wired into a GitHub Actions workflow, so it will not block the PR
-automatically — running it locally (and confirming a green run in the PR) is the
-current enforcement point. Adding a CI workflow that runs it is a recommended
-follow-up.
+This suite is **required before every commit that changes a script and before merge**,
+and is enforced in CI by `.github/workflows/python-tests.yml` (runs on pushes and pull
+requests targeting `main`). Run it locally before pushing so failures surface before CI.
 
 ## Commit Messages
 


### PR DESCRIPTION
## Summary

Adds a CI job that automatically runs the Python test suite, and updates `CONVENTIONS.md` so the tests are documented and enforced — no more relying on contributor discipline.

The repo ships executable Python under `plugins/sdlc-workflow/scripts/` with a 95-test `pytest` suite, but nothing ran it in CI and `CONVENTIONS.md` still said "no runtime code" / "no unit test framework".

## Changes

- **New CI workflow `.github/workflows/python-tests.yml`** — installs `pytest` + `jsonschema` and runs `python3 -m pytest plugins/sdlc-workflow/scripts/ -q` on pushes and PRs to `main`, matching the trigger convention of the existing `skillsaw` / `validate-plugins` workflows.
- **`CONVENTIONS.md`** (docs):
  - Language and Framework / File Organization / Error Handling acknowledge the Python + shell helpers under `plugins/sdlc-workflow/scripts/` and their `test_*.py` suite.
  - Testing Conventions documents the pytest suite as a mandatory pre-commit/pre-merge gate.
  - CI Checks adds the pytest command to the pre-push list and a dedicated Python Unit Tests subsection referencing the new workflow.
  - Test-coverage wording corrected to name the covered core modules (`execute-actions.py`, `jira-client.py`, `pre_verify_pr.py`) and note that `strip_extra_properties.py` and the shell helpers are not yet unit-tested; the Dependencies section no longer claims the repo "contains only documentation and configuration files" (**TC-5974**).

## Verification

- `python3 -m pytest plugins/sdlc-workflow/scripts/ -q` → **95 passed**
- `claude plugin validate plugins/sdlc-workflow` → **passed**
- `uvx skillsaw` → **0 errors** (7 pre-existing warnings, none from this change)

> Note: like the other workflows in this repo, `python-tests.yml` triggers on `main` (push + PR), so it activates once this feature branch lands on `main`; it does not run on this feature-branch-based PR.

Jira: TC-5973 (relates to TC-5811); follow-up **TC-5974** corrects the CONVENTIONS.md coverage/dependency wording. Surfaced as a non-blocking advisory during verify-pr of PR #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce the Python script test suite in CI and document it as a mandatory repository convention.

New Features:
- Add a GitHub Actions workflow that runs the Python script test suite across supported Python versions for pushes and pull requests.

Enhancements:
- Update repository conventions to recognize executable Python and shell tooling and define its error-handling expectations.
- Make the pytest suite a documented pre-commit and pre-merge requirement alongside existing validation checks.

CI:
- Enforce automated Python unit testing through a dedicated CI workflow targeting the main branch and the temporary verification branch.

Documentation:
- Document the Python scripts, their test coverage, mandatory test commands, and CI enforcement in CONVENTIONS.md.
