### PR TITLE
fix(verify-pr): stop post_script writing __pycache__ into fullsend cache tree

### DIFF
--- a/.fullsend/harness/verify-pr.yaml
+++ b/.fullsend/harness/verify-pr.yaml
@@ -27,7 +27,7 @@
 # (base URLs are validated against that allowlist, not inherited).
 # Re-pin after any base edit: push harness/verify-pr.yaml, set the SHA to the new
 # commit + the sha256 to `shasum -a 256 harness/verify-pr.yaml`, `fullsend lock`.
-base: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/430a29c86bfbc601370a32251a555c9d17af6bcb/harness/verify-pr.yaml#sha256=addc868659a4391b18fe09cb2a0523d134a9242e35d644a6db36bcce8277cb16
+base: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/harness/verify-pr.yaml#sha256=d8ebedc8978b1ea2df938110eaef20c669319786c4db2e45faf6c9040e3ebb95
 
 host_files:
   - src: ${GOOGLE_APPLICATION_CREDENTIALS}

--- a/.fullsend/lock.yaml
+++ b/.fullsend/lock.yaml
@@ -4,21 +4,21 @@ generated_at: 2026-09-04T13:39:01.038924Z
 harnesses:
     verify-pr:
         source: harness/verify-pr.yaml
-        sha256: 1d5889ef6f71dae2523db790bd848af6a8353ad739499a4ae583b264bae1c8d2
-        resolved_at: 2026-09-08T13:11:05.215335Z
+        sha256: 272f21acb6e5c73ea5bdfe301ba39b8f5ae0122da8a354f33fe42f293c3318c6
+        resolved_at: 2026-09-09T08:40:35.251104Z
         dependencies:
             - field: base
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/430a29c86bfbc601370a32251a555c9d17af6bcb/harness/verify-pr.yaml
-              sha256: addc868659a4391b18fe09cb2a0523d134a9242e35d644a6db36bcce8277cb16
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/harness/verify-pr.yaml
+              sha256: d8ebedc8978b1ea2df938110eaef20c669319786c4db2e45faf6c9040e3ebb95
               type: file
-              fetched_at: 2026-09-08T13:10:57.161392Z
+              fetched_at: 2026-09-09T08:40:27.050053Z
             - field: pre_script
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/430a29c86bfbc601370a32251a555c9d17af6bcb/plugins/sdlc-workflow/scripts/pre-verify-pr.sh
-              sha256: 4f5d1bfea092559de8f44469a32cd636949d01c5a029f0782c94187057d11f33
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/plugins/sdlc-workflow/scripts/pre-verify-pr.sh
+              sha256: 6ff7f8857ce1bf53da7e82d1d756491bd3cc9aa0c4260c9b03a0aea588e3f051
               type: directory
               files:
                 - path: execute-actions.py
-                  sha256: 6df3bc2598a891868ac3a02f3265b7036c9d4b6d1fdb6394ca619fe89946c520
+                  sha256: 595220e3cac4426acaecfda17e9c7b73532cd9bf59a453c4093dc8e9a57a0936
                 - path: jira-client.py
                   sha256: f6bf79d2c98a2ae020775e68a538f612953c0464f09bd750c988f0d20fd4b159
                 - path: post-verify-pr.sh
@@ -39,14 +39,14 @@ harnesses:
                   sha256: c7ae30979613fa3402de4450c9bb4faf5f011decac79b75a36ba2ef51e4d21aa
                 - path: validate-output-schema.sh
                   sha256: 56b964145da0b62f438dbc1885780d86e2d589c5340adb93c00e3c8777979cbe
-              fetched_at: 2026-09-08T13:11:00.144348Z
+              fetched_at: 2026-09-09T08:40:29.851598Z
             - field: post_script
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/430a29c86bfbc601370a32251a555c9d17af6bcb/plugins/sdlc-workflow/scripts/post-verify-pr.sh
-              sha256: 4f5d1bfea092559de8f44469a32cd636949d01c5a029f0782c94187057d11f33
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/plugins/sdlc-workflow/scripts/post-verify-pr.sh
+              sha256: 6ff7f8857ce1bf53da7e82d1d756491bd3cc9aa0c4260c9b03a0aea588e3f051
               type: directory
               files:
                 - path: execute-actions.py
-                  sha256: 6df3bc2598a891868ac3a02f3265b7036c9d4b6d1fdb6394ca619fe89946c520
+                  sha256: 595220e3cac4426acaecfda17e9c7b73532cd9bf59a453c4093dc8e9a57a0936
                 - path: jira-client.py
                   sha256: f6bf79d2c98a2ae020775e68a538f612953c0464f09bd750c988f0d20fd4b159
                 - path: post-verify-pr.sh
@@ -67,14 +67,14 @@ harnesses:
                   sha256: c7ae30979613fa3402de4450c9bb4faf5f011decac79b75a36ba2ef51e4d21aa
                 - path: validate-output-schema.sh
                   sha256: 56b964145da0b62f438dbc1885780d86e2d589c5340adb93c00e3c8777979cbe
-              fetched_at: 2026-09-08T13:11:00.138536Z
+              fetched_at: 2026-09-09T08:40:29.845646Z
             - field: validation_loop.script
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/430a29c86bfbc601370a32251a555c9d17af6bcb/plugins/sdlc-workflow/scripts/validate-output-schema.sh
-              sha256: 4f5d1bfea092559de8f44469a32cd636949d01c5a029f0782c94187057d11f33
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/plugins/sdlc-workflow/scripts/validate-output-schema.sh
+              sha256: 6ff7f8857ce1bf53da7e82d1d756491bd3cc9aa0c4260c9b03a0aea588e3f051
               type: directory
               files:
                 - path: execute-actions.py
-                  sha256: 6df3bc2598a891868ac3a02f3265b7036c9d4b6d1fdb6394ca619fe89946c520
+                  sha256: 595220e3cac4426acaecfda17e9c7b73532cd9bf59a453c4093dc8e9a57a0936
                 - path: jira-client.py
                   sha256: f6bf79d2c98a2ae020775e68a538f612953c0464f09bd750c988f0d20fd4b159
                 - path: post-verify-pr.sh
@@ -95,40 +95,40 @@ harnesses:
                   sha256: c7ae30979613fa3402de4450c9bb4faf5f011decac79b75a36ba2ef51e4d21aa
                 - path: validate-output-schema.sh
                   sha256: 56b964145da0b62f438dbc1885780d86e2d589c5340adb93c00e3c8777979cbe
-              fetched_at: 2026-09-08T13:11:00.138536Z
+              fetched_at: 2026-09-09T08:40:29.845646Z
             - field: validation_loop.schema
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/430a29c86bfbc601370a32251a555c9d17af6bcb/plugins/sdlc-workflow/schemas/verify-pr-result.schema.json
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/plugins/sdlc-workflow/schemas/verify-pr-result.schema.json
               sha256: 62c3e5ce0c47e73823b5cab9a577be7b721d8fb31389bc8602dc82ee05526ad6
               type: resource
-              fetched_at: 2026-09-08T13:11:00.630765Z
+              fetched_at: 2026-09-09T08:40:30.10887Z
             - field: agent
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/430a29c86bfbc601370a32251a555c9d17af6bcb/plugins/sdlc-workflow/agents/verify-pr.md
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/plugins/sdlc-workflow/agents/verify-pr.md
               sha256: 568b2ab7e32300c84038d500d95f4534ff6c4b20e52eebf2ed5a6c0ae706786a
               type: resource
-              fetched_at: 2026-09-08T13:11:00.883248Z
+              fetched_at: 2026-09-09T08:40:30.353891Z
             - field: policy
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/430a29c86bfbc601370a32251a555c9d17af6bcb/plugins/sdlc-workflow/policies/verify-pr.yaml
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/plugins/sdlc-workflow/policies/verify-pr.yaml
               sha256: 62d1374be253b0b225921bd8e22e679781076ecdb3a9ea22d5e6a4805753c5a7
               type: resource
-              fetched_at: 2026-09-08T13:11:01.150243Z
+              fetched_at: 2026-09-09T08:40:30.598631Z
             - field: host_files[0].src
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/430a29c86bfbc601370a32251a555c9d17af6bcb/plugins/sdlc-workflow/env/gcp-vertex.env
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/plugins/sdlc-workflow/env/gcp-vertex.env
               sha256: 10b2ba695b1d4e65e0964a233b75d6a06853f1eaefc260c56b9eedd989ae7d41
               type: resource
-              fetched_at: 2026-09-08T13:11:01.447018Z
+              fetched_at: 2026-09-09T08:40:31.177742Z
             - field: openshell.profiles[0]
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/430a29c86bfbc601370a32251a555c9d17af6bcb/plugins/sdlc-workflow/profiles/fullsend-vertex-ai.yaml
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/plugins/sdlc-workflow/profiles/fullsend-vertex-ai.yaml
               sha256: 76535a148387b1281be2bfb23b6724e4133327189b38c8ce1de2c6dddb8d8341
               type: resource
-              fetched_at: 2026-09-08T13:11:01.712662Z
+              fetched_at: 2026-09-09T08:40:32.276039Z
             - field: providers[0]
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/430a29c86bfbc601370a32251a555c9d17af6bcb/plugins/sdlc-workflow/providers/vertex-ai.yaml
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/plugins/sdlc-workflow/providers/vertex-ai.yaml
               sha256: ae5ebe527e5d7b0fa6994346fde3f6ba11b632a3ba78ece96591b5ed85083ec1
               type: resource
-              fetched_at: 2026-09-08T13:11:02.357982Z
+              fetched_at: 2026-09-09T08:40:32.590801Z
             - field: plugins[0]
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/430a29c86bfbc601370a32251a555c9d17af6bcb/plugins/sdlc-workflow/plugin.json
-              sha256: 5234e62de3143c5b549f90111888f4d34d290daf7f37c61f40646e269a9daa33
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/plugins/sdlc-workflow/plugin.json
+              sha256: f9c78da59d809dd1f784b9d552d552f4e0395495852e179854b8203c2e2ee46f
               type: directory
               files:
                 - path: .claude-plugin/plugin.json
@@ -150,7 +150,7 @@ harnesses:
                 - path: schemas/verify-pr-result.schema.json
                   sha256: 62c3e5ce0c47e73823b5cab9a577be7b721d8fb31389bc8602dc82ee05526ad6
                 - path: scripts/execute-actions.py
-                  sha256: 6df3bc2598a891868ac3a02f3265b7036c9d4b6d1fdb6394ca619fe89946c520
+                  sha256: 595220e3cac4426acaecfda17e9c7b73532cd9bf59a453c4093dc8e9a57a0936
                 - path: scripts/jira-client.py
                   sha256: f6bf79d2c98a2ae020775e68a538f612953c0464f09bd750c988f0d20fd4b159
                 - path: scripts/post-verify-pr.sh
@@ -237,4 +237,4 @@ harnesses:
                   sha256: 128877cf7e156666dbb403805a0112059cc8cc3255e148c6794da29d48b8f5cf
                 - path: skills/verify-pr/style-conventions.md
                   sha256: 5ab920c596615c0d23354cb0e90fe5ebf5f08635ffa3602e8e2d2abd74028a19
-              fetched_at: 2026-09-08T13:11:05.210442Z
+              fetched_at: 2026-09-09T08:40:35.249442Z

--- a/harness/verify-pr.yaml
+++ b/harness/verify-pr.yaml
@@ -79,6 +79,12 @@ env:
   # prefetch and post_script writes need them; they are never placed in
   # env.sandbox.
   runner:
+    # Disable Python bytecode writes for every runner-side Python invocation.
+    # The pre/post scripts execute in place inside fullsend's content-addressed
+    # cache tree; a stray __pycache__/*.pyc written there mutates the tree and
+    # trips fullsend's next-run integrity check. Defense in depth alongside
+    # execute-actions.py's own sys.dont_write_bytecode (TC-6112).
+    PYTHONDONTWRITEBYTECODE: "1"
     JIRA_ISSUE_ID: "${JIRA_ISSUE_ID}"
     JIRA_SERVER_URL: "${JIRA_SERVER_URL}"
     JIRA_EMAIL: "${JIRA_EMAIL}"

--- a/plugins/sdlc-workflow/scripts/execute-actions.py
+++ b/plugins/sdlc-workflow/scripts/execute-actions.py
@@ -45,6 +45,13 @@ _spec = importlib.util.spec_from_file_location(
     "jira_client", os.path.join(_script_dir, "jira-client.py")
 )
 _jira_mod = importlib.util.module_from_spec(_spec)
+# fullsend executes this script in place inside its content-addressed cache tree.
+# SourceFileLoader.exec_module writes __pycache__/*.pyc next to the source, which
+# mutates that tree and breaks fullsend's next-run integrity check ("cache
+# integrity check failed"). Disable bytecode writes before loading the sibling
+# module so nothing is written into the cache tree (TC-6112). The harness also
+# sets PYTHONDONTWRITEBYTECODE for defense in depth.
+sys.dont_write_bytecode = True
 _spec.loader.exec_module(_jira_mod)
 
 REF_PATTERN = re.compile(r"\{\{([a-z0-9-]+)\.(key|url)\}\}")


### PR DESCRIPTION
## Summary

Every `fullsend run verify-pr` corrupted fullsend's content-addressed script cache, so the *next* run failed at harness load with `cache integrity check failed: expected <hash-A>, got <hash-B>`.

**Root cause:** fullsend fetches the pre/post script directory into its content-addressed cache tree and executes the scripts in place. `execute-actions.py` loads its sibling `jira-client.py` via `importlib` `exec_module`, and Python's `SourceFileLoader` writes `__pycache__/jira_client.*.pyc` next to the source — into the cache tree. The next-run integrity walk then recomputes a different tree hash and fails.

**Fix (defense in depth, two layers):**
- `execute-actions.py` sets `sys.dont_write_bytecode = True` immediately before the `exec_module` call (the exact write vector).
- `harness/verify-pr.yaml` adds `PYTHONDONTWRITEBYTECODE: "1"` to `env.runner` so every runner-side Python invocation from the cache tree is inert.

Re-pin + re-lock (`.fullsend/harness/verify-pr.yaml` base → `c67f6911`, `.fullsend/lock.yaml`) are included in the same PR per the release loop.

## Verification
- `python3 -m pytest plugins/sdlc-workflow/scripts/ -q` → 117 passed (incl. `test_execute_actions.py`).
- Reproduction: running `execute-actions.py` as a script (as the post_script does) triggers the `exec_module` vector and writes **no** `__pycache__/*.pyc`.
- `claude plugin validate plugins/sdlc-workflow` → passed.

Implements [TC-6112](https://redhat.atlassian.net/browse/TC-6112)

## Summary by Sourcery

Prevent verify-pr script execution from corrupting the fullsend cache and causing subsequent cache integrity failures.

Bug Fixes:
- Prevent verify-pr executions from modifying the content-addressed script cache with Python bytecode files, avoiding integrity failures on subsequent runs.

Enhancements:
- Add runner-wide protection against Python bytecode generation and update the verify-pr harness pins and lockfile to the corrected sources.