### PR TITLE
fix(verify-pr): condense SKILL.md under Skillsaw 16k context budget (TC-6137)

### DIFF
--- a/.fullsend/harness/verify-pr.yaml
+++ b/.fullsend/harness/verify-pr.yaml
@@ -27,7 +27,7 @@
 # (base URLs are validated against that allowlist, not inherited).
 # Re-pin after any base edit: push harness/verify-pr.yaml, set the SHA to the new
 # commit + the sha256 to `shasum -a 256 harness/verify-pr.yaml`, `fullsend lock`.
-base: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/harness/verify-pr.yaml#sha256=d8ebedc8978b1ea2df938110eaef20c669319786c4db2e45faf6c9040e3ebb95
+base: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/6572360e3e6cae77a364ed25324e54f67bb77549/harness/verify-pr.yaml#sha256=d8ebedc8978b1ea2df938110eaef20c669319786c4db2e45faf6c9040e3ebb95
 
 host_files:
   - src: ${GOOGLE_APPLICATION_CREDENTIALS}

--- a/.fullsend/lock.yaml
+++ b/.fullsend/lock.yaml
@@ -4,16 +4,16 @@ generated_at: 2026-09-04T13:39:01.038924Z
 harnesses:
     verify-pr:
         source: harness/verify-pr.yaml
-        sha256: 272f21acb6e5c73ea5bdfe301ba39b8f5ae0122da8a354f33fe42f293c3318c6
-        resolved_at: 2026-09-09T08:40:35.251104Z
+        sha256: 207fc58e6400ec27557408256812c62e32326268c88e4592b96633406cf5bb3b
+        resolved_at: 2026-09-09T09:27:45.849411Z
         dependencies:
             - field: base
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/harness/verify-pr.yaml
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/6572360e3e6cae77a364ed25324e54f67bb77549/harness/verify-pr.yaml
               sha256: d8ebedc8978b1ea2df938110eaef20c669319786c4db2e45faf6c9040e3ebb95
               type: file
-              fetched_at: 2026-09-09T08:40:27.050053Z
+              fetched_at: 2026-09-09T09:27:38.211305Z
             - field: pre_script
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/plugins/sdlc-workflow/scripts/pre-verify-pr.sh
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/6572360e3e6cae77a364ed25324e54f67bb77549/plugins/sdlc-workflow/scripts/pre-verify-pr.sh
               sha256: 6ff7f8857ce1bf53da7e82d1d756491bd3cc9aa0c4260c9b03a0aea588e3f051
               type: directory
               files:
@@ -39,9 +39,9 @@ harnesses:
                   sha256: c7ae30979613fa3402de4450c9bb4faf5f011decac79b75a36ba2ef51e4d21aa
                 - path: validate-output-schema.sh
                   sha256: 56b964145da0b62f438dbc1885780d86e2d589c5340adb93c00e3c8777979cbe
-              fetched_at: 2026-09-09T08:40:29.851598Z
+              fetched_at: 2026-09-09T09:27:40.840298Z
             - field: post_script
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/plugins/sdlc-workflow/scripts/post-verify-pr.sh
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/6572360e3e6cae77a364ed25324e54f67bb77549/plugins/sdlc-workflow/scripts/post-verify-pr.sh
               sha256: 6ff7f8857ce1bf53da7e82d1d756491bd3cc9aa0c4260c9b03a0aea588e3f051
               type: directory
               files:
@@ -67,9 +67,9 @@ harnesses:
                   sha256: c7ae30979613fa3402de4450c9bb4faf5f011decac79b75a36ba2ef51e4d21aa
                 - path: validate-output-schema.sh
                   sha256: 56b964145da0b62f438dbc1885780d86e2d589c5340adb93c00e3c8777979cbe
-              fetched_at: 2026-09-09T08:40:29.845646Z
+              fetched_at: 2026-09-09T09:27:40.835254Z
             - field: validation_loop.script
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/plugins/sdlc-workflow/scripts/validate-output-schema.sh
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/6572360e3e6cae77a364ed25324e54f67bb77549/plugins/sdlc-workflow/scripts/validate-output-schema.sh
               sha256: 6ff7f8857ce1bf53da7e82d1d756491bd3cc9aa0c4260c9b03a0aea588e3f051
               type: directory
               files:
@@ -95,40 +95,40 @@ harnesses:
                   sha256: c7ae30979613fa3402de4450c9bb4faf5f011decac79b75a36ba2ef51e4d21aa
                 - path: validate-output-schema.sh
                   sha256: 56b964145da0b62f438dbc1885780d86e2d589c5340adb93c00e3c8777979cbe
-              fetched_at: 2026-09-09T08:40:29.845646Z
+              fetched_at: 2026-09-09T09:27:40.835254Z
             - field: validation_loop.schema
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/plugins/sdlc-workflow/schemas/verify-pr-result.schema.json
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/6572360e3e6cae77a364ed25324e54f67bb77549/plugins/sdlc-workflow/schemas/verify-pr-result.schema.json
               sha256: 62c3e5ce0c47e73823b5cab9a577be7b721d8fb31389bc8602dc82ee05526ad6
               type: resource
-              fetched_at: 2026-09-09T08:40:30.10887Z
+              fetched_at: 2026-09-09T09:27:41.115962Z
             - field: agent
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/plugins/sdlc-workflow/agents/verify-pr.md
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/6572360e3e6cae77a364ed25324e54f67bb77549/plugins/sdlc-workflow/agents/verify-pr.md
               sha256: 568b2ab7e32300c84038d500d95f4534ff6c4b20e52eebf2ed5a6c0ae706786a
               type: resource
-              fetched_at: 2026-09-09T08:40:30.353891Z
+              fetched_at: 2026-09-09T09:27:41.376898Z
             - field: policy
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/plugins/sdlc-workflow/policies/verify-pr.yaml
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/6572360e3e6cae77a364ed25324e54f67bb77549/plugins/sdlc-workflow/policies/verify-pr.yaml
               sha256: 62d1374be253b0b225921bd8e22e679781076ecdb3a9ea22d5e6a4805753c5a7
               type: resource
-              fetched_at: 2026-09-09T08:40:30.598631Z
+              fetched_at: 2026-09-09T09:27:41.635183Z
             - field: host_files[0].src
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/plugins/sdlc-workflow/env/gcp-vertex.env
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/6572360e3e6cae77a364ed25324e54f67bb77549/plugins/sdlc-workflow/env/gcp-vertex.env
               sha256: 10b2ba695b1d4e65e0964a233b75d6a06853f1eaefc260c56b9eedd989ae7d41
               type: resource
-              fetched_at: 2026-09-09T08:40:31.177742Z
+              fetched_at: 2026-09-09T09:27:41.940158Z
             - field: openshell.profiles[0]
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/plugins/sdlc-workflow/profiles/fullsend-vertex-ai.yaml
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/6572360e3e6cae77a364ed25324e54f67bb77549/plugins/sdlc-workflow/profiles/fullsend-vertex-ai.yaml
               sha256: 76535a148387b1281be2bfb23b6724e4133327189b38c8ce1de2c6dddb8d8341
               type: resource
-              fetched_at: 2026-09-09T08:40:32.276039Z
+              fetched_at: 2026-09-09T09:27:42.896365Z
             - field: providers[0]
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/plugins/sdlc-workflow/providers/vertex-ai.yaml
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/6572360e3e6cae77a364ed25324e54f67bb77549/plugins/sdlc-workflow/providers/vertex-ai.yaml
               sha256: ae5ebe527e5d7b0fa6994346fde3f6ba11b632a3ba78ece96591b5ed85083ec1
               type: resource
-              fetched_at: 2026-09-09T08:40:32.590801Z
+              fetched_at: 2026-09-09T09:27:43.142989Z
             - field: plugins[0]
-              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/c67f6911d66f4b5624d4a28b79339a0900a71024/plugins/sdlc-workflow/plugin.json
-              sha256: f9c78da59d809dd1f784b9d552d552f4e0395495852e179854b8203c2e2ee46f
+              url: https://raw.githubusercontent.com/RHEcosystemAppEng/sdlc-plugins/6572360e3e6cae77a364ed25324e54f67bb77549/plugins/sdlc-workflow/plugin.json
+              sha256: 98a51c5a11414149208afe0becb049c726eb7dc727ff91eb52080f4328283c43
               type: directory
               files:
                 - path: .claude-plugin/plugin.json
@@ -224,7 +224,7 @@ harnesses:
                 - path: skills/triage-security/version-impact-analysis.md
                   sha256: a18376094360d435e96436c9fd1bd6a04831123d903e44cf6cf57e600285e3c9
                 - path: skills/verify-pr/SKILL.md
-                  sha256: 94a6c1898b31832007d929d131fdebb5b542bcb382a428f12a9b7b947ee2708e
+                  sha256: 9aa4d0f9f59d1b9d3bd7683a82fd2c700208cce505b90f3802b85ed2c5e3cdfc
                 - path: skills/verify-pr/correctness.md
                   sha256: 44a4c095038d41434b5e658dfd209970a77c1c0417bc2c00548ce1f85abdbade
                 - path: skills/verify-pr/dispatch-template.md
@@ -237,4 +237,4 @@ harnesses:
                   sha256: 128877cf7e156666dbb403805a0112059cc8cc3255e148c6794da29d48b8f5cf
                 - path: skills/verify-pr/style-conventions.md
                   sha256: 5ab920c596615c0d23354cb0e90fe5ebf5f08635ffa3602e8e2d2abd74028a19
-              fetched_at: 2026-09-09T08:40:35.249442Z
+              fetched_at: 2026-09-09T09:27:45.847868Z

--- a/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
+++ b/plugins/sdlc-workflow/skills/verify-pr/SKILL.md
@@ -11,30 +11,25 @@ You are an AI verification assistant that orchestrates PR verification through p
 
 ## Resolving this skill's own files
 
-This skill reads several of its own bundled files: sub-skill instruction files,
-dispatch/finding templates, JSON schemas, and the plugin manifest. **Always resolve
-these from `${CLAUDE_PLUGIN_ROOT}`** — the environment variable Claude Code sets to
-this plugin's installation directory — never from a repo-relative path like
-`plugins/sdlc-workflow/...`.
-
-This matters because the current working directory is **not** always the plugin's
-repository. When verify-pr reviews a PR against the `sdlc-plugins` repo itself, the
-CWD is the target checkout (whatever branch is under review), so a repo-relative path
-would read that branch's copy of these files and let the PR under review **shadow**
-the pinned, stable skill actually running. `${CLAUDE_PLUGIN_ROOT}` always points at
-the delivered plugin, so the stable skill reads its own bundled files in every mode —
+This skill reads several of its own bundled files (sub-skill instruction files,
+dispatch/finding templates, JSON schemas, the plugin manifest). **Always resolve these
+from `${CLAUDE_PLUGIN_ROOT}`** — never a repo-relative path like `plugins/sdlc-workflow/...`.
+The CWD is **not** always the plugin's repository: when verify-pr reviews a PR against
+`sdlc-plugins` itself, the CWD is the target checkout, so a repo-relative path would read
+that branch's copy and let the PR under review **shadow** the pinned, stable skill actually
+running. `${CLAUDE_PLUGIN_ROOT}` always points at the delivered plugin, in every mode —
 interactive (Claude Code) and sandbox (fullsend).
 
-`${CLAUDE_PLUGIN_ROOT}` is a **textual token** that Claude Code substitutes into this
-skill's markdown body (this whole file, including fenced code blocks) before the skill
-runs — it is **not** an OS environment variable. Write the literal token wherever you
-need the path: prose, Read/Glob paths, and inside a `<< 'PYEOF'` heredoc alike. Do
-**not** read it at runtime via `os.environ["CLAUDE_PLUGIN_ROOT"]` or `$CLAUDE_PLUGIN_ROOT`
-in a shell — it is not exported to the shell or to subprocesses, so those resolve to
-empty / `KeyError`. Substitution happens before execution, so a literal token even
-inside a single-quoted heredoc is already the absolute path by the time Python runs.
+`${CLAUDE_PLUGIN_ROOT}` is a **textual token** Claude Code substitutes into this skill's
+markdown body (this whole file, including fenced code blocks) before the skill runs — it
+is **not** an OS environment variable. Write the literal token wherever you need the path:
+prose, Read/Glob paths, and inside a `<< 'PYEOF'` heredoc alike — substitution happens
+before execution, so even inside a single-quoted heredoc it is already the absolute path by
+the time Python runs. Do **not** read it at runtime via `os.environ["CLAUDE_PLUGIN_ROOT"]`
+or `$CLAUDE_PLUGIN_ROOT` in a shell — it is not exported to the shell or subprocesses, so
+those resolve to empty / `KeyError`.
 
-Note: path patterns used to **filter the PR diff** (e.g., detecting changes under
+Note: path patterns used to **filter the PR diff** (e.g. detecting changes under
 `plugins/sdlc-workflow/skills/run-evals/`) stay repo-relative — those describe files
 inside the PR being reviewed, not files this skill reads.
 
@@ -150,12 +145,10 @@ The `report` object and every action conform to
 **Skip this step in interactive mode.**
 
 In sandbox mode the `pre_script` fetches all task and PR data on the trusted runner
-(where the tokens live) and mounts it read-only into the sandbox. Read it:
-
-Validate it against `${CLAUDE_PLUGIN_ROOT}/schemas/verify-pr-input.schema.json`
-before using it — a syntactically valid but structurally wrong or incomplete
-prefetch (e.g., missing the `github` bundle or `task` fields) must be treated as
-invalid rather than passing and failing deep inside a later step:
+(where the tokens live) and mounts it read-only into the sandbox. Validate it against
+`${CLAUDE_PLUGIN_ROOT}/schemas/verify-pr-input.schema.json` before using it — a
+valid-JSON but structurally wrong or incomplete prefetch (e.g. missing the `github`
+bundle or `task` fields) must be treated as invalid, not fail deep inside a later step:
 
 ```bash
 python3 - << 'PYEOF'
@@ -199,20 +192,18 @@ If the file validates against the schema:
   `labels`, `description`, `issuetype`, `comments`) — the task's existing sub-tasks
   and linked issues, prefetched on the runner. **Use it for every idempotency read**
   (Steps 6d, 6f, 7c) instead of calling Jira; the sandbox has no token. The schema
-  **requires** `idempotency.related_issues`, so a prefetch that passes the Step 0.7
-  validation above always carries this array — it is an empty list (never absent)
-  when the task has no sub-tasks or linked issues yet. Treat a present-but-empty
-  array as "no known duplicates"; you never need to fall back to a Jira read for
-  the dedup checks.
+  **requires** this array, so a prefetch that passes validation always carries it — an
+  empty list (never absent) means the task has no sub-tasks/linked issues yet. Treat
+  present-but-empty as "no known duplicates"; never fall back to a Jira read for dedup.
 
 If the validation above fails (file missing, not valid JSON, or not conforming to the
 schema), the handling depends on the mode:
 
 - **Sandbox mode (`FULLSEND_OUTPUT_DIR` is set):** do **not** fall back to Steps 1–3 or
-  the direct Jira/GitHub reads. The sandbox has no tokens, no `gh` CLI, and no network
-  egress, so a credentialed fallback cannot succeed — it would fail obscurely or hang.
-  Fail fast and loud instead: write a structured failure result and stop the skill
-  without performing any further steps or write operations.
+  direct Jira/GitHub reads — the sandbox has no tokens, no `gh` CLI, and no network
+  egress, so a credentialed fallback cannot succeed (it would fail obscurely or hang).
+  Fail fast and loud: write a structured failure result and stop the skill without any
+  further step or write operation.
 
 ```bash
 cat > "$FULLSEND_OUTPUT_DIR/agent-result.json" << 'RESULT_EOF'
@@ -222,9 +213,9 @@ cat > "$FULLSEND_OUTPUT_DIR/agent-result.json" << 'RESULT_EOF'
 RESULT_EOF
 ```
 
-  This result intentionally omits the `report` and `actions` keys required by
+  This result intentionally omits the `report`/`actions` keys required by
   `verify-pr-result.schema.json`, so the runner's output validation rejects it and
-  surfaces the `error` message as a hard failure rather than silently attempting the
+  surfaces the `error` as a hard failure rather than silently attempting the
   interactive path. **Stop execution here — do not run any subsequent step.**
 
 - **Interactive mode (`FULLSEND_OUTPUT_DIR` is unset):** log a warning and fall back to
@@ -240,47 +231,12 @@ Example:
 
 ## Comment Footnote
 
-Every comment posted to Jira by this skill MUST end with the following footnote,
-separated from the main content by a horizontal rule.
-
-Before posting any Jira comment, read the plugin version from
-`${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json` and extract the `version` field.
-Use this value as `{version}` in the footer below.
-
-Use ADF `contentFormat` to ensure the rule and text render correctly:
-
-```json
-{
-  "type": "rule"
-},
-{
-  "type": "paragraph",
-  "content": [
-    {
-      "type": "text",
-      "text": "This comment was AI-generated by "
-    },
-    {
-      "type": "text",
-      "text": "sdlc-workflow/verify-pr",
-      "marks": [
-        {
-          "type": "link",
-          "attrs": {
-            "href": "https://github.com/RHEcosystemAppEng/sdlc-plugins"
-          }
-        }
-      ]
-    },
-    {
-      "type": "text",
-      "text": " v{version}."
-    }
-  ]
-}
-```
-
-Append these two nodes at the end of the ADF document's `content` array.
+Every comment posted to Jira by this skill MUST end with the footnote defined in
+`shared/comment-footnote.md`, using skill name `verify-pr`. **Override** that doc's
+version-path instruction: read the plugin version from
+`${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json` — never the repo-relative path (see
+"Resolving this skill's own files"). Append the two ADF nodes (rule + paragraph) at the
+end of the comment document's `content` array.
 
 ## Step 1 – Fetch and Parse Jira Task
 
@@ -333,17 +289,13 @@ gh pr view <pr-number> --json headRefName -R <owner/repo>
 git branch --show-current
 ```
 
-3. If the branches match, proceed without action — the correct code is already available locally (e.g. the author running self-verification after `/implement-task`).
+3. If the branches match, proceed — the correct code is already local (author self-verification after `/implement-task`; no checkout needed).
 
-4. If they differ, check out the PR branch:
+4. If they differ, check out the PR branch (reviewer/CI audit from an arbitrary branch):
 
 ```
 gh pr checkout <pr-number> -R <owner/repo>
 ```
-
-This step supports two use cases:
-- **Author self-verification** — the contributor already has the PR branch checked out; no checkout needed.
-- **Reviewer/CI audit** — another person or CI job runs `/verify-pr` from an arbitrary branch; the PR branch must be checked out first.
 
 **Sandbox mode:** skip this step entirely — the runner has already checked out the PR
 head tree (`github.headRefName` at `github.commit_sha`) and there is no `gh` CLI in
@@ -425,12 +377,10 @@ Log both lists so the run output shows the full enumeration result, making it
 auditable that all items were considered.
 
 > **Why this matters:** Without mandatory enumeration, a re-run can check only for
-> existing classification replies and conclude "nothing to do" — completely missing
-> new items that arrived after the previous run. This caused a real failure where a
-> bot review comment posted after `/implement-task` pushed a fix commit was missed
-> by the subsequent `/verify-pr` re-run. The same gap allowed review body
-> suggestions (e.g., from sourcery-ai) to be silently skipped because only inline
-> comments were enumerated.
+> existing classification replies, conclude "nothing to do", and miss new items that
+> arrived after the previous run — a real failure mode (a bot review comment posted
+> after an `/implement-task` fix commit was missed on re-run; review-body suggestions
+> from sourcery-ai were skipped because only inline comments were enumerated).
 
 ### Step 4a.1 – Detect Eval Result Reviews
 
@@ -460,9 +410,9 @@ inform classification decisions.
    with the absolute path from the Registry (e.g., `<Path>/CONVENTIONS.md`). If present,
    read its contents. This provides explicit, documented project conventions.
 
-2. **Codebase convention cache:** This step does not perform exhaustive codebase analysis
-   yet — that happens in the Style/Conventions sub-agent. The goal here is only to load
-   CONVENTIONS.md once for reuse across comment classification and sub-agent dispatch.
+2. **Scope:** load CONVENTIONS.md once here for reuse across comment classification and
+   sub-agent dispatch; exhaustive codebase analysis happens later in the
+   Style/Conventions sub-agent.
 
 If `CONVENTIONS.md` does not exist, proceed normally — the Style/Conventions sub-agent
 will check for implicit conventions demonstrated by codebase usage patterns.
@@ -822,54 +772,34 @@ gh api repos/<owner/repo>/pulls/<pr-number>/comments/<comment_id>/replies -f bod
 ```
 
 **For suggestions upgraded to code change requests via convention check (Step 6b):**
-
-Include the convention evidence in the reply so the upgrade reasoning is transparent:
+Include the convention evidence so the upgrade reasoning is transparent (e.g. "…this
+matches project convention: 17 migrations use Index::create for FK columns; CONVENTIONS.md
+§Indexes documents this pattern. Sub-task […] created…"):
 
 ```
 gh api repos/<owner/repo>/pulls/<pr-number>/comments/<comment_id>/replies -f body="[sdlc-workflow/verify-pr] Classified as **code change request** (upgraded from suggestion) — this matches project convention: <evidence>. Sub-task [<SUB-TASK-KEY>](<sub-task-webUrl>) created to address this feedback."
 ```
 
-Example: `"[sdlc-workflow/verify-pr] Classified as **code change request** (upgraded from suggestion) — this matches project convention: 17 migrations use Index::create for FK columns; CONVENTIONS.md §Indexes documents this pattern. Sub-task [PROJ-456](https://redhat.atlassian.net/browse/PROJ-456) created to address this feedback."`
-
-**For all other classifications (suggestion, question, nit):**
-
-Reply with a brief explanation of the classification and why no sub-task was created:
+**For all other classifications (suggestion, question, nit):** reply with a brief
+explanation of the classification and why no sub-task was created (e.g. suggestion → "not
+documented in CONVENTIONS.md and no established codebase pattern"; question → "asks for
+clarification; no code change needed"; nit → "minor style, does not affect correctness"):
 
 ```
 gh api repos/<owner/repo>/pulls/<pr-number>/comments/<comment_id>/replies -f body="[sdlc-workflow/verify-pr] Classified as **<classification>** — <reasoning>. No sub-task created."
 ```
 
-Example replies:
-- `"[sdlc-workflow/verify-pr] Classified as **suggestion** — this proposes an alternative approach that is not documented in CONVENTIONS.md and has no established codebase pattern. No sub-task created."`
-- `"[sdlc-workflow/verify-pr] Classified as **question** — this asks for clarification; no code change needed. No sub-task created."`
-- `"[sdlc-workflow/verify-pr] Classified as **nit** — minor style feedback that does not affect correctness. No sub-task created."`
-
 #### Review body items
 
 Review body items (identified by `review-body-*` synthetic IDs) lack a `comment_id`
-and cannot receive threaded replies. Instead, post a **standalone PR comment** using
-the issues API:
+and cannot receive threaded replies. Post a **standalone PR comment** via the issues
+API instead — use the **same classification body as the matching inline case above**,
+but prefixed with `Re: @<reviewer> review — ` right after the `[sdlc-workflow/verify-pr]`
+tag (code change request → sub-task link; upgraded suggestion → convention evidence +
+sub-task link; suggestion/question/nit → reasoning + "No sub-task created."):
 
 ```
-gh api repos/<owner/repo>/issues/<pr-number>/comments -f body="[sdlc-workflow/verify-pr] Re: @<reviewer> review — Classified as **<classification>** — <reasoning>. <action taken or 'No sub-task created.'>"
-```
-
-**For code change requests that resulted in a sub-task:**
-
-```
-gh api repos/<owner/repo>/issues/<pr-number>/comments -f body="[sdlc-workflow/verify-pr] Re: @<reviewer> review — Classified as **code change request** — sub-task [<SUB-TASK-KEY>](<sub-task-webUrl>) created to address this feedback."
-```
-
-**For suggestions upgraded via convention check (Step 6b):**
-
-```
-gh api repos/<owner/repo>/issues/<pr-number>/comments -f body="[sdlc-workflow/verify-pr] Re: @<reviewer> review — Classified as **code change request** (upgraded from suggestion) — this matches project convention: <evidence>. Sub-task [<SUB-TASK-KEY>](<sub-task-webUrl>) created to address this feedback."
-```
-
-**For all other classifications:**
-
-```
-gh api repos/<owner/repo>/issues/<pr-number>/comments -f body="[sdlc-workflow/verify-pr] Re: @<reviewer> review — Classified as **<classification>** — <reasoning>. No sub-task created."
+gh api repos/<owner/repo>/issues/<pr-number>/comments -f body="[sdlc-workflow/verify-pr] Re: @<reviewer> review — Classified as **<classification>** — <same body as the matching inline case>"
 ```
 
 When a review body contains multiple classified suggestions (sub-identifiers), post
@@ -903,18 +833,14 @@ For **review body items** (no `comment_id`), use `post_pr_comment`:
 
 ### Step 6f – Idempotency Guarantees
 
-Idempotency is enforced **within** Step 4a's mandatory enumeration, not as a
-separate gate before Steps 6d/6e. The enumeration in Step 4a partitions all
-classifiable items (inline comment threads and review body items) into unclassified
-and already-classified lists — only unclassified items proceed to Steps 4b–4c for
-classification and then to Steps 6c–6e for side effects. This design ensures that:
-
-- Every classifiable item is always discovered (enumeration cannot be bypassed).
-- Already-processed items are filtered out per-item (no duplicate replies or
-  sub-tasks).
-- New items arriving between runs (e.g., from a bot re-analyzing code after a
-  fix commit, or a reviewer adding a new review) are always detected because the
-  enumeration is unconditional.
+Idempotency is enforced **within** Step 4a's mandatory enumeration, not as a separate
+gate before Steps 6d/6e: the enumeration partitions all classifiable items (inline
+comment threads and review body items) into unclassified and already-classified lists —
+only unclassified items proceed to classification (4b–4c) and side effects (6c–6e).
+Every item is always discovered (enumeration is unconditional and cannot be bypassed),
+already-processed items are filtered per-item (no duplicate replies/sub-tasks), and new
+items arriving between runs (a bot re-analyzing after a fix commit, a new review) are
+always detected. Do **not** treat this as a top-level gate that can skip enumeration.
 
 **Idempotency detection per item type:**
 - **Inline comment threads:** a reply containing `"[sdlc-workflow/verify-pr] Classified as"`
@@ -929,10 +855,6 @@ exists, skip creation. This guards against edge cases where a classification rep
 was not posted (e.g., due to a network error) but the sub-task was created.
 **Sandbox mode:** read these existing sub-tasks from `idempotency.related_issues`
 (Step 0.7) — inspect each entry's `description` — instead of a live Jira read.
-
-Do **not** interpret this step as a top-level decision that can skip item
-enumeration. The enumeration in Step 4a is always mandatory; this step only
-documents the idempotency mechanisms embedded within that enumeration.
 
 ### Step 6g – Record Result
 
@@ -975,22 +897,10 @@ The sub-agent receives these inputs:
 3. **Review comments** — the code change requests that triggered sub-tasks in Step 6d
 4. **Relevant code** — the files on the PR branch related to each flagged defect
 5. **Project CONVENTIONS.md** — if it exists in the repository root
-6. **Aggregated domain findings** — findings from all four domain sub-agents,
-   organized by source with clear attribution:
-
-   ```
-   ### From Intent Alignment
-   <Intent Alignment findings from Step 6a>
-
-   ### From Security
-   <Security findings from Step 6a>
-
-   ### From Correctness
-   <Correctness findings from Step 6a>
-
-   ### From Style/Conventions
-   <Style/Conventions findings from Step 6a>
-   ```
+6. **Aggregated domain findings** — findings from all four domain sub-agents, organized
+   by source with clear attribution: one `### From <domain>` section each for Intent
+   Alignment, Security, Correctness, and Style/Conventions, holding that sub-agent's
+   Step 6a findings.
 
 #### Classification gate — universality test
 
@@ -1024,15 +934,11 @@ test to determine whether the corrective guidance is a method or a fact:
   in a general-purpose skill. Create a task to document the pattern in
   CONVENTIONS.md (see Step 7b).
 
-> **Examples:**
-> - "Every new public symbol must have a documentation comment" → **method**
->   (applies to any language, no specific API needed) → skill gap
-> - "Use `Vec<_>` for type inference in collect chains" → **fact**
->   (Rust-specific syntax) → convention gap
-> - "Pre-allocate collections with `HashMap::with_capacity(n)`" → **fact**
->   (Rust-specific API) → convention gap
-> - "Assert on specific values, not just collection length" → **method**
->   (applies to any test framework) → skill gap
+> **Examples:** "Every new public symbol must have a documentation comment" and "Assert
+> on specific values, not just collection length" → **method** (any language / test
+> framework, no specific API) → skill gap. "Use `Vec<_>` for type inference in collect
+> chains" or "Pre-allocate with `HashMap::with_capacity(n)`" → **fact** (Rust-specific
+> syntax/API) → convention gap.
 
 #### Convention Check (for repo-specific knowledge)
 


### PR DESCRIPTION
Implements [TC-6137](https://redhat.atlassian.net/browse/TC-6137)

## Problem

`verify-pr/SKILL.md` had a Skillsaw context-budget estimate of **16,172 tokens**, 172 over the 16,000-token error limit.

## Change

Condensation only — **no semantic or behavioral changes**. The estimate is now **15,419 tokens** (581 headroom below the error limit):

- Replace the inline ADF comment-footnote block with a reference to `shared/comment-footnote.md` (skill name `verify-pr`), keeping the `${CLAUDE_PLUGIN_ROOT}` version-path override so the rendered footnote is byte-identical.
- Collapse the four duplicated Step 6e review-body reply templates into one referential form; fold illustrative example replies into inline hints.
- Compress prose in "Resolving this skill's own files", Step 0.7, Step 3, Step 4a/4b, Step 6f, and Step 7 — every directive preserved verbatim.

Paired with the mandatory fullsend re-pin/re-lock: `.fullsend/harness/verify-pr.yaml` `base:` re-pinned to the content commit and `.fullsend/lock.yaml` regenerated (base file unchanged, so its `#sha256` stays `d8ebedc8…`).

## Verification

- `uvx skillsaw plugins/sdlc-workflow/skills/verify-pr/SKILL.md` — **0 errors**, no context-budget error (15,419 tokens, 581 headroom). The 8,000 warn always fires for skills this size and is not a blocker.
- `claude plugin validate plugins/sdlc-workflow` — **passed**.

## Acceptance Criteria

- [x] skillsaw reports no context-budget error with meaningful headroom
- [x] verify-pr behavior unchanged (condensation only)
- [x] `.fullsend` re-pinned + re-locked in the same PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Reduce the verify-pr skill's context usage below the Skillsaw limit without changing its behavior.

Enhancements:
- Condense the verify-pr skill documentation while preserving its verification behavior and comment-footnote output.
- Consolidate review-body response guidance with the existing inline classification response patterns.

Documentation:
- Reduce verify-pr/SKILL.md below the Skillsaw context-budget error threshold through documentation condensation and shared footnote guidance.

Tests:
- Validate the condensed skill with Skillsaw and Claude plugin validation.

Chores:
- Re-pin and regenerate the fullsend harness lock metadata for the updated plugin content.