### PR TITLE
feat(verify-pr): re-sync FULLSEND_OUTPUT_DIR sandbox dual-mode onto SKILL.md

### DIFF
--- a/plugins/sdlc-workflow/schemas/verify-pr-input.schema.json
+++ b/plugins/sdlc-workflow/schemas/verify-pr-input.schema.json
@@ -95,6 +95,32 @@
         }
       }
     },
+    "idempotency": {
+      "type": "object",
+      "description": "Related-issue metadata prefetched on the trusted runner so the sandbox can run the Steps 6d/6f/7c idempotency checks (duplicate sub-task and root-cause detection) without a Jira token or egress. Optional: absent or empty when the task has no sub-tasks or linked issues yet.",
+      "additionalProperties": false,
+      "properties": {
+        "related_issues": {
+          "type": "array",
+          "description": "The task's existing sub-tasks and linked issues (e.g., root-cause tasks), each with the fields the dedup checks inspect.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": { "type": "string", "description": "Issue key (e.g., TC-4742)" },
+              "summary": { "type": "string" },
+              "labels": { "type": "array", "items": { "type": "string" } },
+              "description": { "type": "object", "description": "Issue description in the tracker's native format (e.g., ADF)" },
+              "issuetype": { "type": "string", "description": "Issue type name (e.g., Sub-task, Task)" },
+              "comments": {
+                "type": "array",
+                "description": "Comment bodies in the tracker's native format; searched by Step 7c for the root-cause marker.",
+                "items": { "type": "object" }
+              }
+            }
+          }
+        }
+      }
+    },
     "source": {
       "type": "object",
       "description": "Raw issue tracker response for fields not captured above",

--- a/plugins/sdlc-workflow/schemas/verify-pr-input.schema.json
+++ b/plugins/sdlc-workflow/schemas/verify-pr-input.schema.json
@@ -4,7 +4,7 @@
   "title": "Verify PR Pre-Script Input",
   "description": "Pre-fetched task data written by the pre_script and mounted into the sandbox. The skill reads this instead of calling the issue tracker or GitHub APIs directly.",
   "type": "object",
-  "required": ["task_id", "task", "pr_url", "github"],
+  "required": ["task_id", "task", "pr_url", "github", "idempotency"],
   "additionalProperties": false,
   "properties": {
     "task_id": {
@@ -97,8 +97,9 @@
     },
     "idempotency": {
       "type": "object",
-      "description": "Related-issue metadata prefetched on the trusted runner so the sandbox can run the Steps 6d/6f/7c idempotency checks (duplicate sub-task and root-cause detection) without a Jira token or egress. Optional: absent or empty when the task has no sub-tasks or linked issues yet.",
+      "description": "Related-issue metadata prefetched on the trusted runner so the sandbox can run the Steps 6d/6f/7c idempotency checks (duplicate sub-task and root-cause detection) without a Jira token or egress. Always present in a valid prefetch: the producer runs on the trusted runner with a Jira token, so it can always emit the bundle — with an empty related_issues array when the task has no sub-tasks or linked issues yet. Requiring it (rather than leaving it optional) closes the gap that let a schema-valid prefetch omit the bundle and silently skip dedup in the tokenless sandbox.",
       "additionalProperties": false,
+      "required": ["related_issues"],
       "properties": {
         "related_issues": {
           "type": "array",

--- a/plugins/sdlc-workflow/schemas/verify-pr-input.schema.json
+++ b/plugins/sdlc-workflow/schemas/verify-pr-input.schema.json
@@ -106,6 +106,7 @@
           "description": "The task's existing sub-tasks and linked issues (e.g., root-cause tasks), each with the fields the dedup checks inspect.",
           "items": {
             "type": "object",
+            "required": ["key", "summary", "labels", "description", "issuetype", "comments"],
             "properties": {
               "key": { "type": "string", "description": "Issue key (e.g., TC-4742)" },
               "summary": { "type": "string" },

--- a/plugins/sdlc-workflow/scripts/execute-actions.py
+++ b/plugins/sdlc-workflow/scripts/execute-actions.py
@@ -666,14 +666,18 @@ def execute_post_report(action: dict, registry: dict, report: dict) -> None:
     (``gh api ... -X PATCH``)
     instead of creating a duplicate, so a retry after a partial failure is
     idempotent while a new commit still gets a fresh comment. The Jira side is
-    already idempotent via its sticky marker; only ``report_md`` (without the
-    GitHub marker) is sent there.
+    already idempotent via its sticky marker; it receives the report rendered
+    from ``report_adf`` (the tracker-native body) via ``adf_to_markdown``, which
+    the native CLI converts back to ADF — the GitHub-only ``report_md`` (and its
+    embedded marker) is never sent to Jira.
     """
     repo = report["pr_repo"]
     pr_number = report["pr_number"]
     jira_issue_id = report["jira_issue_id"]
     commit_sha = report["commit_sha"]
     report_md = resolve_refs(report["report_md"], registry)
+    report_adf = resolve_refs_in_obj(report["report_adf"], registry)
+    jira_body_md = adf_to_markdown(report_adf)
 
     marker = f"{GITHUB_REPORT_MARKER_PREFIX}{_normalize_commit_sha(commit_sha)} -->"
     github_body = f"{report_md}\n\n{marker}"
@@ -699,7 +703,7 @@ def execute_post_report(action: dict, registry: dict, report: dict) -> None:
             sys.exit(1)
         print(f"  Posted report to PR #{pr_number}")
 
-    post_jira_comment_native(jira_issue_id, report_md)
+    post_jira_comment_native(jira_issue_id, jira_body_md)
     print(f"  Posted report to Jira {jira_issue_id}")
 
 

--- a/plugins/sdlc-workflow/scripts/pre-verify-pr.sh
+++ b/plugins/sdlc-workflow/scripts/pre-verify-pr.sh
@@ -148,15 +148,34 @@ gh pr view "${PR_NUM}" -R "${PR_REPO}" --json commits --jq .commits > "${PRE_OUT
 
 echo "GitHub read bundle prefetched to ${PRE_OUTPUT_DIR}"
 
+# 7b. Idempotency prefetch — the sandbox has no Jira token, but Steps 6d/6f/7c
+#     dedupe against the task's existing sub-tasks and linked (e.g., root-cause)
+#     issues. Fetch each related issue here on the trusted runner (summary,
+#     labels, description, issuetype, and comments) so the sandbox can run those
+#     checks tokenlessly. No `|| true`: a related issue the token created should
+#     be readable, so a fetch failure is a real error surfaced under set -e.
+REL_DIR="${PRE_OUTPUT_DIR}/related-issues"
+rm -rf "${REL_DIR}"
+mkdir -p "${REL_DIR}"
+RELATED_KEYS=$(printf '%s\n' "${ISSUE_JSON}" | python3 "${SCRIPT_DIR}/pre_verify_pr.py" related-keys)
+for key in ${RELATED_KEYS}; do
+  python3 "${SCRIPT_DIR}/jira-client.py" get_issue "${key}" \
+    --fields "summary,labels,description,issuetype,comment" \
+    > "${REL_DIR}/${key}.json"
+done
+echo "Idempotency read bundle prefetched to ${REL_DIR}"
+
 # 8. Write pre-fetched data for sandbox consumption (tracker-agnostic format,
-#    with the GitHub bundle embedded under `github`).
+#    with the GitHub bundle embedded under `github` and the idempotency
+#    related-issue metadata under `idempotency`).
 printf '%s\n' "${ISSUE_JSON}" | python3 "${SCRIPT_DIR}/pre_verify_pr.py" transform \
   "${JIRA_ISSUE_ID}" "${PR_URL}" \
   --github-dir "${PRE_OUTPUT_DIR}" \
   --pr-repo "${PR_REPO}" \
   --pr-number "${PR_NUM}" \
   --head-ref "${HEAD_REF}" \
-  --commit-sha "${COMMIT_SHA}" > "${PRE_OUTPUT_DIR}/verify-pr-input.json"
+  --commit-sha "${COMMIT_SHA}" \
+  --idempotency-dir "${REL_DIR}" > "${PRE_OUTPUT_DIR}/verify-pr-input.json"
 
 echo "Pre-fetched data written to ${PRE_OUTPUT_DIR}/verify-pr-input.json"
 echo "Input validation passed"

--- a/plugins/sdlc-workflow/scripts/pre_verify_pr.py
+++ b/plugins/sdlc-workflow/scripts/pre_verify_pr.py
@@ -7,17 +7,26 @@ tracker-agnostic input schema used by the sandbox.
 
 CLI usage (called by pre-verify-pr.sh):
     echo "$ISSUE_JSON" | python3 pre_verify_pr.py extract-pr-url
+    echo "$ISSUE_JSON" | python3 pre_verify_pr.py related-keys
     echo "$ISSUE_JSON" | python3 pre_verify_pr.py transform TASK_ID PR_URL \\
         [--github-dir DIR --pr-repo REPO --pr-number N \\
-         --head-ref REF --commit-sha SHA]
+         --head-ref REF --commit-sha SHA --idempotency-dir DIR]
 
 When the --github-* options are supplied, `transform` reads the raw GitHub
 reads from DIR (pr.diff, pr.stat, reviews.json, review-comments.json,
 issue-comments.json, commits.json) and embeds them under a `github` key.
+
+`related-keys` prints the task's sub-task and linked-issue keys (one per line)
+so the shell can prefetch each on the runner. When --idempotency-dir is given,
+`transform` reads those prefetched issue JSONs and embeds their summary/labels/
+description/comments under an `idempotency` key, giving the sandbox a tokenless
+data source for the Steps 6d/6f/7c idempotency checks.
 """
 
 import argparse
+import glob
 import json
+import os
 import sys
 
 
@@ -62,7 +71,58 @@ def build_github_bundle(pr_repo, pr_number, head_ref, commit_sha,
     }
 
 
-def transform_to_input(issue, task_id, pr_url, github=None):
+def related_keys(issue):
+    """Keys of the task's sub-tasks and linked issues (idempotency targets).
+
+    Steps 6d/6f/7c dedupe against the parent task's existing sub-tasks and its
+    linked (e.g., root-cause) issues. The pre_script fetches each of these keys
+    on the trusted runner so the sandbox can run those idempotency checks
+    without a Jira token. Returns a sorted, de-duplicated list.
+    """
+    fields = issue.get("fields", {})
+    keys = set()
+    for sub in fields.get("subtasks") or []:
+        key = sub.get("key")
+        if key:
+            keys.add(key)
+    for link in fields.get("issuelinks") or []:
+        related = link.get("inwardIssue") or link.get("outwardIssue") or {}
+        key = related.get("key")
+        if key:
+            keys.add(key)
+    return sorted(keys)
+
+
+def build_idempotency_bundle(related_issue_jsons):
+    """Bundle related-issue metadata for the sandbox idempotency checks.
+
+    Each item is a full issue JSON the runner fetched with fields summary,
+    labels, description, issuetype, and comment. The sandbox reads this instead
+    of calling Jira to dedupe sub-tasks (Steps 6d/6f) and root-cause tasks
+    (Step 7c). Descriptions and comment bodies are kept in the tracker's native
+    format (ADF for Jira) — the sandbox agent inspects them directly.
+    """
+    related = []
+    for ri in related_issue_jsons:
+        fields = ri.get("fields", {})
+        comments = [
+            c.get("body") or {}
+            for c in (fields.get("comment") or {}).get("comments", [])
+        ]
+        related.append({
+            "key": ri.get("key", ""),
+            "summary": fields.get("summary", ""),
+            "labels": fields.get("labels", []),
+            # Coerce an explicit null description to {} so the value stays an
+            # object per verify-pr-input.schema.json (see transform_to_input).
+            "description": fields.get("description") or {},
+            "issuetype": (fields.get("issuetype") or {}).get("name", ""),
+            "comments": comments,
+        })
+    return {"related_issues": related}
+
+
+def transform_to_input(issue, task_id, pr_url, github=None, idempotency=None):
     """Transform Jira issue JSON to tracker-agnostic input schema."""
     fields = issue.get("fields", {})
     result = {
@@ -99,6 +159,8 @@ def transform_to_input(issue, task_id, pr_url, github=None):
     }
     if github is not None:
         result["github"] = github
+    if idempotency is not None:
+        result["idempotency"] = idempotency
     return result
 
 
@@ -129,11 +191,22 @@ def _github_from_dir(args):
     )
 
 
+def _idempotency_from_dir(path):
+    """Read every related-issue JSON the shell wrote and build the bundle.
+
+    Globs ``<path>/*.json`` (one file per related key, written by
+    pre-verify-pr.sh). An empty directory yields an empty related_issues list.
+    """
+    files = sorted(glob.glob(os.path.join(path, "*.json")))
+    return build_idempotency_bundle([_read_json(f) for f in files])
+
+
 def main(argv):
     parser = argparse.ArgumentParser(prog="pre_verify_pr.py")
     sub = parser.add_subparsers(dest="command", required=True)
 
     sub.add_parser("extract-pr-url")
+    sub.add_parser("related-keys")
 
     t = sub.add_parser("transform")
     t.add_argument("task_id")
@@ -143,15 +216,24 @@ def main(argv):
     t.add_argument("--pr-number", type=int)
     t.add_argument("--head-ref")
     t.add_argument("--commit-sha")
+    t.add_argument("--idempotency-dir")
 
     args = parser.parse_args(argv)
     issue = json.load(sys.stdin)
 
     if args.command == "extract-pr-url":
         print(extract_pr_url(issue))
+    elif args.command == "related-keys":
+        for key in related_keys(issue):
+            print(key)
     elif args.command == "transform":
         github = _github_from_dir(args) if args.github_dir else None
-        result = transform_to_input(issue, args.task_id, args.pr_url, github)
+        idempotency = (
+            _idempotency_from_dir(args.idempotency_dir)
+            if args.idempotency_dir else None
+        )
+        result = transform_to_input(
+            issue, args.task_id, args.pr_url, github, idempotency)
         json.dump(result, sys.stdout, indent=2)
 
 

--- a/plugins/sdlc-workflow/scripts/pre_verify_pr.py
+++ b/plugins/sdlc-workflow/scripts/pre_verify_pr.py
@@ -123,7 +123,14 @@ def build_idempotency_bundle(related_issue_jsons):
 
 
 def transform_to_input(issue, task_id, pr_url, github=None, idempotency=None):
-    """Transform Jira issue JSON to tracker-agnostic input schema."""
+    """Transform Jira issue JSON to tracker-agnostic input schema.
+
+    The ``idempotency`` bundle is always emitted (defaulting to an empty
+    ``related_issues`` list when none is supplied) so the tokenless sandbox
+    always has a data source for the Steps 6d/6f/7c dedup checks. This matches
+    verify-pr-input.schema.json, which requires ``idempotency.related_issues``:
+    a schema-valid prefetch can never omit the bundle and silently skip dedup.
+    """
     fields = issue.get("fields", {})
     result = {
         "task_id": task_id,
@@ -159,8 +166,9 @@ def transform_to_input(issue, task_id, pr_url, github=None, idempotency=None):
     }
     if github is not None:
         result["github"] = github
-    if idempotency is not None:
-        result["idempotency"] = idempotency
+    result["idempotency"] = (
+        idempotency if idempotency is not None else {"related_issues": []}
+    )
     return result
 
 

--- a/plugins/sdlc-workflow/scripts/test_execute_actions.py
+++ b/plugins/sdlc-workflow/scripts/test_execute_actions.py
@@ -616,6 +616,20 @@ def test_render_adf_date_falls_back_on_out_of_range_timestamp():
     assert result == out_of_range, f"Got: {result!r}"
 
 
+# A report's tracker-native body. execute_post_report renders this (not the
+# GitHub-only report_md) to markdown for Jira via adf_to_markdown, so the fixtures
+# below give it text that renders to a string distinct from report_md — proving
+# Jira receives the ADF-derived body while GitHub keeps report_md + its marker.
+_REPORT_ADF = {
+    "type": "doc",
+    "version": 1,
+    "content": [
+        {"type": "paragraph", "content": [{"type": "text", "text": "Jira native body."}]}
+    ],
+}
+_REPORT_ADF_MD = "Jira native body."
+
+
 def test_execute_post_comment_routes_to_native():
     """execute_post_comment resolves refs in body_adf, renders to markdown, and posts it."""
     recorder = _RunRecorder()
@@ -682,6 +696,7 @@ def test_post_comment_and_report_use_distinct_sticky_markers():
             "jira_issue_id": "TC-777",
             "commit_sha": "946556e",
             "report_md": "## Verify report",
+            "report_adf": _REPORT_ADF,
         }
         execute_actions.execute_post_report({"type": "post_report"}, {}, report)
     finally:
@@ -720,6 +735,7 @@ def test_execute_post_report_posts_github_then_jira():
             "jira_issue_id": "TC-777",
             "commit_sha": "946556e",
             "report_md": "## Verify report\nAll good.",
+            "report_adf": _REPORT_ADF,
         }
         execute_actions.execute_post_report({"type": "post_report"}, {}, report)
     finally:
@@ -743,10 +759,14 @@ def test_execute_post_report_posts_github_then_jira():
     gh_body = gh_call["cmd"][gh_call["cmd"].index("--body") + 1]
     assert gh_body.startswith("## Verify report\nAll good.")
     assert "<!-- sdlc-workflow:verify-pr report commit:946556e -->" in gh_body
-    # Jira side is unchanged: sticky CLI, clean body without the GitHub marker.
+    # Jira side: sticky CLI, and the body is rendered from report_adf (the
+    # tracker-native content) via adf_to_markdown — NOT the GitHub-only report_md,
+    # which carries the commit marker Jira must never receive.
     assert jira_call["cmd"][:3] == ["fullsend", "issues", "post-comment"]
     assert jira_call["cmd"][jira_call["cmd"].index("--number") + 1] == "777"
-    assert jira_call["input"] == "## Verify report\nAll good."
+    assert jira_call["input"] == _REPORT_ADF_MD
+    assert jira_call["input"] != report["report_md"], "Jira must not receive report_md"
+    assert "sdlc-workflow:verify-pr report commit:" not in jira_call["input"]
 
 
 def test_execute_post_report_updates_existing_github_comment_on_retry():
@@ -775,6 +795,7 @@ def test_execute_post_report_updates_existing_github_comment_on_retry():
             "jira_issue_id": "TC-777",
             "commit_sha": "946556e",
             "report_md": "## Verify report\nAll good.",
+            "report_adf": _REPORT_ADF,
         }
         # When posting the report again (e.g. after a prior Jira failure)
         execute_actions.execute_post_report({"type": "post_report"}, {}, report)
@@ -832,6 +853,7 @@ def test_execute_post_report_updates_comment_on_later_page():
             "jira_issue_id": "TC-777",
             "commit_sha": "946556e",
             "report_md": "## Verify report\nAll good.",
+            "report_adf": _REPORT_ADF,
         }
         # When posting the report again for the same commit
         execute_actions.execute_post_report({"type": "post_report"}, {}, report)
@@ -877,6 +899,7 @@ def _run_post_report_with_sha_resolution(commit_sha, existing_comments, resolve)
             "jira_issue_id": "TC-777",
             "commit_sha": commit_sha,
             "report_md": "## Verify report",
+            "report_adf": _REPORT_ADF,
         }
         execute_actions.execute_post_report({"type": "post_report"}, {}, report)
     finally:
@@ -1000,6 +1023,14 @@ def test_post_report_resolves_ref_created_by_later_action():
             "jira_issue_id": "TC-777",
             "commit_sha": "946556e",
             "report_md": "Filed sub-task {{sub-1.key}}.",
+            "report_adf": {
+                "type": "doc",
+                "version": 1,
+                "content": [
+                    {"type": "paragraph",
+                     "content": [{"type": "text", "text": "Filed sub-task {{sub-1.key}}."}]}
+                ],
+            },
         },
         "actions": [
             {"type": "post_report"},
@@ -1043,6 +1074,10 @@ def test_post_report_resolves_ref_created_by_later_action():
     gh_body = create_call["cmd"][create_call["cmd"].index("--body") + 1]
     assert "Filed sub-task TC-999." in gh_body, f"ref not resolved: {gh_body}"
     assert "{{sub-1.key}}" not in gh_body, "placeholder leaked into report body"
+    # The Jira body is rendered from report_adf, and its refs resolve too.
+    jira_call = next(c for c in calls if c["cmd"][:3] == ["fullsend", "issues", "post-comment"])
+    assert jira_call["input"] == "Filed sub-task TC-999.", f"ref not resolved in ADF: {jira_call['input']}"
+    assert "{{sub-1.key}}" not in jira_call["input"], "placeholder leaked into Jira body"
 
 
 def test_find_report_comment_id_exits_on_unparseable_json():

--- a/plugins/sdlc-workflow/scripts/test_pre_verify_pr.py
+++ b/plugins/sdlc-workflow/scripts/test_pre_verify_pr.py
@@ -271,6 +271,155 @@ def test_cli_transform_github_dir():
     assert gh["commits"] == [{"oid": "abc1234def"}]
 
 
+# --- idempotency prefetch (related_keys, build_idempotency_bundle, transform) ---
+
+def test_related_keys_from_subtasks_and_links():
+    """related_keys collects sub-task keys and linked-issue keys, deduped/sorted."""
+    issue = {"fields": {
+        "subtasks": [{"key": "TC-201"}, {"key": "TC-202"}],
+        "issuelinks": [
+            {"type": {"name": "Blocks"}, "inwardIssue": {"key": "TC-202"}},
+            {"type": {"name": "Related"}, "outwardIssue": {"key": "TC-300"}},
+        ],
+    }}
+    # TC-202 appears as both a sub-task and a link — deduped; result is sorted
+    assert pre_verify_pr.related_keys(issue) == ["TC-201", "TC-202", "TC-300"]
+
+
+def test_related_keys_empty_when_no_relations():
+    issue = {"fields": {"summary": "S"}}
+    assert pre_verify_pr.related_keys(issue) == []
+
+
+def test_build_idempotency_bundle_extracts_fields_and_comments():
+    """The bundle carries the fields the dedup checks inspect, incl. comment bodies."""
+    ri = {
+        "key": "TC-500",
+        "fields": {
+            "summary": "Fix eval-3 assertion failures",
+            "labels": ["ai-generated-jira", "eval-failure"],
+            "description": {"type": "doc", "content": []},
+            "issuetype": {"name": "Sub-task"},
+            "comment": {"comments": [
+                {"body": {"type": "doc", "content": [{"type": "text"}]}},
+                {"body": {"type": "doc"}},
+            ]},
+        },
+    }
+    bundle = pre_verify_pr.build_idempotency_bundle([ri])
+    entry = bundle["related_issues"][0]
+    assert entry["key"] == "TC-500"
+    assert entry["summary"] == "Fix eval-3 assertion failures"
+    assert entry["labels"] == ["ai-generated-jira", "eval-failure"]
+    assert entry["description"] == {"type": "doc", "content": []}
+    assert entry["issuetype"] == "Sub-task"
+    assert len(entry["comments"]) == 2
+    assert entry["comments"][0] == {"type": "doc", "content": [{"type": "text"}]}
+
+
+def test_build_idempotency_bundle_handles_missing_fields():
+    """A related issue lacking comments/description yields empty defaults, not errors."""
+    bundle = pre_verify_pr.build_idempotency_bundle([{"key": "TC-9", "fields": {}}])
+    entry = bundle["related_issues"][0]
+    assert entry["summary"] == ""
+    assert entry["labels"] == []
+    assert entry["description"] == {}  # null/absent coerced to object
+    assert entry["issuetype"] == ""
+    assert entry["comments"] == []
+
+
+def test_build_idempotency_bundle_empty():
+    assert pre_verify_pr.build_idempotency_bundle([]) == {"related_issues": []}
+
+
+def test_transform_with_idempotency_attaches_key():
+    issue = {"fields": {"summary": "S", "status": {"name": "Open"}, "labels": [], "issuelinks": []}}
+    idem = pre_verify_pr.build_idempotency_bundle([{"key": "TC-1", "fields": {}}])
+    result = pre_verify_pr.transform_to_input(issue, "TC-1", "", None, idem)
+    assert result["idempotency"]["related_issues"][0]["key"] == "TC-1"
+
+
+def test_transform_without_idempotency_omits_key():
+    issue = {"fields": {"summary": "S", "status": {"name": "Open"}, "labels": [], "issuelinks": []}}
+    result = pre_verify_pr.transform_to_input(issue, "TC-1", "")
+    assert "idempotency" not in result
+
+
+def test_cli_transform_idempotency_dir():
+    """CLI transform globs the related-issue JSONs and embeds the idempotency bundle."""
+    issue = {"fields": {"summary": "S", "status": {"name": "Open"}, "labels": [], "issuelinks": []}}
+    with tempfile.TemporaryDirectory() as d:
+        with open(os.path.join(d, "TC-501.json"), "w") as f:
+            json.dump({"key": "TC-501", "fields": {
+                "summary": "Existing sub-task", "labels": ["review-feedback"],
+                "description": {"type": "doc"}, "issuetype": {"name": "Sub-task"},
+                "comment": {"comments": [{"body": {"type": "doc"}}]},
+            }}, f)
+        result = subprocess.run(
+            [sys.executable, os.path.join(script_dir, "pre_verify_pr.py"),
+             "transform", "TC-1", "https://github.com/o/r/pull/1",
+             "--idempotency-dir", d],
+            input=json.dumps(issue), capture_output=True, text=True,
+        )
+    assert result.returncode == 0, f"Exit {result.returncode}: {result.stderr}"
+    output = json.loads(result.stdout)
+    related = output["idempotency"]["related_issues"]
+    assert len(related) == 1
+    assert related[0]["key"] == "TC-501"
+    assert related[0]["labels"] == ["review-feedback"]
+    assert related[0]["comments"] == [{"type": "doc"}]
+
+
+def test_cli_transform_empty_idempotency_dir():
+    """An empty related-issues dir yields an empty related_issues list, not an error."""
+    issue = {"fields": {"summary": "S", "status": {"name": "Open"}, "labels": [], "issuelinks": []}}
+    with tempfile.TemporaryDirectory() as d:
+        result = subprocess.run(
+            [sys.executable, os.path.join(script_dir, "pre_verify_pr.py"),
+             "transform", "TC-1", "https://github.com/o/r/pull/1",
+             "--idempotency-dir", d],
+            input=json.dumps(issue), capture_output=True, text=True,
+        )
+    assert result.returncode == 0, f"Exit {result.returncode}: {result.stderr}"
+    assert json.loads(result.stdout)["idempotency"] == {"related_issues": []}
+
+
+def test_cli_related_keys():
+    """The related-keys subcommand prints sub-task and linked-issue keys."""
+    issue = {"fields": {
+        "subtasks": [{"key": "TC-201"}],
+        "issuelinks": [{"type": {"name": "Related"}, "outwardIssue": {"key": "TC-300"}}],
+    }}
+    result = subprocess.run(
+        [sys.executable, os.path.join(script_dir, "pre_verify_pr.py"), "related-keys"],
+        input=json.dumps(issue), capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"Exit {result.returncode}: {result.stderr}"
+    assert result.stdout.split() == ["TC-201", "TC-300"]
+
+
+def test_idempotency_input_validates_against_schema():
+    """A produced input carrying the idempotency bundle validates against the schema."""
+    from jsonschema import validate
+
+    issue = {"fields": {"summary": "S", "description": {}, "status": {"name": "Open"},
+                        "labels": [], "issuelinks": []}}
+    github = pre_verify_pr.build_github_bundle(
+        "o/r", 5, "feat/x", "deadbee", "diff", "stat", [], [], [], [])
+    idem = pre_verify_pr.build_idempotency_bundle([{"key": "TC-9", "fields": {
+        "summary": "Existing", "labels": ["review-feedback"],
+        "description": {"type": "doc"}, "issuetype": {"name": "Sub-task"},
+        "comment": {"comments": [{"body": {"type": "doc"}}]},
+    }}])
+    result = pre_verify_pr.transform_to_input(
+        issue, "TC-1", "https://github.com/o/r/pull/5", github, idem)
+    schema_path = os.path.join(
+        script_dir, "..", "schemas", "verify-pr-input.schema.json")
+    with open(schema_path) as f:
+        schema = json.load(f)
+    validate(instance=result, schema=schema)  # raises on failure
+
+
 # --- stat production (pre-verify-pr.sh) ---
 
 pre_verify_sh = os.path.join(script_dir, "pre-verify-pr.sh")
@@ -330,6 +479,31 @@ def test_pre_verify_sh_uses_supported_stat_command():
         if "gh pr diff" in line:
             assert "--stat" not in line, f"unsupported gh flag reintroduced: {line!r}"
     assert "git apply --stat" in script, "expected git apply --stat stat mechanism"
+
+
+# --- idempotency prefetch (pre-verify-pr.sh) ---
+
+def test_pre_verify_sh_prefetches_related_issues():
+    """Regression guard: pre-verify-pr.sh fetches related-issue metadata for the
+    sandbox idempotency checks (TC-5982) — it lists related keys, fetches each
+    issue including its comments, and passes --idempotency-dir to transform.
+    """
+    with open(pre_verify_sh) as f:
+        script = f.read()
+
+    # It enumerates the task's related keys via pre_verify_pr.py related-keys
+    assert "related-keys" in script, "expected related-keys enumeration"
+    # It fetches each related issue including the comment field (for Step 7c)
+    non_comment = [
+        line for line in script.splitlines()
+        if 'get_issue "${key}"' in line and not line.lstrip().startswith("#")
+    ]
+    assert non_comment, "expected a per-key get_issue fetch"
+    # The fields list feeding that fetch must include comment, description, labels
+    assert "summary,labels,description,issuetype,comment" in script, \
+        "related-issue fetch must request comment/description/labels"
+    # And it wires the prefetched dir into transform
+    assert "--idempotency-dir" in script, "transform must receive --idempotency-dir"
 
 
 # --- paginated fetch aggregation (pre-verify-pr.sh) ---

--- a/plugins/sdlc-workflow/scripts/test_pre_verify_pr.py
+++ b/plugins/sdlc-workflow/scripts/test_pre_verify_pr.py
@@ -339,10 +339,16 @@ def test_transform_with_idempotency_attaches_key():
     assert result["idempotency"]["related_issues"][0]["key"] == "TC-1"
 
 
-def test_transform_without_idempotency_omits_key():
+def test_transform_without_idempotency_defaults_to_empty():
+    """With no idempotency supplied, transform still emits an empty bundle.
+
+    Option 1 of TC-6026: the key is always present so the tokenless sandbox
+    always has a data source for the Steps 6d/6f/7c dedup checks — a missing
+    argument degrades to "no known duplicates", never an omitted key.
+    """
     issue = {"fields": {"summary": "S", "status": {"name": "Open"}, "labels": [], "issuelinks": []}}
     result = pre_verify_pr.transform_to_input(issue, "TC-1", "")
-    assert "idempotency" not in result
+    assert result["idempotency"] == {"related_issues": []}
 
 
 def test_cli_transform_idempotency_dir():
@@ -418,6 +424,39 @@ def test_idempotency_input_validates_against_schema():
     with open(schema_path) as f:
         schema = json.load(f)
     validate(instance=result, schema=schema)  # raises on failure
+
+
+def test_prefetch_omitting_idempotency_fails_schema_validation():
+    """A prefetch lacking the idempotency bundle is rejected by the schema.
+
+    Option 1 of TC-6026: idempotency is a top-level required key, so Step 0.7
+    validation rejects a bundle that omits it *before* any consuming step runs —
+    the fail-fast contract from TC-5980/TC-5981. This closes the gap that let a
+    schema-valid prefetch skip the tokenless dedup checks silently.
+    """
+    from jsonschema import validate
+    from jsonschema.exceptions import ValidationError
+
+    # Given an otherwise-valid input (task + github) with no idempotency key
+    issue = {"fields": {"summary": "S", "description": {}, "status": {"name": "Open"},
+                        "labels": [], "issuelinks": []}}
+    github = pre_verify_pr.build_github_bundle(
+        "o/r", 5, "feat/x", "deadbee", "diff", "stat", [], [], [], [])
+    instance = pre_verify_pr.transform_to_input(
+        issue, "TC-1", "https://github.com/o/r/pull/5", github)
+    del instance["idempotency"]  # simulate an older/hand-supplied bundle
+
+    schema_path = os.path.join(
+        script_dir, "..", "schemas", "verify-pr-input.schema.json")
+    with open(schema_path) as f:
+        schema = json.load(f)
+
+    # When validating it against the input schema, Then it is rejected
+    try:
+        validate(instance=instance, schema=schema)
+        assert False, "schema accepted a prefetch missing idempotency"
+    except ValidationError as e:
+        assert "idempotency" in str(e), f"unexpected error: {e}"
 
 
 # --- stat production (pre-verify-pr.sh) ---

--- a/plugins/sdlc-workflow/scripts/test_pre_verify_pr.py
+++ b/plugins/sdlc-workflow/scripts/test_pre_verify_pr.py
@@ -459,6 +459,43 @@ def test_prefetch_omitting_idempotency_fails_schema_validation():
         assert "idempotency" in str(e), f"unexpected error: {e}"
 
 
+def test_incomplete_related_issue_fails_schema_validation():
+    """A related-issue entry missing a per-item field is rejected by the schema.
+
+    TC-6032: idempotency.related_issues.items requires the fields the dedup
+    checks consume (Steps 6d/6f/7c). Without a per-item `required` list, a
+    structurally incomplete entry passed Step 0.7 and dedup silently treated it
+    as non-matching — the item-level analogue of the TC-6026 array-level gap.
+    """
+    from jsonschema import validate
+    from jsonschema.exceptions import ValidationError
+
+    # Given an otherwise-valid input whose sole related issue omits `comments`
+    issue = {"fields": {"summary": "S", "description": {}, "status": {"name": "Open"},
+                        "labels": [], "issuelinks": []}}
+    github = pre_verify_pr.build_github_bundle(
+        "o/r", 5, "feat/x", "deadbee", "diff", "stat", [], [], [], [])
+    instance = pre_verify_pr.transform_to_input(
+        issue, "TC-1", "https://github.com/o/r/pull/5", github)
+    instance["idempotency"] = {"related_issues": [{
+        "key": "TC-9", "summary": "Existing", "labels": [],
+        "description": {}, "issuetype": "Sub-task",
+        # `comments` intentionally omitted
+    }]}
+
+    schema_path = os.path.join(
+        script_dir, "..", "schemas", "verify-pr-input.schema.json")
+    with open(schema_path) as f:
+        schema = json.load(f)
+
+    # When validating it against the input schema, Then it is rejected
+    try:
+        validate(instance=instance, schema=schema)
+        assert False, "schema accepted a related issue missing a required field"
+    except ValidationError as e:
+        assert "comments" in str(e), f"unexpected error: {e}"
+
+
 # --- stat production (pre-verify-pr.sh) ---
 
 pre_verify_sh = os.path.join(script_dir, "pre-verify-pr.sh")

--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -149,8 +149,30 @@ If the file validates against the schema:
   (checkout), Step 4a (review/comment fetches), Step 5a (diff/stat/commits), and
   Step 9's HEAD-SHA retrieval — using the bundle fields instead.
 
-If the file is missing or invalid, log a warning and fall back to Steps 1–3 and the
-direct GitHub reads (interactive behavior).
+If the validation above fails (file missing, not valid JSON, or not conforming to the
+schema), the handling depends on the mode:
+
+- **Sandbox mode (`FULLSEND_OUTPUT_DIR` is set):** do **not** fall back to Steps 1–3 or
+  the direct Jira/GitHub reads. The sandbox has no tokens, no `gh` CLI, and no network
+  egress, so a credentialed fallback cannot succeed — it would fail obscurely or hang.
+  Fail fast and loud instead: write a structured failure result and stop the skill
+  without performing any further steps or write operations.
+
+```bash
+cat > "$FULLSEND_OUTPUT_DIR/agent-result.json" << 'RESULT_EOF'
+{
+  "error": "verify-pr aborted: pre-fetched input (/sandbox/workspace/.pre-script/verify-pr-input.json) is missing, unparseable, or does not conform to verify-pr-input.schema.json. The pre_script must produce a valid input bundle before the sandbox runs; no credentialed fallback is possible inside the sandbox."
+}
+RESULT_EOF
+```
+
+  This result intentionally omits the `report` and `actions` keys required by
+  `verify-pr-result.schema.json`, so the runner's output validation rejects it and
+  surfaces the `error` message as a hard failure rather than silently attempting the
+  interactive path. **Stop execution here — do not run any subsequent step.**
+
+- **Interactive mode (`FULLSEND_OUTPUT_DIR` is unset):** log a warning and fall back to
+  Steps 1–3 and the direct GitHub reads (existing interactive behavior, unchanged).
 
 ## Inputs
 

--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -58,6 +58,75 @@ Before attempting any JIRA operations throughout this skill, determine the acces
 
 Refer to `shared/jira-rest-fallback.md` for complete implementation details.
 
+## Step 0.6 – Sandbox Mode Detection
+
+Check whether the `FULLSEND_OUTPUT_DIR` environment variable is set:
+
+```bash
+echo ${FULLSEND_OUTPUT_DIR:-not-set}
+```
+
+If **set**, this skill is running inside a fullsend sandbox (no Jira or GitHub
+tokens, no `gh` CLI, no network egress). Switch to **sandbox mode**:
+
+- Do NOT call Jira write APIs (`create_issue`, `add_comment`, `create_issue_link`,
+  `transition_issue`) directly.
+- Do NOT call GitHub read APIs (`gh pr view`/`gh pr diff`/`gh api`) — every PR read
+  is pre-fetched into `verify-pr-input.json` and the PR head is already checked out
+  (GitHub is tier-1; there is no `gh`/`GH_TOKEN` in the sandbox).
+- Do NOT post GitHub PR comments or replies directly.
+- Instead, accumulate every write operation as an action in an in-memory JSON
+  structure, and at the end of execution write the complete result to
+  `$FULLSEND_OUTPUT_DIR/agent-result.json` (see Step 9's **Sandbox Mode Output**).
+
+If **not set**, execute in **interactive mode** — the current behavior, calling Jira
+and GitHub APIs directly. Marketplace users are unaffected.
+
+Throughout the remaining steps, when you encounter a write operation:
+- **Interactive mode:** execute it directly (existing behavior).
+- **Sandbox mode:** append it to the actions array instead — each step below gives the
+  matching action shape.
+
+Initialize the accumulator as an in-memory JSON structure:
+
+```json
+{
+  "report": {},
+  "actions": []
+}
+```
+
+The `report` object and every action conform to
+`plugins/sdlc-workflow/schemas/verify-pr-result.schema.json`; the runner's
+`post_script` executes the accumulated actions after the sandbox exits.
+
+## Step 0.7 – Load Pre-Fetched Data (sandbox mode only)
+
+**Skip this step in interactive mode.**
+
+In sandbox mode the `pre_script` fetches all task and PR data on the trusted runner
+(where the tokens live) and mounts it read-only into the sandbox. Read it:
+
+```bash
+cat /sandbox/workspace/.pre-script/verify-pr-input.json | python3 -m json.tool > /dev/null 2>&1 && echo "Pre-fetched data available" || echo "ERROR: Pre-fetched data missing or invalid"
+```
+
+If the file exists and contains valid JSON (shape defined by
+`plugins/sdlc-workflow/schemas/verify-pr-input.schema.json`):
+
+- Read `task` (`summary`, `description` in the tracker's native ADF, `status`,
+  `labels`, `issue_links`, `custom_fields`) and `pr_url`. **Skip Step 1 (Fetch and
+  Parse Jira Task) and Step 2 (Identify PR)** — parse the task sections from
+  `task.description` and take the PR URL from `pr_url`.
+- Read the `github` bundle (`pr_repo`, `pr_number`, `headRefName`, `commit_sha`,
+  `diff`, `stat`, `reviews`, `review_comments`, `issue_comments`, `commits`) and use
+  the already-checked-out PR-head tree. **Skip every GitHub read step** — Step 3
+  (checkout), Step 4a (review/comment fetches), Step 5a (diff/stat/commits), and
+  Step 9's HEAD-SHA retrieval — using the bundle fields instead.
+
+If the file is missing or invalid, log a warning and fall back to Steps 1–3 and the
+direct GitHub reads (interactive behavior).
+
 ## Inputs
 
 The user will provide a Jira issue ID for a task that has an associated PR.
@@ -140,6 +209,10 @@ or not configured, ask the user to provide the PR URL.
 
 Extract the PR number and repository from the URL for use in subsequent `gh` commands.
 
+**Sandbox mode:** skip the custom-field read — take the PR URL from `pr_url` and the
+`owner/repo` + PR number from `github.pr_repo` / `github.pr_number` in the pre-fetched
+data (Step 0.7).
+
 ## Step 3 – Checkout PR Branch
 
 Ensure the PR branch is checked out locally so that subsequent steps inspect the correct code.
@@ -169,6 +242,10 @@ This step supports two use cases:
 - **Author self-verification** — the contributor already has the PR branch checked out; no checkout needed.
 - **Reviewer/CI audit** — another person or CI job runs `/verify-pr` from an arbitrary branch; the PR branch must be checked out first.
 
+**Sandbox mode:** skip this step entirely — the runner has already checked out the PR
+head tree (`github.headRefName` at `github.commit_sha`) and there is no `gh` CLI in
+the sandbox. Inspect the working tree directly.
+
 ## Step 4 – Classify Review Feedback
 
 Read PR review feedback and classify each comment thread for downstream processing
@@ -182,6 +259,10 @@ Fetch all reviews and review comments from the PR:
 gh api repos/<owner/repo>/pulls/<pr-number>/reviews
 gh api repos/<owner/repo>/pulls/<pr-number>/comments
 ```
+
+**Sandbox mode:** do not call `gh api` — use `github.reviews`, `github.review_comments`,
+and (for the enumeration below) `github.issue_comments` from the pre-fetched data
+(Step 0.7).
 
 Group inline comments into threads using the `in_reply_to_id` field. Each top-level
 comment (no `in_reply_to_id`) starts a thread; replies are grouped under their parent.
@@ -311,6 +392,10 @@ constructs dispatch envelopes following the structure defined in
 `plugins/sdlc-workflow/skills/verify-pr/dispatch-template.md`.
 
 ### Step 5a – Gather Dispatch Inputs
+
+**Sandbox mode:** do not run the `gh pr diff`/`gh pr view` commands below — the full
+diff, diffstat, and commits are pre-fetched as `github.diff`, `github.stat`, and
+`github.commits` (Step 0.7). Use those values as the corresponding dispatch inputs.
 
 Collect all inputs needed for sub-agent dispatch envelopes:
 
@@ -502,6 +587,35 @@ After creating each sub-task, create a "Blocks" issue link from the sub-task to 
 
 jira.create_issue_link(type="Blocks", inwardIssue=<sub-task-id>, outwardIssue=<parent-task-id>)
 
+**Sandbox mode:** Instead of calling `jira.create_issue` and `jira.create_issue_link`,
+append a `create_subtask` action and a `create_link` action. Use this pattern for **all**
+sub-task categories below (review feedback, CI failure, eval failure):
+
+```json
+{
+  "type": "create_subtask",
+  "ref": "subtask-N",
+  "parent": "<parent-task-id>",
+  "summary": "<summary>",
+  "labels": ["ai-generated-jira", "<category-label>"],
+  "description_adf": <pre-rendered ADF object>
+}
+```
+
+```json
+{
+  "type": "create_link",
+  "link_type": "Blocks",
+  "inward": "{{subtask-N.key}}",
+  "outward": "<parent-task-id>"
+}
+```
+
+Use incrementing refs (`subtask-1`, `subtask-2`, …). The `{{subtask-N.key}}` (and, in
+replies, `{{subtask-N.url}}`) placeholders are resolved by the `post_script` once the
+sub-task is created. Set `<category-label>` to `review-feedback` for review-feedback and
+CI-failure sub-tasks, or `eval-failure` for eval-failure sub-tasks.
+
 #### CI failure sub-tasks
 
 Process `create-sub-task` actions from the Correctness sub-agent. For each action:
@@ -528,6 +642,9 @@ Process `create-sub-task` actions from the Correctness sub-agent. For each actio
 
 3. **Create issue link:**
    jira.create_issue_link(type="Blocks", inwardIssue=<sub-task-id>, outwardIssue=<parent-task-id>)
+
+**Sandbox mode:** use the `create_subtask` + `create_link` pattern from the review
+feedback sandbox-mode block above, with labels `["ai-generated-jira", "review-feedback"]`.
 
 #### Eval failure sub-tasks
 
@@ -572,6 +689,9 @@ and sub-task creation below.
 
 4. **Create issue link:**
    jira.create_issue_link(type="Blocks", inwardIssue=<sub-task-id>, outwardIssue=<parent-task-id>)
+
+**Sandbox mode:** use the `create_subtask` + `create_link` pattern from the review
+feedback sandbox-mode block above, with labels `["ai-generated-jira", "eval-failure"]`.
 
 ### Step 6e – Reply to Review Comments
 
@@ -638,6 +758,31 @@ gh api repos/<owner/repo>/issues/<pr-number>/comments -f body="[sdlc-workflow/ve
 When a review body contains multiple classified suggestions (sub-identifiers), post
 a single standalone comment that lists all classifications together rather than one
 comment per sub-identifier.
+
+**Sandbox mode:** Instead of calling `gh api`, append one action per reply.
+
+For **inline comment threads** (they have a `comment_id`), use `post_pr_reply`:
+
+```json
+{
+  "type": "post_pr_reply",
+  "repo": "<owner/repo>",
+  "pr_number": <pr-number>,
+  "comment_id": <comment-id>,
+  "body": "<reply body; use {{subtask-N.key}} / {{subtask-N.url}} placeholders when referencing a created sub-task>"
+}
+```
+
+For **review body items** (no `comment_id`), use `post_pr_comment`:
+
+```json
+{
+  "type": "post_pr_comment",
+  "repo": "<owner/repo>",
+  "pr_number": <pr-number>,
+  "body": "<standalone comment body>"
+}
+```
 
 ### Step 6f – Idempotency Guarantees
 
@@ -864,6 +1009,29 @@ Link the root-cause task to the parent task:
 
 jira.create_issue_link(type="Relates", inwardIssue=<root-cause-task-id>, outwardIssue=<parent-task-id>)
 
+**Sandbox mode:** Instead of calling `jira.create_issue` and `jira.create_issue_link`,
+append a `create_root_cause_task` action and a `create_link` action (the schema's
+`link_type` enum uses `Related`, the equivalent of the interactive `Relates`):
+
+```json
+{
+  "type": "create_root_cause_task",
+  "ref": "rc-N",
+  "summary": "Root-cause: <description>",
+  "labels": ["ai-generated-jira", "root-cause"],
+  "description_adf": <pre-rendered ADF object>
+}
+```
+
+```json
+{
+  "type": "create_link",
+  "link_type": "Related",
+  "inward": "{{rc-N.key}}",
+  "outward": "<parent-task-id>"
+}
+```
+
 #### Action 2 – Post the root-cause analysis as a comment
 
 After creating the task, post a Jira comment on the newly created root-cause task
@@ -880,6 +1048,17 @@ The comment must include:
 
 Include the **Comment Footnote** at the end of the comment (see the Comment Footnote
 section at the top of this skill for the required ADF format).
+
+**Sandbox mode:** Instead of calling `jira.add_comment`, append a `post_comment` action
+targeting the not-yet-created root-cause task by its ref:
+
+```json
+{
+  "type": "post_comment",
+  "issue": "{{rc-N.key}}",
+  "body_adf": <pre-rendered ADF with the root-cause analysis and the Comment Footnote>
+}
+```
 
 ### Step 7c – Idempotency Check
 
@@ -966,6 +1145,9 @@ gh pr view <pr-number> --json commits --jq '.commits[-1].oid' -R <owner/repo>
 
 Store the full SHA and its short form (first 7 characters) for use in the report.
 
+**Sandbox mode:** do not call `gh pr view` — use `github.commit_sha` from the
+pre-fetched data (Step 0.7) as the full SHA.
+
 ### Post to GitHub PR
 
 The report comment is **scoped to the commit it verifies**. Posting is idempotent
@@ -1026,6 +1208,52 @@ Include the Comment Footnote at the end of the Jira comment.
 
 **Important:** This skill does NOT merge the PR and does NOT transition the Jira issue.
 The report is informational — a human reviewer decides whether to merge.
+
+### Sandbox Mode Output
+
+**Sandbox mode only:** Instead of posting to GitHub and Jira directly, populate the
+`report` object and append a single `post_report` action. The runner's `post_script`
+posts the GitHub PR comment (from `report_md`, applying the commit-scoped
+find-then-update-or-create path above) and the Jira comment (from `report_adf`) after
+the sandbox exits.
+
+Populate `report` (all fields required by
+`plugins/sdlc-workflow/schemas/verify-pr-result.schema.json`):
+
+```json
+{
+  "jira_issue_id": "<JIRA-ID>",
+  "pr_repo": "<owner/repo>",
+  "pr_number": <pr-number>,
+  "commit_sha": "<PR head commit SHA — github.commit_sha; 7–40 hex, canonicalized by the runner>",
+  "overall": "PASS|WARN|FAIL",
+  "table_md": "<the markdown verification table from Step 8>",
+  "report_md": "<full GitHub PR comment body: commit-scoped header + table + summary + markdown footnote>",
+  "report_adf": <full Jira comment ADF: report + Comment Footnote>,
+  "plugin_version": "<version from plugins/sdlc-workflow/.claude-plugin/plugin.json>"
+}
+```
+
+Append the final action:
+
+```json
+{ "type": "post_report" }
+```
+
+Write the complete accumulated JSON (the `report` object plus every action collected
+across Steps 6–9) to the output file:
+
+```bash
+cat > $FULLSEND_OUTPUT_DIR/agent-result.json << 'RESULT_EOF'
+<the complete { "report": {...}, "actions": [...] } JSON>
+RESULT_EOF
+```
+
+Verify it is valid JSON:
+
+```bash
+python3 -m json.tool $FULLSEND_OUTPUT_DIR/agent-result.json > /dev/null && echo "Output validated"
+```
 
 ## Important Rules
 

--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -107,12 +107,37 @@ The `report` object and every action conform to
 In sandbox mode the `pre_script` fetches all task and PR data on the trusted runner
 (where the tokens live) and mounts it read-only into the sandbox. Read it:
 
+Validate it against `plugins/sdlc-workflow/schemas/verify-pr-input.schema.json`
+before using it — a syntactically valid but structurally wrong or incomplete
+prefetch (e.g., missing the `github` bundle or `task` fields) must be treated as
+invalid rather than passing and failing deep inside a later step:
+
 ```bash
-cat /sandbox/workspace/.pre-script/verify-pr-input.json | python3 -m json.tool > /dev/null 2>&1 && echo "Pre-fetched data available" || echo "ERROR: Pre-fetched data missing or invalid"
+python3 - << 'PYEOF'
+import json, sys
+from jsonschema import validate, ValidationError
+
+INPUT = "/sandbox/workspace/.pre-script/verify-pr-input.json"
+SCHEMA = "plugins/sdlc-workflow/schemas/verify-pr-input.schema.json"
+try:
+    with open(INPUT) as f:
+        instance = json.load(f)
+    with open(SCHEMA) as f:
+        schema = json.load(f)
+    validate(instance=instance, schema=schema)
+    print("Pre-fetched data available")
+except FileNotFoundError:
+    print("ERROR: Pre-fetched data missing"); sys.exit(1)
+except json.JSONDecodeError as e:
+    print(f"ERROR: Pre-fetched data is not valid JSON: {e}"); sys.exit(1)
+except ValidationError as e:
+    path = ".".join(str(p) for p in e.path) or "<root>"
+    print(f"ERROR: Pre-fetched data failed schema validation at {path}: {e.message}")
+    sys.exit(1)
+PYEOF
 ```
 
-If the file exists and contains valid JSON (shape defined by
-`plugins/sdlc-workflow/schemas/verify-pr-input.schema.json`):
+If the file validates against the schema:
 
 - Read `task` (`summary`, `description` in the tracker's native ADF, `status`,
   `labels`, `issue_links`, `custom_fields`) and `pr_url`. **Skip Step 1 (Fetch and

--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -151,8 +151,12 @@ If the file validates against the schema:
 - Read the `idempotency.related_issues` array (each entry has `key`, `summary`,
   `labels`, `description`, `issuetype`, `comments`) — the task's existing sub-tasks
   and linked issues, prefetched on the runner. **Use it for every idempotency read**
-  (Steps 6d, 6f, 7c) instead of calling Jira; the sandbox has no token. The array is
-  empty when the task has no sub-tasks or linked issues yet.
+  (Steps 6d, 6f, 7c) instead of calling Jira; the sandbox has no token. The schema
+  **requires** `idempotency.related_issues`, so a prefetch that passes the Step 0.7
+  validation above always carries this array — it is an empty list (never absent)
+  when the task has no sub-tasks or linked issues yet. Treat a present-but-empty
+  array as "no known duplicates"; you never need to fall back to a Jira read for
+  the dedup checks.
 
 If the validation above fails (file missing, not valid JSON, or not conforming to the
 schema), the handling depends on the mode:

--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -148,6 +148,11 @@ If the file validates against the schema:
   the already-checked-out PR-head tree. **Skip every GitHub read step** — Step 3
   (checkout), Step 4a (review/comment fetches), Step 5a (diff/stat/commits), and
   Step 9's HEAD-SHA retrieval — using the bundle fields instead.
+- Read the `idempotency.related_issues` array (each entry has `key`, `summary`,
+  `labels`, `description`, `issuetype`, `comments`) — the task's existing sub-tasks
+  and linked issues, prefetched on the runner. **Use it for every idempotency read**
+  (Steps 6d, 6f, 7c) instead of calling Jira; the sandbox has no token. The array is
+  empty when the task has no sub-tasks or linked issues yet.
 
 If the validation above fails (file missing, not valid JSON, or not conforming to the
 schema), the handling depends on the mode:
@@ -670,7 +675,9 @@ Process `create-sub-task` actions from the Correctness sub-agent. For each actio
 1. **Idempotency check:** check the parent task's existing sub-tasks (issue links)
    for sub-tasks with labels `["ai-generated-jira", "review-feedback"]` whose
    descriptions reference the same CI check name or failure. If a matching sub-task
-   already exists, skip creation for that failure.
+   already exists, skip creation for that failure. **Sandbox mode:** read the
+   candidate sub-tasks from `idempotency.related_issues` (Step 0.7) — match on
+   `labels` and `description` — instead of a live Jira read.
 
 2. **Create sub-task:** create a Jira sub-task using the action's Title, Relevant
    files, and Root cause fields:
@@ -717,7 +724,9 @@ and sub-task creation below.
 2. **Idempotency check:** Check the parent task's existing sub-tasks (issue links)
    for sub-tasks with labels `["ai-generated-jira", "eval-failure"]` whose summaries
    reference the same eval ID. If a matching sub-task already exists, skip creation
-   for that eval.
+   for that eval. **Sandbox mode:** read the candidate sub-tasks from
+   `idempotency.related_issues` (Step 0.7) — match on `labels` and `summary` —
+   instead of a live Jira read.
 
 3. **Create sub-task:** For each failing eval, create a Jira sub-task:
 
@@ -857,6 +866,8 @@ check the parent task's issue links for existing sub-tasks whose descriptions
 reference the same review comment or review body. If a matching sub-task already
 exists, skip creation. This guards against edge cases where a classification reply
 was not posted (e.g., due to a network error) but the sub-task was created.
+**Sandbox mode:** read these existing sub-tasks from `idempotency.related_issues`
+(Step 0.7) — inspect each entry's `description` — instead of a live Jira read.
 
 Do **not** interpret this step as a top-level decision that can skip item
 enumeration. The enumeration in Step 4a is always mandatory; this step only
@@ -1114,6 +1125,11 @@ linked to the parent task. For each linked task with label `root-cause`, fetch i
 comments and search for a comment containing "Root-cause analysis from
 <PARENT-TASK-ID>". If a root-cause task already exists for the same phase and the
 same defect, skip creation.
+
+**Sandbox mode:** do not fetch comments from Jira. Read the linked tasks from
+`idempotency.related_issues` (Step 0.7), filter to entries whose `labels` include
+`root-cause`, and search each entry's `comments` for the "Root-cause analysis from
+<PARENT-TASK-ID>" marker.
 
 Record the Root-Cause Investigation result:
 - **N/A** — no sub-tasks were created in Step 6d (nothing to investigate)

--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -60,14 +60,29 @@ Refer to `shared/jira-rest-fallback.md` for complete implementation details.
 
 ## Step 0.6 – Sandbox Mode Detection
 
-Check whether the `FULLSEND_OUTPUT_DIR` environment variable is set:
+Detect whether the `FULLSEND_OUTPUT_DIR` environment variable is **present** in the
+environment (exported at all), independently of whether it holds a value. Use
+presence detection (`${VAR+x}`), not a default-value expansion (`${VAR:-...}`): the
+`:-` operator treats an exported-but-empty value the same as unset, which would send
+a runner that exported the gate with an empty value down the credentialed
+interactive path — the opposite of the intended tokenless behavior. An
+exported-but-empty value is a misconfiguration and must fail fast, not silently fall
+back:
 
 ```bash
-echo ${FULLSEND_OUTPUT_DIR:-not-set}
+if [ "${FULLSEND_OUTPUT_DIR+x}" = x ]; then
+  if [ -z "$FULLSEND_OUTPUT_DIR" ]; then
+    echo "ERROR: FULLSEND_OUTPUT_DIR is set but empty" >&2
+    exit 1
+  fi
+  echo "sandbox mode: $FULLSEND_OUTPUT_DIR"
+else
+  echo "interactive mode"
+fi
 ```
 
-If **set**, this skill is running inside a fullsend sandbox (no Jira or GitHub
-tokens, no `gh` CLI, no network egress). Switch to **sandbox mode**:
+If **present** (and non-empty), this skill is running inside a fullsend sandbox (no
+Jira or GitHub tokens, no `gh` CLI, no network egress). Switch to **sandbox mode**:
 
 - Do NOT call Jira write APIs (`create_issue`, `add_comment`, `create_issue_link`,
   `transition_issue`) directly.
@@ -79,8 +94,9 @@ tokens, no `gh` CLI, no network egress). Switch to **sandbox mode**:
   structure, and at the end of execution write the complete result to
   `$FULLSEND_OUTPUT_DIR/agent-result.json` (see Step 9's **Sandbox Mode Output**).
 
-If **not set**, execute in **interactive mode** — the current behavior, calling Jira
-and GitHub APIs directly. Marketplace users are unaffected.
+If **genuinely unset** (absent from the environment), execute in **interactive
+mode** — the current behavior, calling Jira and GitHub APIs directly. Marketplace
+users are unaffected.
 
 Throughout the remaining steps, when you encounter a write operation:
 - **Interactive mode:** execute it directly (existing behavior).


### PR DESCRIPTION
## Summary

Re-applies the sandbox dual-mode adaptation onto the current `verify-pr` `SKILL.md`, gated on the `FULLSEND_OUTPUT_DIR` environment variable. When the var is **unset** (marketplace/interactive users), behavior is unchanged. When **set** (fullsend sandbox), the skill runs without Jira/GitHub tokens: it reads pre-fetched task and PR data and accumulates every write as a structured action.

## Changes

Purely additive to `plugins/sdlc-workflow/skills/verify-pr/SKILL.md` (228 insertions, no deletions):

- **Step 0.6 – Sandbox Mode Detection** — detects `FULLSEND_OUTPUT_DIR`; in sandbox mode, no direct Jira writes / GitHub reads / PR comment posts, and initializes the `{ "report": {}, "actions": [] }` accumulator.
- **Step 0.7 – Load Pre-Fetched Data** — reads `/sandbox/workspace/.pre-script/verify-pr-input.json` (the TC-5810 prefetch contract), skips Steps 1–3 and all GitHub reads, with a fallback to direct APIs if the file is missing/invalid.
- **Inline sandbox-mode notes** on each read/write step (Steps 2, 3, 4a, 5a, 6d, 6e, 7b, 9).
- **Step 9 – Sandbox Mode Output** — populates the `report` object, appends a `post_report` action, and writes the complete result to `$FULLSEND_OUTPUT_DIR/agent-result.json`.

## Contract alignment

Every emitted action `type` matches the `verify-pr-result.schema.json` enum: `create_subtask`, `create_link`, `post_pr_reply`, `post_pr_comment`, `create_root_cause_task`, `post_comment`, `post_report`. `link_type` values use the schema's `Blocks`/`Related` enum.

## Verification

- `uvx skillsaw` — 0 errors (Grade A); context-budget finding is warn-level (non-blocking; CI strict mode disabled).
- `claude plugin validate plugins/sdlc-workflow` — validation passed.
- No `scripts/` changes → pytest not required.
- Interactive path unchanged (all changes gated on `FULLSEND_OUTPUT_DIR`).

Implements [TC-5812](https://redhat.atlassian.net/browse/TC-5812)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review feedback fixes (Sourcery-ai on PR #286)

Four follow-up sub-tasks address review comments on this PR:

- **TC-5980** — Step 0.7 now validates the prefetched `verify-pr-input.json` against `verify-pr-input.schema.json` (jsonschema), not just JSON syntax; malformed-but-parseable input is rejected.
- **TC-5981** — On bad/missing prefetch input, sandbox mode fails fast: it writes an `{"error": ...}` result (no credentialed fallback is possible tokenless) so the runner's output validation surfaces it as a hard failure. Interactive mode keeps warn-and-fall-back.
- **TC-5982** — Idempotency checks (Steps 6d/6f/7c) now run tokenlessly in the sandbox: `pre-verify-pr.sh` prefetches related-issue metadata (summary, labels, description, issuetype, comments) into `verify-pr-input.json` under a new optional `idempotency` key.
- **TC-5983** — `execute_post_report` now posts the Jira comment from `report_adf` (via `adf_to_markdown`), matching Step 9's contract; GitHub still gets `report_md` + its commit marker.
- **TC-6026** — Reconcile the optional `idempotency` bundle: the schema now **requires** `idempotency.related_issues`, so Step 0.7 rejects a prefetch omitting it *before* the tokenless Steps 6d/6f/7c dedup checks run (fail-fast, per TC-5980/TC-5981). `pre_verify_pr.py` always emits the bundle (empty list when the task has no relations); SKILL.md states the always-present invariant.
- **TC-6032** — Tighten the idempotency contract at the item level: `idempotency.related_issues.items` now **requires** the six fields the dedup checks consume (`key`, `summary`, `labels`, `description`, `issuetype`, `comments`), so a structurally incomplete prefetched entry fails Step 0.7 instead of being silently treated as non-matching. `build_idempotency_bundle` already emits all six; a test asserts an incomplete entry raises `ValidationError`.
- **TC-6033** — Step 0.6 now uses presence detection (`${FULLSEND_OUTPUT_DIR+x}`) and fails fast on an exported-but-empty value, instead of `${FULLSEND_OUTPUT_DIR:-not-set}` which treated exported-but-empty as unset and fell back to the credentialed interactive path despite the sandbox gate being present.

Verification: `python3 -m pytest plugins/sdlc-workflow/scripts/ -q` (109 passed), `uvx skillsaw` (0 errors, Grade A), `claude plugin validate plugins/sdlc-workflow` (passed).

## Summary by Sourcery

Enable verify-pr to run safely in tokenless sandboxes while retaining the existing interactive workflow.

New Features:
- Add sandbox execution for verify-pr that consumes validated pre-fetched task and GitHub data and emits structured actions and reports without Jira or GitHub credentials.

Bug Fixes:
- Fail fast on missing or invalid sandbox input instead of attempting an unavailable credentialed fallback.
- Preserve tokenless idempotency checks by requiring and prefetching related-issue metadata.
- Send Jira report comments from tracker-native report content rather than GitHub-specific markdown and commit markers.

Enhancements:
- Align sandbox actions, link types, and report output with the verify-pr result schema while preserving interactive behavior.

Documentation:
- Document sandbox detection, prefetch validation, tokenless processing, structured actions, and result output for verify-pr.

Tests:
- Expand coverage for related-issue prefetching, schema validation, sandbox idempotency data, and tracker-specific report posting.
