### PR TITLE
fix(implement-task): require module-level tests before committing for Rust repos

### DIFF
--- a/evals/implement-task/evals.json
+++ b/evals/implement-task/evals.json
@@ -16,7 +16,8 @@
         "The plan references creating a branch named TC-9201 or notes the branch naming convention (constraint 3.1), and references the Target Branch value from the task description",
         "The conventions analysis identifies at least 2 patterns from sibling code: error handling with Result<T, AppError> and .context(), and the model/service/endpoints module structure",
         "The plan extracts and references the Target Branch section from the task description, identifying 'main' as the target branch",
-        "The plan mentions checking for a description digest comment (Step 1.5) and notes that when no digest is found, it proceeds with a warning rather than blocking execution (backward compatibility per shared/description-digest-protocol.md)"
+        "The plan mentions checking for a description digest comment (Step 1.5) and notes that when no digest is found, it proceeds with a warning rather than blocking execution (backward compatibility per shared/description-digest-protocol.md)",
+        "The plan describes using `cargo metadata --no-deps --format-version 1` (or cargo metadata) to resolve the crate name for the affected module before running module-level tests — not deriving it from the nearest `Cargo.toml`, which may be a virtual workspace manifest"
       ]
     },
     {

--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -738,6 +738,33 @@ running the project's standard build or lint step (if one exists) and compare th
 warning output against the pre-implementation baseline captured during Step 7. If
 new warnings were introduced, fix them before proceeding.
 
+### Module-level test requirement (Rust)
+
+For Rust repositories, run the test suite for every crate containing modified files,
+regardless of whether `CONVENTIONS.md` CI checks include a test command. Lint, fmt,
+and `cargo check` pass even when test logic is broken — a separate test run is required
+before committing.
+
+For each modified file, determine its containing crate from the nearest `Cargo.toml`.
+Run:
+
+```
+cargo test -p <crate-name>
+```
+
+or, if the project uses nextest:
+
+```
+cargo nextest run -p <crate-name>
+```
+
+Apply the same hard-stop rule: if the test command exits non-zero, stop immediately,
+report the failure, and do not proceed to Step 10.
+
+> **Note:** If the test context requires a database or external service, attempt the
+> run first — many Rust projects bootstrap their own test DB. Only skip if the
+> environment is genuinely unavailable, and report clearly that tests were not run.
+
 ### Data-flow trace
 
 For each new feature, trace data through its complete lifecycle: input (API request,

--- a/plugins/sdlc-workflow/skills/implement-task/SKILL.md
+++ b/plugins/sdlc-workflow/skills/implement-task/SKILL.md
@@ -745,7 +745,7 @@ regardless of whether `CONVENTIONS.md` CI checks include a test command. Lint, f
 and `cargo check` pass even when test logic is broken — a separate test run is required
 before committing.
 
-For each modified file, determine its containing crate from the nearest `Cargo.toml`.
+For each modified file, run `cargo metadata --no-deps --format-version 1` from the workspace root and resolve the package whose manifest or target source contains the file. Use that package's `name` as `<crate-name>`; do not derive it from the nearest `Cargo.toml`, which may be a virtual workspace manifest. Skip modified files that do not belong to any package or crate.
 Run:
 
 ```


### PR DESCRIPTION
## Summary

- Add **Step 9: Module-level test requirement (Rust)** sub-section to implement-task SKILL.md
- Requires running `cargo test -p <crate-name>` (or nextest) for every crate containing modified files, regardless of whether CONVENTIONS.md CI checks include a test command
- Applies the same hard-stop rule as other CI checks — non-zero exit stops execution before commit
- Fix crate resolution: use `cargo metadata --no-deps --format-version 1` instead of nearest `Cargo.toml` to correctly handle virtual workspace manifests (TC-6084)
- Add eval-1 assertion covering the `cargo metadata` crate resolution pattern

## Context

`cargo xtask precommit` (the CI check extracted from trustify's CONVENTIONS.md) runs clippy, fmt, and `cargo check` — but not `cargo test`. Logic bugs pass all three. TC-5996 introduced 3 bugs that would have been caught by running `cargo test -p trustify-module-fundamental` locally.

## Related

- Implements [TC-6073](https://redhat.atlassian.net/browse/TC-6073)
- Implements [TC-6084](https://redhat.atlassian.net/browse/TC-6084)
- Follow-up: [TC-6083](https://redhat.atlassian.net/browse/TC-6083) — update trustify CONVENTIONS.md to list the test command